### PR TITLE
Add promo rarity and fix 400 error retry behavior

### DIFF
--- a/mtg_collector/cli/ingest_ids.py
+++ b/mtg_collector/cli/ingest_ids.py
@@ -18,7 +18,7 @@ from mtg_collector.services.scryfall import (
 )
 from mtg_collector.utils import normalize_condition, normalize_finish
 
-RARITY_MAP = {"C": "common", "U": "uncommon", "R": "rare", "M": "mythic"}
+RARITY_MAP = {"C": "common", "U": "uncommon", "R": "rare", "M": "mythic", "P": "promo"}
 
 
 def resolve_and_add_ids(
@@ -163,7 +163,7 @@ def run(args):
 
         if rarity_code not in RARITY_MAP:
             print(
-                f"Error: Invalid rarity '{rarity_code}'. Use C (common), U (uncommon), R (rare), M (mythic)."
+                f"Error: Invalid rarity '{rarity_code}'. Use C (common), U (uncommon), R (rare), M (mythic), P (promo)."
             )
             sys.exit(1)
 

--- a/mtg_collector/services/claude.py
+++ b/mtg_collector/services/claude.py
@@ -122,7 +122,7 @@ Each corner has tiny printed text with collector info. Look for the pattern:
   SET ★ EN    (foil)
 
 Where:
-- RARITY: a single letter — C (common), U (uncommon), R (rare), M (mythic rare)
+- RARITY: a single letter — C (common), U (uncommon), R (rare), M (mythic rare), P (promo)
 - COLLECTOR_NUMBER: 3-4 digits, often with leading zeros (e.g. 0075, 0187, 0200)
 - SET: 3-4 letter set code (e.g. EOE, ECL, MKM) — appears BEFORE "EN"
 - "EN" is the language marker (English) — NOT part of the set code
@@ -183,6 +183,9 @@ Return ONLY a JSON array:
             except json.JSONDecodeError as e:
                 last_error = f"JSON parse error: {e}"
                 print(f"  {last_error}")
+            except anthropic.BadRequestError as e:
+                print(f"  Error: {e}")
+                return []
             except Exception as e:
                 last_error = str(e)
                 if "api_key" in str(e).lower() or "authentication" in str(e).lower():


### PR DESCRIPTION
## Summary

- Add P (promo) to the rarity error message and Claude Vision prompt so promo cards are recognized during corner-based ingestion
- Don't retry on HTTP 400 errors (e.g. billing/credit balance issues) — these are non-transient and retrying just wastes time

## Test plan

- [ ] `mtg ingest-ids --id P 0123 EOE` is accepted as valid rarity
- [ ] `mtg ingest-ids --id X 0123 EOE` error message now lists P (promo)
- [ ] Claude Vision prompt includes P (promo) in rarity list
- [ ] 400 errors from Anthropic API fail immediately without retrying

🤖 Generated with [Claude Code](https://claude.com/claude-code)