### PR TITLE
Fix FK and UNIQUE constraint failures during set caching

### DIFF
--- a/mtg_collector/db/models.py
+++ b/mtg_collector/db/models.py
@@ -87,9 +87,17 @@ class CardRepository:
         """Insert or update a card."""
         self.conn.execute(
             """
-            INSERT OR REPLACE INTO cards
+            INSERT INTO cards
             (oracle_id, name, type_line, mana_cost, cmc, oracle_text, colors, color_identity)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(oracle_id) DO UPDATE SET
+                name = excluded.name,
+                type_line = excluded.type_line,
+                mana_cost = excluded.mana_cost,
+                cmc = excluded.cmc,
+                oracle_text = excluded.oracle_text,
+                colors = excluded.colors,
+                color_identity = excluded.color_identity
             """,
             (
                 card.oracle_id,
@@ -154,8 +162,13 @@ class SetRepository:
         """Insert or update a set."""
         self.conn.execute(
             """
-            INSERT OR REPLACE INTO sets (set_code, set_name, set_type, released_at, cards_fetched_at)
+            INSERT INTO sets (set_code, set_name, set_type, released_at, cards_fetched_at)
             VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(set_code) DO UPDATE SET
+                set_name = excluded.set_name,
+                set_type = excluded.set_type,
+                released_at = excluded.released_at,
+                cards_fetched_at = COALESCE(excluded.cards_fetched_at, sets.cards_fetched_at)
             """,
             (s.set_code, s.set_name, s.set_type, s.released_at, s.cards_fetched_at),
         )
@@ -211,11 +224,25 @@ class PrintingRepository:
         """Insert or update a printing."""
         self.conn.execute(
             """
-            INSERT OR REPLACE INTO printings
+            INSERT INTO printings
             (scryfall_id, oracle_id, set_code, collector_number, rarity,
              frame_effects, border_color, full_art, promo, promo_types,
              finishes, artist, image_uri, raw_json)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(scryfall_id) DO UPDATE SET
+                oracle_id = excluded.oracle_id,
+                set_code = excluded.set_code,
+                collector_number = excluded.collector_number,
+                rarity = excluded.rarity,
+                frame_effects = excluded.frame_effects,
+                border_color = excluded.border_color,
+                full_art = excluded.full_art,
+                promo = excluded.promo,
+                promo_types = excluded.promo_types,
+                finishes = excluded.finishes,
+                artist = excluded.artist,
+                image_uri = excluded.image_uri,
+                raw_json = excluded.raw_json
             """,
             (
                 p.scryfall_id,

--- a/mtg_collector/services/scryfall.py
+++ b/mtg_collector/services/scryfall.py
@@ -430,8 +430,12 @@ def ensure_set_cached(
         card = api.to_card_model(card_data)
         card_repo.upsert(card)
 
-        printing = api.to_printing_model(card_data)
-        printing_repo.upsert(printing)
+        # Don't overwrite printings that already exist from direct API lookups —
+        # /cards/{set}/{cn} returns the canonical scryfall_id, search results may not.
+        cn = card_data["collector_number"]
+        if not printing_repo.get_by_set_cn(set_code, cn):
+            printing = api.to_printing_model(card_data)
+            printing_repo.upsert(printing)
 
     # Mark set as cached
     set_repo.mark_cards_cached(set_code)


### PR DESCRIPTION
## Summary

- Replace `INSERT OR REPLACE` with `INSERT ... ON CONFLICT DO UPDATE` in all repository upsert methods (cards, sets, printings). `INSERT OR REPLACE` performs a DELETE+INSERT internally, which violates FK constraints when printings are referenced by collection entries.
- Skip printing upserts in `ensure_set_cached` when a printing already exists for that (set_code, collector_number). Scryfall's search API can return different UUIDs than the direct `/cards/{set}/{cn}` endpoint for the same printing — existing printings from direct lookups have the canonical scryfall_id and should not be overwritten.

## Test plan

- [x] All existing tests pass
- [x] Run `mtg ingest-ids` with cards spanning multiple sets (including sets with previously-cached individual printings)
- [x] Verify collection entries retain correct scryfall_ids after set bulk-caching

🤖 Generated with [Claude Code](https://claude.com/claude-code)