### PR TITLE
Add User-Agent to MTGJSON download and better missing-data error

### DIFF
--- a/mtg_collector/services/pack_generator.py
+++ b/mtg_collector/services/pack_generator.py
@@ -21,6 +21,11 @@ class PackGenerator:
     @property
     def data(self) -> dict:
         if self._data is None:
+            if not self.mtgjson_path.exists():
+                raise FileNotFoundError(
+                    f"AllPrintings.json not found at {self.mtgjson_path}\n"
+                    f"Run 'mtg data fetch' to download it."
+                )
             with open(self.mtgjson_path) as f:
                 self._data = json.load(f)
         return self._data


### PR DESCRIPTION
## Summary

- Set a `User-Agent` header on the MTGJSON download request — some CDNs reject the default `urllib` User-Agent with a 403
- Raise a clear `FileNotFoundError` with actionable guidance when `AllPrintings.json` is missing, instead of a raw OS error

## Test plan

- [ ] `mtg data fetch` downloads successfully
- [ ] `mtg pack` without data file shows helpful error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)