### PR TITLE
Add names-only card mode

### DIFF
--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -191,6 +191,40 @@ def _compute_card_crop(fragments, indices, image_w=None, image_h=None):
     return {"x": round(x1), "y": round(y1), "w": round(w), "h": round(h)}
 
 
+def _compute_name_bbox(fragments, indices, image_w=None, image_h=None):
+    """Compute union bounding box of fragment indices with 10% buffer, no aspect-ratio constraint."""
+    if not indices:
+        return None
+    xs, ys, xws, yhs = [], [], [], []
+    for i in indices:
+        if i < len(fragments):
+            b = fragments[i]["bbox"]
+            xs.append(b["x"])
+            ys.append(b["y"])
+            xws.append(b["x"] + b["w"])
+            yhs.append(b["y"] + b["h"])
+    if not xs:
+        return None
+    x1, y1 = min(xs), min(ys)
+    x2, y2 = max(xws), max(yhs)
+    w, h = x2 - x1, y2 - y1
+    # Add 10% buffer
+    bx, by = w * 0.1, h * 0.1
+    x1 -= bx
+    y1 -= by
+    w += 2 * bx
+    h += 2 * by
+    # Clamp to image bounds
+    if image_w and image_h:
+        x1 = max(0, x1)
+        y1 = max(0, y1)
+        if x1 + w > image_w:
+            w = image_w - x1
+        if y1 + h > image_h:
+            h = image_h - y1
+    return {"x": round(x1), "y": round(y1), "w": round(w), "h": round(h)}
+
+
 def _format_candidates(raw_cards):
     """Format raw Scryfall card dicts into the candidate shape the client expects."""
     formatted = []
@@ -319,6 +353,12 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             self._api_ingest_next_card()
         elif path == "/api/ingest/search-card":
             self._api_ingest_search_card()
+        elif path == "/api/ingest/next-name":
+            self._api_ingest_next_name()
+        elif path == "/api/ingest/confirm-name":
+            self._api_ingest_confirm_name()
+        elif path == "/api/ingest/skip-name":
+            self._api_ingest_skip_name()
         else:
             self._send_json({"error": "Not found"}, 404)
 
@@ -734,11 +774,14 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         idx = data.get("image_idx")
         count = data.get("card_count", 1)
         force = data.get("force_ingest", False)
+        mode = data.get("mode")
         with _ingest_lock:
             session = _ingest_sessions.get(sid)
             if session and 0 <= idx < len(session["images"]):
                 session["images"][idx]["card_count"] = int(count)
                 session["images"][idx]["force_ingest"] = bool(force)
+                if mode:
+                    session["images"][idx]["mode"] = mode
         self._send_json({"ok": True})
 
     def _api_ingest_serve_image(self, filename):
@@ -784,7 +827,11 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                 pass
 
         try:
-            self._process_image_sse(sid, img_idx, img, force, send_event)
+            mode = img.get("mode", "full")
+            if mode == "names":
+                self._process_image_names_sse(sid, img_idx, img, force, send_event)
+            else:
+                self._process_image_sse(sid, img_idx, img, force, send_event)
         except Exception as e:
             _log_ingest(f"Error processing image {img_idx}: {e}")
             send_event("error", {"message": str(e)})
@@ -969,6 +1016,329 @@ class CrackPackHandler(BaseHTTPRequestHandler):
 
         send_event("matches_ready", {"cards": cards_payload})
         conn.close()
+
+    def _process_image_names_sse(self, sid, img_idx, img, force, send_event):
+        """Process a single image in names-only mode: OCR -> Claude names -> Scryfall search."""
+        from mtg_collector.services.ocr import run_ocr_with_boxes
+        from mtg_collector.services.claude import ClaudeVision
+        from mtg_collector.services.scryfall import ScryfallAPI
+        from mtg_collector.db.schema import init_db
+        from mtg_collector.utils import now_iso
+
+        image_path = str(_get_ingest_images_dir() / img["stored_name"])
+        md5 = img["md5"]
+        card_count = img["card_count"]
+        cache_key = md5 + ":names"
+
+        _log_ingest(f"Processing image {img_idx} (names mode): {img['filename']} (MD5={md5}, count={card_count}, force={force})")
+
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        init_db(conn)
+
+        ocr_fragments = None
+        claude_cards = None
+
+        if not force:
+            cache_row = conn.execute(
+                "SELECT ocr_result, claude_result FROM ingest_cache WHERE image_md5 = ?",
+                (cache_key,),
+            ).fetchone()
+            if cache_row:
+                _log_ingest(f"Cache hit for names MD5={cache_key}")
+                ocr_fragments = json.loads(cache_row["ocr_result"])
+                send_event("cached", {"step": "ocr"})
+                send_event("ocr_complete", {"fragment_count": len(ocr_fragments), "fragments": ocr_fragments})
+
+                if cache_row["claude_result"]:
+                    claude_cards = json.loads(cache_row["claude_result"])
+                    send_event("cached", {"step": "claude"})
+                    send_event("claude_complete", {"card_count": len(claude_cards), "cards": claude_cards})
+
+        # Step 1: OCR
+        if ocr_fragments is None:
+            send_event("status", {"message": "Running OCR..."})
+            t0 = time.time()
+            ocr_fragments = run_ocr_with_boxes(image_path)
+            elapsed = time.time() - t0
+            _log_ingest(f"OCR complete: {len(ocr_fragments)} fragments in {elapsed:.1f}s")
+            send_event("ocr_complete", {"fragment_count": len(ocr_fragments), "fragments": ocr_fragments})
+
+        # Step 2: Claude name extraction
+        if claude_cards is None:
+            send_event("status", {"message": "Calling Claude (names mode)..."})
+            t0 = time.time()
+            claude = ClaudeVision()
+            claude_cards, usage = claude.extract_names_from_ocr(
+                ocr_fragments, card_count,
+                status_callback=lambda msg: send_event("status", {"message": msg}),
+            )
+            elapsed = time.time() - t0
+            token_info = {}
+            if usage:
+                token_info = {"in": usage.input_tokens, "out": usage.output_tokens}
+            _log_ingest(f"Claude names complete: {len(claude_cards)} unique names in {elapsed:.1f}s, tokens={token_info}")
+            send_event("claude_complete", {
+                "card_count": len(claude_cards),
+                "cards": claude_cards,
+                "tokens": token_info,
+            })
+
+            # Validate total quantity matches expected count
+            total_qty = sum(c.get("quantity", 1) for c in claude_cards)
+            if total_qty != card_count:
+                msg = (f"Expected {card_count} card(s) but Claude found {total_qty}. "
+                       f"Discard this image and take a better photo.")
+                _log_ingest(f"Count mismatch (names): {msg}")
+                send_event("count_mismatch", {"message": msg, "expected": card_count, "found": total_qty})
+                conn.close()
+                return
+
+        # Save to cache
+        conn.execute(
+            """INSERT OR REPLACE INTO ingest_cache
+               (image_md5, image_path, card_count, ocr_result, claude_result, created_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (cache_key, image_path, card_count, json.dumps(ocr_fragments),
+             json.dumps(claude_cards), now_iso()),
+        )
+        conn.commit()
+
+        # Step 3: Scryfall search for each unique name
+        send_event("status", {"message": "Querying Scryfall..."})
+        scryfall = ScryfallAPI()
+
+        names_data = []
+        for ci, card_info in enumerate(claude_cards):
+            name = card_info.get("name", "")
+            quantity = card_info.get("quantity", 1)
+            frag_indices = card_info.get("fragment_indices", [])
+
+            # Search Scryfall by name
+            candidates = scryfall.search_card(name)
+            formatted = _format_candidates(candidates)
+            _log_ingest(f"Scryfall name {ci}: {len(formatted)} candidates for '{name}' (qty={quantity})")
+
+            # Compute per-occurrence bboxes
+            occurrence_crops = []
+            for occ_indices in frag_indices:
+                crop = _compute_name_bbox(ocr_fragments, occ_indices)
+                occurrence_crops.append(crop)
+
+            names_data.append({
+                "name": name,
+                "quantity": quantity,
+                "uncertain": card_info.get("uncertain", False),
+                "candidates": formatted,
+                "occurrence_crops": occurrence_crops,
+                "occurrence_frag_indices": frag_indices,
+            })
+
+        # Check lineage for already-ingested
+        lineage_rows = conn.execute(
+            "SELECT card_index FROM ingest_lineage WHERE image_md5 = ?",
+            (cache_key,),
+        ).fetchall()
+        already_ingested_indices = {row["card_index"] for row in lineage_rows}
+
+        # Build names_disambiguated: per name_idx, list of length quantity
+        names_disambiguated = []
+        card_index_offset = 0
+        for ni, nd in enumerate(names_data):
+            qty = nd["quantity"]
+            occ_list = []
+            for oi in range(qty):
+                global_idx = card_index_offset + oi
+                if global_idx in already_ingested_indices:
+                    occ_list.append("already_ingested")
+                else:
+                    occ_list.append(None)
+            names_disambiguated.append(occ_list)
+            card_index_offset += qty
+
+        # Update session state
+        with _ingest_lock:
+            session = _ingest_sessions.get(sid)
+            if session and img_idx < len(session["images"]):
+                session["images"][img_idx]["ocr_result"] = ocr_fragments
+                session["images"][img_idx]["claude_result"] = claude_cards
+                session["images"][img_idx]["names_data"] = names_data
+                session["images"][img_idx]["names_disambiguated"] = names_disambiguated
+
+        send_event("names_ready", {"names": names_data})
+        conn.close()
+
+    def _api_ingest_next_name(self):
+        """Find the next name that needs disambiguation across all names-mode images."""
+        data = self._read_json_body()
+        if data is None:
+            return
+        sid = data.get("session_id", "")
+
+        with _ingest_lock:
+            session = _ingest_sessions.get(sid)
+            if not session:
+                self._send_json({"error": "Invalid session"}, 400)
+                return
+
+            total_names = 0
+            total_done = 0
+
+            for img_idx, img in enumerate(session["images"]):
+                if img.get("mode") != "names":
+                    continue
+                names_disambiguated = img.get("names_disambiguated")
+                if names_disambiguated is None:
+                    continue
+                names_data = img.get("names_data", [])
+
+                for name_idx, occ_list in enumerate(names_disambiguated):
+                    total_names += 1
+                    # A name is "done" when all occurrences are assigned (non-None)
+                    if all(o is not None for o in occ_list):
+                        total_done += 1
+                    else:
+                        # Found next unfinished name
+                        nd = names_data[name_idx] if name_idx < len(names_data) else {}
+                        self._send_json({
+                            "done": False,
+                            "image_idx": img_idx,
+                            "name_idx": name_idx,
+                            "image_filename": img["stored_name"],
+                            "name": nd.get("name", "???"),
+                            "quantity": nd.get("quantity", 1),
+                            "uncertain": nd.get("uncertain", False),
+                            "candidates": nd.get("candidates", []),
+                            "occurrence_crops": nd.get("occurrence_crops", []),
+                            "assignments": occ_list,
+                            "total_names": total_names + sum(
+                                len(im.get("names_disambiguated", []))
+                                for im in session["images"][img_idx + 1:]
+                                if im.get("mode") == "names" and im.get("names_disambiguated") is not None
+                            ),
+                            "total_done": total_done,
+                        })
+                        return
+
+        self._send_json({"done": True, "total_names": total_names, "total_done": total_done})
+
+    def _api_ingest_confirm_name(self):
+        """Batch-confirm assignments for a name: create one collection entry per occurrence."""
+        from mtg_collector.services.scryfall import ScryfallAPI, cache_scryfall_data
+        from mtg_collector.db.models import (
+            CardRepository, SetRepository, PrintingRepository, CollectionRepository, CollectionEntry,
+        )
+        from mtg_collector.db.schema import init_db
+        from mtg_collector.utils import now_iso
+
+        data = self._read_json_body()
+        if data is None:
+            return
+
+        sid = data["session_id"]
+        img_idx = data["image_idx"]
+        name_idx = data["name_idx"]
+        assignments = data["assignments"]  # [{occurrence_idx, scryfall_id, finish}]
+
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        init_db(conn)
+
+        scryfall = ScryfallAPI()
+        card_repo = CardRepository(conn)
+        set_repo = SetRepository(conn)
+        printing_repo = PrintingRepository(conn)
+        collection_repo = CollectionRepository(conn)
+
+        with _ingest_lock:
+            session = _ingest_sessions.get(sid)
+            if not session or img_idx >= len(session["images"]):
+                conn.close()
+                self._send_json({"error": "Invalid session or image"}, 400)
+                return
+            img = session["images"][img_idx]
+            md5 = img["md5"]
+            cache_key = md5 + ":names"
+            names_data = img.get("names_data", [])
+
+        # Compute card_index_offset for this name
+        card_index_offset = 0
+        for ni in range(name_idx):
+            if ni < len(names_data):
+                card_index_offset += names_data[ni].get("quantity", 1)
+
+        entry_ids = []
+        for a in assignments:
+            occ_idx = a["occurrence_idx"]
+            scryfall_id = a["scryfall_id"]
+            finish = a.get("finish", "nonfoil")
+
+            card_data = scryfall.get_card_by_id(scryfall_id)
+            if not card_data:
+                conn.close()
+                self._send_json({"error": f"Card {scryfall_id} not found on Scryfall"}, 404)
+                return
+
+            cache_scryfall_data(scryfall, card_repo, set_repo, printing_repo, card_data)
+
+            entry = CollectionEntry(
+                id=None,
+                scryfall_id=scryfall_id,
+                finish=finish,
+                condition="Near Mint",
+                source="ocr_ingest_names",
+            )
+            entry_id = collection_repo.add(entry)
+            entry_ids.append(entry_id)
+
+            # Insert lineage
+            global_card_idx = card_index_offset + occ_idx
+            conn.execute(
+                """INSERT INTO ingest_lineage (collection_id, image_md5, image_path, card_index, created_at)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (entry_id, cache_key, img.get("stored_name", ""), global_card_idx, now_iso()),
+            )
+
+        conn.commit()
+        conn.close()
+
+        # Mark disambiguated
+        with _ingest_lock:
+            session = _ingest_sessions.get(sid)
+            if session and img_idx < len(session["images"]):
+                nd = session["images"][img_idx].get("names_disambiguated")
+                if nd and name_idx < len(nd):
+                    for a in assignments:
+                        nd[name_idx][a["occurrence_idx"]] = a["scryfall_id"]
+
+        name = names_data[name_idx]["name"] if name_idx < len(names_data) else "???"
+        _log_ingest(f"Confirmed name '{name}': {len(entry_ids)} occurrence(s) -> IDs {entry_ids}")
+
+        self._send_json({"ok": True, "entry_ids": entry_ids, "name": name})
+
+    def _api_ingest_skip_name(self):
+        """Skip all occurrences of a name."""
+        data = self._read_json_body()
+        if data is None:
+            return
+
+        sid = data["session_id"]
+        img_idx = data["image_idx"]
+        name_idx = data["name_idx"]
+
+        with _ingest_lock:
+            session = _ingest_sessions.get(sid)
+            if session and img_idx < len(session["images"]):
+                nd = session["images"][img_idx].get("names_disambiguated")
+                if nd and name_idx < len(nd):
+                    for oi in range(len(nd[name_idx])):
+                        if nd[name_idx][oi] is None:
+                            nd[name_idx][oi] = "skipped"
+
+        _log_ingest(f"Skipped name {name_idx} in image {img_idx}")
+        self._send_json({"ok": True})
 
     def _api_ingest_next_card(self):
         """Find the next card that needs disambiguation across all images."""

--- a/mtg_collector/services/claude.py
+++ b/mtg_collector/services/claude.py
@@ -281,6 +281,131 @@ OCR FRAGMENTS:
         print(f"  Failed after {self.max_retries + 1} attempts. Last error: {last_error}")
         return [], None
 
+    def extract_names_from_ocr(
+        self,
+        fragments: List[Dict],
+        expected_count: int,
+        status_callback: callable = None,
+    ) -> tuple:
+        """
+        Extract card names from OCR fragments of stacked cards with only name bars visible.
+
+        Each fragment has: text, bbox ({x, y, w, h}), confidence.
+        Returns (cards_list, usage) where each card has name, quantity, uncertain,
+        and fragment_indices (list of lists — one inner list per physical copy).
+        """
+        frag_lines = []
+        for i, f in enumerate(fragments):
+            b = f["bbox"]
+            frag_lines.append(
+                f'[{i}] (x={int(b["x"])},y={int(b["y"])} w={int(b["w"])},h={int(b["h"])}): "{f["text"]}"'
+            )
+        frag_blob = "\n".join(frag_lines)
+
+        prompt = f"""Below are numbered OCR text fragments from a photo of Magic: The Gathering cards
+stacked so only their NAME BARS are visible. The cards may be arranged in multiple
+columns side by side. Use the x-coordinates to distinguish columns and y-coordinates
+for vertical ordering within each column.
+
+The OCR is noisy — names may be misspelled, fragmented across multiple fragments,
+or partially obscured. Your job is to figure out the actual card name for each visible
+name bar, and count how many copies of each card appear.
+
+Two fragments that are at nearly the same y-position but very different x-positions
+are from different columns (different cards). Two fragments at similar x but different
+y are different cards in the same column.
+
+IMPORTANT: The total quantity across all cards MUST equal exactly {expected_count}.
+
+Rules:
+- Merge duplicate card names and sum their quantities.
+- Use the official English card name (correct any OCR misspellings).
+- If you cannot confidently identify a name, include it as-is with uncertain: true.
+- fragment_indices is a list of lists — one inner list per physical copy of that card.
+  Each inner list contains the OCR fragment indices that belong to that particular copy.
+
+OCR FRAGMENTS:
+{frag_blob}"""
+
+        card_schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "quantity": {"type": "integer"},
+                "uncertain": {"type": "boolean"},
+                "fragment_indices": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                    },
+                },
+            },
+            "required": ["name", "quantity", "fragment_indices"],
+            "additionalProperties": False,
+        }
+
+        def _status(msg):
+            if status_callback:
+                status_callback(msg)
+
+        _status(f"Sending {len(fragments)} fragments to Claude (names mode)...")
+
+        last_error = None
+        for attempt in range(self.max_retries + 1):
+            try:
+                if attempt > 0:
+                    wait_time = 3 * (2 ** (attempt - 1))
+                    _status(f"Retry {attempt + 1}/{self.max_retries + 1} in {wait_time}s...")
+                    print(f"  Retrying in {wait_time}s (attempt {attempt + 1}/{self.max_retries + 1})...")
+                    time.sleep(wait_time)
+
+                _status(f"Waiting for Claude... (attempt {attempt + 1}/{self.max_retries + 1})")
+                response = self.client.messages.create(
+                    model="claude-sonnet-4-5-20250929",
+                    max_tokens=4000,
+                    messages=[{"role": "user", "content": prompt}],
+                    output_config={
+                        "format": {
+                            "type": "json_schema",
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "cards": {
+                                        "type": "array",
+                                        "items": card_schema,
+                                    },
+                                },
+                                "required": ["cards"],
+                                "additionalProperties": False,
+                            },
+                        },
+                    },
+                )
+
+                text_content = response.content[0].text
+
+                if not text_content.strip():
+                    raise ValueError("Empty response from Claude")
+
+                _status("Parsing Claude response...")
+                result = json.loads(text_content)
+                cards = result["cards"]
+
+                return cards, response.usage
+            except anthropic.BadRequestError as e:
+                print(f"  Error: {e}")
+                return [], None
+            except Exception as e:
+                last_error = str(e)
+                if "api_key" in str(e).lower() or "authentication" in str(e).lower():
+                    print(f"  Error: {e}")
+                    return [], None
+                print(f"  Error: {e}")
+
+        print(f"  Failed after {self.max_retries + 1} attempts. Last error: {last_error}")
+        return [], None
+
     def encode_image(self, image_path: str) -> str:
         """Encode image to base64."""
         with open(image_path, "rb") as f:

--- a/mtg_collector/static/index.html
+++ b/mtg_collector/static/index.html
@@ -148,7 +148,7 @@ body {
   <a href="/crack">Crack-a-Pack<span>Open virtual booster packs with prices and pick tracking</span></a>
   <a href="/sheets">Explore Sheets<span>View booster pack structure, sheets, and pull rates</span></a>
   <a href="/collection">Collection<span>Browse your card collection with search, filters, and prices</span></a>
-  <a href="/ingestor-ocr">Ingestor (OCR)<span>Identify cards from photos using OCR + AI with visual disambiguation</span></a>
+  <a href="/ingestor-ocr">Ingestor (OCR)<span>Identify cards from photos — full cards or stacked name bars</span></a>
 </div>
 
 <div class="settings-col">

--- a/mtg_collector/static/ingest.html
+++ b/mtg_collector/static/ingest.html
@@ -150,6 +150,29 @@ button.secondary:hover { background: #444; }
 .image-row label { font-size: 0.85rem; color: #888; }
 .image-row .status-text { font-size: 0.8rem; color: #888; }
 
+/* Mode toggle pill-row */
+.mode-toggle {
+  display: inline-flex;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid #555;
+}
+.mode-toggle button {
+  padding: 4px 10px;
+  font-size: 0.75rem;
+  border: none;
+  border-radius: 0;
+  background: #333;
+  color: #888;
+  cursor: pointer;
+  font-weight: 600;
+}
+.mode-toggle button:hover { background: #444; }
+.mode-toggle button.active {
+  background: #e94560;
+  color: #fff;
+}
+
 /* Card count button group */
 .count-group {
   display: flex;
@@ -255,6 +278,39 @@ button.secondary:hover { background: #444; }
 .crop-panel img {
   position: absolute;
   transform-origin: 0 0;
+}
+
+/* Names-mode crop panel — wider, no fixed aspect ratio */
+.crop-panel.names-mode {
+  aspect-ratio: auto;
+  width: 400px;
+  height: min(calc(100vh - 200px), 600px);
+  position: relative;
+}
+.crop-panel .bbox-overlay {
+  position: absolute;
+  border: 2px solid #888;
+  border-radius: 3px;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+  z-index: 2;
+}
+.crop-panel .bbox-overlay.selected {
+  border-color: #4caf50;
+  background: rgba(76, 175, 80, 0.15);
+}
+.crop-panel .bbox-overlay.assigned {
+  border-color: #42a5f5;
+  background: rgba(66, 165, 245, 0.15);
+}
+.crop-panel .bbox-overlay .bbox-set-icon {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  font-size: 0.9rem;
+  background: rgba(0,0,0,0.6);
+  border-radius: 3px;
+  padding: 1px 3px;
 }
 
 /* Right panel: candidates */
@@ -418,6 +474,69 @@ button.secondary:hover { background: #444; }
   font-size: 0.85rem;
 }
 
+/* ── Names Mode Grid ── */
+.names-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 6px;
+}
+.names-grid .name-tile {
+  position: relative;
+  background: #16213e;
+  border: 2px solid transparent;
+  border-radius: 6px;
+  overflow: hidden;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+.names-grid .name-tile:hover { border-color: #0f3460; }
+.name-tile .tile-img {
+  width: 100%;
+  aspect-ratio: 63 / 44;
+  object-fit: cover;
+  object-position: top center;
+  border-radius: 4px 4px 0 0;
+}
+.name-tile .tile-set-icon {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  z-index: 1;
+  font-size: 1.6rem;
+  width: 36px;
+  height: 36px;
+  line-height: 36px;
+  text-align: center;
+  background: #efefef;
+  border-radius: 5px;
+  border: 2px solid #0f3460;
+}
+.name-tile .tile-buttons {
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+}
+.name-tile .tile-buttons button {
+  flex: 1;
+  padding: 6px 4px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  border: 1px solid #555;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.name-tile .btn-nonfoil {
+  background: #555;
+  color: #e0e0e0;
+}
+.name-tile .btn-nonfoil:hover { background: #666; }
+.name-tile .btn-foil {
+  background: linear-gradient(135deg, #ff6b6b, #ffd93d, #6bff6b, #6bb5ff, #d06bff);
+  color: #000;
+  border-color: transparent;
+}
+.name-tile .btn-foil:hover { opacity: 0.85; }
+
 /* ── Done Screen ── */
 #done-view {
   display: none;
@@ -469,14 +588,14 @@ button.secondary:hover { background: #444; }
   <div id="image-list"></div>
   <div id="process-controls">
     <button id="process-all-btn" disabled>Process All</button>
-    <span id="process-all-warning" style="color: #e94560; font-size: 0.85rem; margin-left: 12px;">Set card count for all images before processing</span>
+    <span id="process-all-warning" style="color: #e94560; font-size: 0.85rem; margin-left: 12px;">Set mode and card count for all images before processing</span>
   </div>
 </div>
 
 <!-- Processing Log (shown inline during upload, moves into disambig layout) -->
 <div id="processing-log"></div>
 
-<!-- Phase 2: Disambiguation -->
+<!-- Phase 2: Disambiguation (full-card mode) -->
 <div id="disambig-view">
   <div class="disambig-layout" id="disambig-layout">
     <div class="crop-panel" id="crop-panel">
@@ -509,6 +628,36 @@ button.secondary:hover { background: #444; }
   </div>
 </div>
 
+<!-- Phase 2b: Disambiguation (names mode) -->
+<div id="names-disambig-view" style="display:none; margin: 0 24px;">
+  <div class="disambig-layout" id="names-disambig-layout">
+    <div class="crop-panel names-mode" id="names-crop-panel">
+      <img id="names-crop-img" src="">
+    </div>
+    <div class="candidates-panel">
+      <div class="card-info" id="names-card-info">
+        <div class="card-name-row">
+          <h3 id="names-card-name">&mdash;</h3>
+          <span id="names-qty-badge" style="font-size:0.8rem; color:#888; margin-left:4px;"></span>
+          <button id="names-edit-btn" class="icon-btn" title="Edit name and search" onclick="startNamesEdit()">&#9998;</button>
+        </div>
+        <div class="search-override" id="names-search-override" style="display:none">
+          <input type="text" id="names-search-input" placeholder="Search by card name...">
+          <button id="names-search-btn" onclick="namesSearchOverride()">Search</button>
+        </div>
+        <div class="meta" id="names-card-meta"></div>
+      </div>
+      <div class="disambig-actions">
+        <button id="names-confirm-btn" disabled>Confirm</button>
+        <button id="names-skip-btn" class="secondary">Skip</button>
+        <button id="names-reset-btn" class="secondary">Reset</button>
+        <div class="progress" id="names-progress-text"></div>
+      </div>
+      <div class="candidates-list names-grid" id="names-candidates-grid"></div>
+    </div>
+  </div>
+</div>
+
 <!-- Phase 3: Done -->
 <div id="done-view">
   <h2>All done!</h2>
@@ -524,6 +673,17 @@ const state = {
   processing: false,
   confirmedCount: 0,
   skippedCount: 0,
+  // Names mode state
+  namesMode: {
+    imageIdx: null,
+    nameIdx: null,
+    assignments: [],  // [{occurrence_idx, scryfall_id, finish}]
+    selectedBoxes: new Set(),
+    candidates: [],
+    quantity: 0,
+  },
+  hasNamesImages: false,
+  hasFullImages: false,
 };
 
 let _settings = {};
@@ -588,6 +748,7 @@ async function handleFiles(fileList) {
       storedName: uploaded.stored_name,
       index: uploaded.index,
       cardCount: 0,
+      mode: null,  // "full" or "names" — must be set
       forceIngest: false,
       processed: false,
     };
@@ -605,6 +766,10 @@ function renderImageRow(img) {
   row.innerHTML = `
     <img class="thumb" src="/api/ingest/image/${img.storedName}" alt="${img.filename}">
     <span class="name">${img.filename}</span>
+    <div class="mode-toggle" id="mode-toggle-${img.index}">
+      <button onclick="setMode(${img.index}, 'full')" id="mode-full-${img.index}">Full Cards</button>
+      <button onclick="setMode(${img.index}, 'names')" id="mode-names-${img.index}">Names Only</button>
+    </div>
     <label>Cards:</label>
     <div class="count-group">
       <button onclick="adjustCount(${img.index}, -5)">-5</button>
@@ -621,10 +786,21 @@ function renderImageRow(img) {
   imageList.appendChild(row);
 }
 
+function setMode(index, mode) {
+  const img = state.images.find(i => i.index === index);
+  if (!img) return;
+  img.mode = mode;
+  // Update toggle UI
+  document.getElementById(`mode-full-${index}`).className = mode === 'full' ? 'active' : '';
+  document.getElementById(`mode-names-${index}`).className = mode === 'names' ? 'active' : '';
+  updateProcessAllState();
+  syncCount(index);
+}
+
 function adjustCount(index, delta) {
   const img = state.images.find(i => i.index === index);
   if (!img) return;
-  img.cardCount = Math.max(0, Math.min(20, img.cardCount + delta));
+  img.cardCount = Math.max(0, Math.min(99, img.cardCount + delta));
   const countEl = document.getElementById(`count-${index}`);
   countEl.textContent = img.cardCount;
   countEl.style.color = img.cardCount === 0 ? '#e94560' : '#e0e0e0';
@@ -633,7 +809,7 @@ function adjustCount(index, delta) {
 }
 
 function updateProcessAllState() {
-  const allSet = state.images.length > 0 && state.images.every(img => img.cardCount > 0);
+  const allSet = state.images.length > 0 && state.images.every(img => img.cardCount > 0 && img.mode);
   document.getElementById('process-all-btn').disabled = !allSet;
   document.getElementById('process-all-warning').style.display = allSet ? 'none' : 'inline';
 }
@@ -654,6 +830,7 @@ async function syncCount(index) {
       image_idx: index,
       card_count: img.cardCount,
       force_ingest: img.forceIngest,
+      mode: img.mode,
     }),
   });
 }
@@ -679,6 +856,10 @@ async function processAll() {
     await syncCount(img.index);
   }
 
+  // Track what modes we have
+  state.hasFullImages = state.images.some(i => i.mode === 'full');
+  state.hasNamesImages = state.images.some(i => i.mode === 'names');
+
   for (let i = 0; i < state.images.length; i++) {
     const img = state.images[i];
     if (img.processed) continue;
@@ -694,7 +875,7 @@ async function processAll() {
     document.getElementById('pill-step').textContent = 'Starting...';
     document.getElementById('pill-step').className = 'pill active';
 
-    appendLog(`Processing ${img.filename}...`, 'running');
+    appendLog(`Processing ${img.filename} [${img.mode}]...`, 'running');
 
     await processImageSSE(img);
 
@@ -778,6 +959,13 @@ function processImageSSE(img) {
       }
     });
 
+    es.addEventListener('names_ready', (e) => {
+      const data = JSON.parse(e.data);
+      const totalCandidates = data.names.reduce((sum, n) => sum + n.candidates.length, 0);
+      const totalQty = data.names.reduce((sum, n) => sum + n.quantity, 0);
+      appendLog(`  Scryfall: ${data.names.length} unique name(s), ${totalQty} copies, ${totalCandidates} total candidates`, 'done');
+    });
+
     es.addEventListener('error', (e) => {
       if (e.data) {
         const data = JSON.parse(e.data);
@@ -811,13 +999,22 @@ function appendLog(text, cls) {
 
 async function showDisambiguation() {
   document.getElementById('upload-phase').style.display = 'none';
-  document.getElementById('disambig-view').style.display = 'block';
-  // Move log into the disambig layout as first child
-  const log = document.getElementById('processing-log');
-  const layout = document.getElementById('disambig-layout');
-  layout.insertBefore(log, layout.firstChild);
-  await loadNextCard();
+
+  // Handle full-card images first, then names images
+  if (state.hasFullImages) {
+    document.getElementById('disambig-view').style.display = 'block';
+    const log = document.getElementById('processing-log');
+    const layout = document.getElementById('disambig-layout');
+    layout.insertBefore(log, layout.firstChild);
+    await loadNextCard();
+  } else if (state.hasNamesImages) {
+    await startNamesDisambiguation();
+  } else {
+    showDone();
+  }
 }
+
+// ── Full-card disambiguation ──
 
 async function loadNextCard() {
   const resp = await fetch('/api/ingest/next-card', {
@@ -828,7 +1025,13 @@ async function loadNextCard() {
   const data = await resp.json();
 
   if (data.done) {
-    showDone();
+    // Full-card done — move to names if needed
+    if (state.hasNamesImages) {
+      document.getElementById('disambig-view').style.display = 'none';
+      await startNamesDisambiguation();
+    } else {
+      showDone();
+    }
     return;
   }
 
@@ -881,7 +1084,7 @@ function startNameEdit() {
   nameEl.style.display = 'none';
   editBtn.style.display = 'none';
   searchRow.style.display = 'flex';
-  input.value = nameEl.textContent === '—' ? '' : nameEl.textContent;
+  input.value = nameEl.textContent === '\u2014' ? '' : nameEl.textContent;
   input.focus();
   input.select();
 }
@@ -1105,8 +1308,456 @@ document.getElementById('skip-btn').addEventListener('click', async () => {
   await loadNextCard();
 });
 
+// ── Names Mode Disambiguation ──
+
+async function startNamesDisambiguation() {
+  document.getElementById('names-disambig-view').style.display = 'block';
+  // Move log into names disambig layout
+  const log = document.getElementById('processing-log');
+  const layout = document.getElementById('names-disambig-layout');
+  layout.insertBefore(log, layout.firstChild);
+  await loadNextName();
+}
+
+async function loadNextName() {
+  const resp = await fetch('/api/ingest/next-name', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ session_id: state.sessionId }),
+  });
+  const data = await resp.json();
+
+  if (data.done) {
+    showDone();
+    return;
+  }
+
+  const nm = state.namesMode;
+  nm.imageIdx = data.image_idx;
+  nm.nameIdx = data.name_idx;
+  nm.quantity = data.quantity;
+  nm.candidates = data.candidates;
+  // Initialize assignments: one per occurrence, null = unassigned
+  nm.assignments = (data.assignments || []).map(a => a);
+  // Select all unassigned boxes
+  nm.selectedBoxes = new Set();
+  for (let i = 0; i < nm.quantity; i++) {
+    if (!nm.assignments[i]) nm.selectedBoxes.add(i);
+  }
+
+  // Update UI
+  document.getElementById('names-card-name').textContent = data.name || '(Unknown)';
+  document.getElementById('names-qty-badge').textContent = `x${data.quantity}`;
+  document.getElementById('names-card-meta').textContent =
+    data.uncertain ? 'Name uncertain — verify carefully' : '';
+
+  // Reset search UI
+  document.getElementById('names-card-name').style.display = '';
+  document.getElementById('names-edit-btn').style.display = '';
+  document.getElementById('names-qty-badge').style.display = '';
+  document.getElementById('names-search-override').style.display = 'none';
+
+  // Progress
+  document.getElementById('names-progress-text').textContent =
+    `${data.total_done + 1} of ${data.total_names}`;
+  document.getElementById('pill-card').textContent =
+    `Name ${data.total_done + 1} of ${data.total_names}`;
+  document.getElementById('pill-card').className = 'pill active';
+
+  const img = state.images.find(i => i.index === data.image_idx);
+  if (img) {
+    document.getElementById('pill-filename').textContent = img.filename;
+  }
+
+  // Set up crop panel with bbox overlays
+  setupNamesCropView(data.image_filename, data.occurrence_crops);
+
+  // Render candidate grid with N/F buttons
+  renderNamesCandidates(data.candidates);
+
+  updateNamesConfirmState();
+}
+
+function setupNamesCropView(imageFilename, occurrenceCrops) {
+  const panel = document.getElementById('names-crop-panel');
+  const img = document.getElementById('names-crop-img');
+
+  // Remove old overlays
+  panel.querySelectorAll('.bbox-overlay').forEach(el => el.remove());
+
+  function applyView() {
+    requestAnimationFrame(() => {
+      const panelW = panel.clientWidth;
+      const panelH = panel.clientHeight;
+      if (panelW === 0 || panelH === 0) {
+        requestAnimationFrame(applyView);
+        return;
+      }
+
+      // Compute bounding box encompassing all occurrences
+      let minX = Infinity, minY = Infinity, maxX = 0, maxY = 0;
+      for (const crop of occurrenceCrops) {
+        if (!crop) continue;
+        minX = Math.min(minX, crop.x);
+        minY = Math.min(minY, crop.y);
+        maxX = Math.max(maxX, crop.x + crop.w);
+        maxY = Math.max(maxY, crop.y + crop.h);
+      }
+
+      // Add padding
+      const pw = (maxX - minX) * 0.2;
+      const ph = (maxY - minY) * 0.2;
+      minX = Math.max(0, minX - pw);
+      minY = Math.max(0, minY - ph);
+      maxX = Math.min(img.naturalWidth || maxX + pw, maxX + pw);
+      maxY = Math.min(img.naturalHeight || maxY + ph, maxY + ph);
+
+      const regionW = maxX - minX;
+      const regionH = maxY - minY;
+
+      if (regionW > 0 && regionH > 0) {
+        const scaleX = panelW / regionW;
+        const scaleY = panelH / regionH;
+        const scale = Math.min(scaleX, scaleY) * 0.9;
+
+        const offsetX = (panelW / 2) - (minX + regionW / 2) * scale;
+        const offsetY = (panelH / 2) - (minY + regionH / 2) * scale;
+
+        img.style.transform = `translate(${offsetX}px, ${offsetY}px) scale(${scale})`;
+        img._scale = scale;
+        img._tx = offsetX;
+        img._ty = offsetY;
+
+        // Draw bbox overlays for each occurrence
+        const nm = state.namesMode;
+        for (let oi = 0; oi < occurrenceCrops.length; oi++) {
+          const crop = occurrenceCrops[oi];
+          if (!crop) continue;
+
+          const div = document.createElement('div');
+          div.className = 'bbox-overlay';
+          div.dataset.occIdx = oi;
+
+          // Position relative to panel
+          const left = crop.x * scale + offsetX;
+          const top = crop.y * scale + offsetY;
+          const w = crop.w * scale;
+          const h = crop.h * scale;
+
+          div.style.left = left + 'px';
+          div.style.top = top + 'px';
+          div.style.width = w + 'px';
+          div.style.height = h + 'px';
+
+          // State styling
+          if (nm.assignments[oi] && nm.assignments[oi] !== null) {
+            div.classList.add('assigned');
+          } else if (nm.selectedBoxes.has(oi)) {
+            div.classList.add('selected');
+          }
+
+          div.addEventListener('click', (e) => {
+            e.stopPropagation();
+            toggleOccurrenceBox(oi);
+          });
+
+          panel.appendChild(div);
+        }
+      } else {
+        const scale = Math.min(panelW / (img.naturalWidth || 1), panelH / (img.naturalHeight || 1));
+        img.style.transform = `scale(${scale})`;
+        img._scale = scale;
+        img._tx = 0;
+        img._ty = 0;
+      }
+    });
+  }
+
+  const newSrc = `/api/ingest/image/${imageFilename}`;
+  if (img.src.endsWith(imageFilename) && img.complete) {
+    applyView();
+  } else {
+    img.src = newSrc;
+    img.onload = applyView;
+  }
+
+  // Pan/zoom handlers
+  let dragging = false, lastX, lastY;
+
+  panel.onmousedown = e => {
+    if (e.target.classList.contains('bbox-overlay')) return;
+    dragging = true;
+    lastX = e.clientX;
+    lastY = e.clientY;
+    e.preventDefault();
+  };
+
+  panel.onmousemove = e => {
+    if (!dragging) return;
+    const dx = e.clientX - lastX;
+    const dy = e.clientY - lastY;
+    lastX = e.clientX;
+    lastY = e.clientY;
+    img._tx += dx;
+    img._ty += dy;
+    img.style.transform = `translate(${img._tx}px, ${img._ty}px) scale(${img._scale})`;
+    // Move overlays too
+    panel.querySelectorAll('.bbox-overlay').forEach(el => {
+      el.style.left = (parseFloat(el.style.left) + dx) + 'px';
+      el.style.top = (parseFloat(el.style.top) + dy) + 'px';
+    });
+  };
+
+  panel.onmouseup = () => dragging = false;
+  panel.onmouseleave = () => dragging = false;
+
+  panel.onwheel = e => {
+    e.preventDefault();
+    const rect = panel.getBoundingClientRect();
+    const mouseX = e.clientX - rect.left;
+    const mouseY = e.clientY - rect.top;
+
+    const oldScale = img._scale || 1;
+    const factor = e.deltaY < 0 ? 1.15 : 1 / 1.15;
+    const newScale = oldScale * factor;
+
+    const newTx = mouseX - (mouseX - img._tx) * (newScale / oldScale);
+    const newTy = mouseY - (mouseY - img._ty) * (newScale / oldScale);
+
+    img._tx = newTx;
+    img._ty = newTy;
+    img._scale = newScale;
+
+    img.style.transform = `translate(${newTx}px, ${newTy}px) scale(${newScale})`;
+    // Reposition overlays
+    const ratio = newScale / oldScale;
+    panel.querySelectorAll('.bbox-overlay').forEach(el => {
+      const elX = parseFloat(el.style.left);
+      const elY = parseFloat(el.style.top);
+      const elW = parseFloat(el.style.width);
+      const elH = parseFloat(el.style.height);
+      el.style.left = (mouseX + (elX - mouseX) * ratio) + 'px';
+      el.style.top = (mouseY + (elY - mouseY) * ratio) + 'px';
+      el.style.width = (elW * ratio) + 'px';
+      el.style.height = (elH * ratio) + 'px';
+    });
+  };
+}
+
+function toggleOccurrenceBox(occIdx) {
+  const nm = state.namesMode;
+  // Only toggle unassigned boxes
+  if (nm.assignments[occIdx] && nm.assignments[occIdx] !== null) return;
+
+  if (nm.selectedBoxes.has(occIdx)) {
+    nm.selectedBoxes.delete(occIdx);
+  } else {
+    nm.selectedBoxes.add(occIdx);
+  }
+  refreshBboxStyles();
+}
+
+function refreshBboxStyles() {
+  const nm = state.namesMode;
+  const panel = document.getElementById('names-crop-panel');
+  panel.querySelectorAll('.bbox-overlay').forEach(el => {
+    const oi = parseInt(el.dataset.occIdx);
+    el.classList.remove('selected', 'assigned');
+    el.innerHTML = '';
+    if (nm.assignments[oi] && nm.assignments[oi] !== null) {
+      el.classList.add('assigned');
+      // Show set icon if we have candidate info
+      const a = nm.assignments[oi];
+      if (a.set_code) {
+        const icon = document.createElement('i');
+        icon.className = `ss ss-${a.set_code.toLowerCase()} ss-${a.rarity || 'common'} ss-grad ss-fw bbox-set-icon`;
+        el.appendChild(icon);
+      }
+    } else if (nm.selectedBoxes.has(oi)) {
+      el.classList.add('selected');
+    }
+  });
+}
+
+function renderNamesCandidates(candidates) {
+  const grid = document.getElementById('names-candidates-grid');
+  grid.innerHTML = '';
+
+  if (!candidates.length) {
+    grid.innerHTML = '<div style="padding:20px;color:#888;text-align:center;">No candidates found</div>';
+    return;
+  }
+
+  for (const c of candidates) {
+    const tile = document.createElement('div');
+    tile.className = 'name-tile';
+
+    const setCode = (c.set_code || '').toLowerCase();
+    const rarityClass = `ss-${c.rarity || 'common'}`;
+
+    tile.innerHTML = `
+      <i class="ss ss-${setCode} ${rarityClass} ss-grad ss-fw tile-set-icon"></i>
+      ${c.image_uri ? `<img class="tile-img" src="${c.image_uri}" loading="lazy">` : `<div style="width:100%;aspect-ratio:63/44;background:#0d1117;border-radius:4px 4px 0 0;"></div>`}
+      <div class="tile-buttons">
+        <button class="btn-nonfoil" title="Assign as nonfoil">N</button>
+        <button class="btn-foil" title="Assign as foil">F</button>
+      </div>
+    `;
+    tile.title = `${c.name} — ${c.set_name} (${c.set_code.toUpperCase()} #${c.collector_number})`;
+
+    // N button
+    tile.querySelector('.btn-nonfoil').addEventListener('click', (e) => {
+      e.stopPropagation();
+      assignToSelected(c, 'nonfoil');
+    });
+
+    // F button
+    tile.querySelector('.btn-foil').addEventListener('click', (e) => {
+      e.stopPropagation();
+      assignToSelected(c, 'foil');
+    });
+
+    grid.appendChild(tile);
+  }
+}
+
+function assignToSelected(candidate, finish) {
+  const nm = state.namesMode;
+  if (nm.selectedBoxes.size === 0) return;
+
+  for (const oi of nm.selectedBoxes) {
+    nm.assignments[oi] = {
+      occurrence_idx: oi,
+      scryfall_id: candidate.scryfall_id,
+      finish: finish,
+      set_code: candidate.set_code,
+      rarity: candidate.rarity,
+    };
+  }
+
+  nm.selectedBoxes.clear();
+
+  // Auto-select remaining unassigned boxes
+  for (let i = 0; i < nm.quantity; i++) {
+    if (!nm.assignments[i] || nm.assignments[i] === null) {
+      nm.selectedBoxes.add(i);
+    }
+  }
+
+  refreshBboxStyles();
+  updateNamesConfirmState();
+}
+
+function updateNamesConfirmState() {
+  const nm = state.namesMode;
+  const allAssigned = nm.assignments.every(a => a && a !== null);
+  document.getElementById('names-confirm-btn').disabled = !allAssigned;
+}
+
+// Names confirm
+document.getElementById('names-confirm-btn').addEventListener('click', async () => {
+  const nm = state.namesMode;
+  const assignments = nm.assignments.filter(a => a && a.scryfall_id).map(a => ({
+    occurrence_idx: a.occurrence_idx,
+    scryfall_id: a.scryfall_id,
+    finish: a.finish,
+  }));
+
+  const resp = await fetch('/api/ingest/confirm-name', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      session_id: state.sessionId,
+      image_idx: nm.imageIdx,
+      name_idx: nm.nameIdx,
+      assignments: assignments,
+    }),
+  });
+  const data = await resp.json();
+
+  if (data.ok) {
+    state.confirmedCount += assignments.length;
+    appendLog(`Confirmed: ${data.name} x${assignments.length} -> IDs ${data.entry_ids.join(', ')}`, 'done');
+    await loadNextName();
+  }
+});
+
+// Names skip
+document.getElementById('names-skip-btn').addEventListener('click', async () => {
+  const nm = state.namesMode;
+  await fetch('/api/ingest/skip-name', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      session_id: state.sessionId,
+      image_idx: nm.imageIdx,
+      name_idx: nm.nameIdx,
+    }),
+  });
+  state.skippedCount += nm.quantity;
+  appendLog(`Skipped name: ${document.getElementById('names-card-name').textContent}`, '');
+  await loadNextName();
+});
+
+// Names reset
+document.getElementById('names-reset-btn').addEventListener('click', () => {
+  const nm = state.namesMode;
+  nm.assignments = new Array(nm.quantity).fill(null);
+  nm.selectedBoxes = new Set();
+  for (let i = 0; i < nm.quantity; i++) nm.selectedBoxes.add(i);
+  refreshBboxStyles();
+  updateNamesConfirmState();
+});
+
+// Names search override
+function startNamesEdit() {
+  document.getElementById('names-card-name').style.display = 'none';
+  document.getElementById('names-edit-btn').style.display = 'none';
+  document.getElementById('names-qty-badge').style.display = 'none';
+  document.getElementById('names-search-override').style.display = 'flex';
+  const input = document.getElementById('names-search-input');
+  input.value = document.getElementById('names-card-name').textContent;
+  input.focus();
+  input.select();
+}
+
+async function namesSearchOverride() {
+  const input = document.getElementById('names-search-input');
+  const query = input.value.trim();
+  if (!query) return;
+
+  const btn = document.getElementById('names-search-btn');
+  btn.disabled = true;
+  btn.textContent = 'Searching...';
+
+  const resp = await fetch('/api/ingest/search-card', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      session_id: state.sessionId,
+      image_idx: state.namesMode.imageIdx,
+      card_idx: state.namesMode.nameIdx,
+      query: query,
+    }),
+  });
+  const data = await resp.json();
+
+  btn.disabled = false;
+  btn.textContent = 'Search';
+
+  state.namesMode.candidates = data.candidates;
+  renderNamesCandidates(data.candidates);
+}
+
+document.getElementById('names-search-input').addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') namesSearchOverride();
+});
+
+// ── Done ──
+
 function showDone() {
   document.getElementById('disambig-view').style.display = 'none';
+  document.getElementById('names-disambig-view').style.display = 'none';
   document.getElementById('done-view').style.display = 'block';
   document.getElementById('pill-card').textContent = 'Done';
   document.getElementById('pill-card').className = 'pill done';


### PR DESCRIPTION
## Summary
- Adds a new card ingestion mode where users provide only card names (no rarity/collector number/set)
- Claude identifies cards from names and resolves them via Scryfall
- New UI page for the names-only workflow

Stacked on #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)