### PR TITLE
Color AND filters + flavor names for reprints

### DIFF
--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -544,6 +544,8 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         filter_badges = params.get("filter_badge[]", [])
         filter_cmc_min = params.get("filter_cmc_min", [""])[0]
         filter_cmc_max = params.get("filter_cmc_max", [""])[0]
+        filter_date_min = params.get("filter_date_min", [""])[0]
+        filter_date_max = params.get("filter_date_max", [""])[0]
 
         conn = sqlite3.connect(self.db_path)
         conn.row_factory = sqlite3.Row
@@ -619,6 +621,13 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         if filter_cmc_max:
             where_clauses.append("card.cmc <= ?")
             sql_params.append(float(filter_cmc_max))
+
+        if filter_date_min:
+            where_clauses.append("c.acquired_at >= ?")
+            sql_params.append(filter_date_min)
+        if filter_date_max:
+            where_clauses.append("c.acquired_at < date(?, '+1 day')")
+            sql_params.append(filter_date_max)
 
         where_sql = " AND ".join(where_clauses) if where_clauses else "1=1"
 

--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -1557,6 +1557,11 @@ function getFilterParams() {
   if (cmcMin !== '') params.set('filter_cmc_min', cmcMin);
   if (cmcMax !== '') params.set('filter_cmc_max', cmcMax);
 
+  const dateMin = dateMinEl.value;
+  const dateMax = dateMaxEl.value;
+  if (dateMin) params.set('filter_date_min', dateMin);
+  if (dateMax) params.set('filter_date_max', dateMax);
+
   return params.toString();
 }
 
@@ -1604,19 +1609,6 @@ async function fetchCollection() {
       const price = parseFloat(card.tcg_price) || 0;
       if (!isNaN(pMin) && price < pMin) return false;
       if (!isNaN(pMax) && price > pMax) return false;
-      return true;
-    });
-  }
-
-  // Client-side date added filtering
-  const dateMin = dateMinEl.value;
-  const dateMax = dateMaxEl.value;
-  if (dateMin || dateMax) {
-    allCards = allCards.filter(card => {
-      const d = (card.acquired_at || '').slice(0, 10);
-      if (!d) return false;
-      if (dateMin && d < dateMin) return false;
-      if (dateMax && d > dateMax) return false;
       return true;
     });
   }


### PR DESCRIPTION
## Summary
- **Color filters use AND semantics**: Selecting W + U shows only cards containing both colors (e.g. Azorius), not all white or blue cards
- **Flavor names for Universe Beyond reprints**: Cards like Final Fantasy reprints now display their printed name (e.g. "Warrior of Light") instead of the oracle name (e.g. "Jodah, the Unifier"). The oracle name appears in smaller text in the card modal. Search matches both names.
- **Fix date filter qty inflation**: Date filtering was client-side after GROUP BY, so filtering by date range showed inflated quantities (counting copies from all dates). Moved to server-side WHERE clause so qty only counts cards within the filtered period.

## Test plan
- [ ] Select W + U color filters — only multicolor WU cards appear (not mono-W or mono-U)
- [ ] Final Fantasy reprints show their flavor name in table, grid, and modal title
- [ ] Oracle name appears as subtitle in the modal for reprinted cards
- [ ] Searching "warrior of light" finds the card
- [ ] Searching "jodah" also finds the card
- [ ] Non-reprint cards are unaffected (no subtitle, name unchanged)
- [ ] Filter by date range — total card count matches actual cards added in that period
- [ ] Date filter + set filter combo produces correct counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)