### PR TITLE
Add card lifecycle status, wishlist, and set browsing

### DIFF
--- a/mtg_collector/cli/__init__.py
+++ b/mtg_collector/cli/__init__.py
@@ -25,9 +25,9 @@ def main():
     # Import subcommand modules and register them
     # These imports are done here to allow partial functionality
     # even if some dependencies (like anthropic) are missing
-    from mtg_collector.cli import db_cmd, data_cmd, list_cmd, show, edit, delete, stats, export, ingest_ids, crack_pack, crack_pack_server
+    from mtg_collector.cli import db_cmd, data_cmd, list_cmd, show, edit, delete, stats, export, ingest_ids, crack_pack, crack_pack_server, wishlist
 
-    modules = [db_cmd, data_cmd, list_cmd, show, edit, delete, stats, export, ingest_ids, crack_pack, crack_pack_server]
+    modules = [db_cmd, data_cmd, list_cmd, show, edit, delete, stats, export, ingest_ids, crack_pack, crack_pack_server, wishlist]
 
     # Try to import modules that require external dependencies
     try:

--- a/mtg_collector/cli/edit.py
+++ b/mtg_collector/cli/edit.py
@@ -23,7 +23,13 @@ def register(subparsers):
     parser.add_argument("--source", metavar="SRC", help="Set source")
     parser.add_argument("--notes", metavar="TEXT", help="Set notes")
     parser.add_argument("--tags", metavar="TAGS", help="Set tags")
-    parser.add_argument("--tradelist", type=int, choices=[0, 1], help="Set tradelist flag")
+    parser.add_argument(
+        "--status",
+        choices=["owned", "ordered", "listed", "sold", "removed"],
+        help="Set lifecycle status",
+    )
+    parser.add_argument("--sale-price", type=float, metavar="PRICE", help="Set sale price (for sold cards)")
+    parser.add_argument("--tradelist", type=int, choices=[0, 1], help="Set tradelist flag (deprecated, use --status)")
     parser.add_argument("--alter", type=int, choices=[0, 1], help="Set alter flag")
     parser.add_argument("--proxy", type=int, choices=[0, 1], help="Set proxy flag")
     parser.add_argument("--signed", type=int, choices=[0, 1], help="Set signed flag")
@@ -73,6 +79,14 @@ def run(args):
     if args.tags is not None:
         entry.tags = args.tags
         changes.append("tags=...")
+
+    if args.status:
+        entry.status = args.status
+        changes.append(f"status={entry.status}")
+
+    if args.sale_price is not None:
+        entry.sale_price = args.sale_price
+        changes.append(f"sale_price=${entry.sale_price:.2f}")
 
     if args.tradelist is not None:
         entry.tradelist = bool(args.tradelist)

--- a/mtg_collector/cli/show.py
+++ b/mtg_collector/cli/show.py
@@ -66,6 +66,7 @@ def run(args):
         print(f"Available:       {', '.join(printing.finishes) if printing.finishes else 'N/A'}")
     print()
 
+    print(f"Status:          {entry.status}")
     print(f"Finish:          {entry.finish}")
     print(f"Condition:       {entry.condition}")
     print(f"Language:        {entry.language}")
@@ -75,6 +76,8 @@ def run(args):
     print(f"Source:          {entry.source}")
     if entry.purchase_price is not None:
         print(f"Purchase Price:  ${entry.purchase_price:.2f}")
+    if entry.sale_price is not None:
+        print(f"Sale Price:      ${entry.sale_price:.2f}")
     if entry.notes:
         print(f"Notes:           {entry.notes}")
     if entry.tags:
@@ -82,8 +85,6 @@ def run(args):
     print()
 
     flags = []
-    if entry.tradelist:
-        flags.append("Tradelist")
     if entry.alter:
         flags.append("Alter")
     if entry.proxy:
@@ -95,5 +96,16 @@ def run(args):
     if flags:
         print(f"Flags:           {', '.join(flags)}")
 
+    # Status history
+    history = collection_repo.get_status_history(entry.id)
+    if history:
+        print()
+        print("Status History:")
+        for h in history:
+            from_s = h["from_status"] or "(new)"
+            note_s = f" — {h['note']}" if h["note"] else ""
+            print(f"  {h['changed_at']}  {from_s} → {h['to_status']}{note_s}")
+
+    print()
     print(f"Scryfall ID:     {entry.scryfall_id}")
     print("=" * 60)

--- a/mtg_collector/cli/stats.py
+++ b/mtg_collector/cli/stats.py
@@ -32,6 +32,12 @@ def run(args):
     print(f"Unique Printings:  {stats['unique_printings']:,}")
     print()
 
+    if stats.get("by_status"):
+        print("By Status:")
+        for status, count in sorted(stats["by_status"].items()):
+            print(f"  {status:<12} {count:,}")
+        print()
+
     if stats["by_finish"]:
         print("By Finish:")
         for finish, count in sorted(stats["by_finish"].items()):

--- a/mtg_collector/cli/wishlist.py
+++ b/mtg_collector/cli/wishlist.py
@@ -1,0 +1,178 @@
+"""Wishlist command: mtg wishlist"""
+
+from mtg_collector.db import (
+    CardRepository,
+    PrintingRepository,
+    SetRepository,
+    WishlistRepository,
+    get_connection,
+    init_db,
+)
+from mtg_collector.utils import now_iso
+
+
+def register(subparsers):
+    """Register the wishlist subcommand."""
+    parser = subparsers.add_parser(
+        "wishlist",
+        help="Manage your wishlist",
+        description="Add, list, remove, and fulfill wishlist entries.",
+    )
+    sub = parser.add_subparsers(dest="wishlist_action", metavar="<action>")
+
+    # wishlist add
+    add_parser = sub.add_parser("add", help="Add a card to your wishlist")
+    add_parser.add_argument("name", help="Card name")
+    add_parser.add_argument("--set", dest="set_code", metavar="CODE", help="Preferred set code")
+    add_parser.add_argument("--cn", metavar="CN", help="Collector number (requires --set)")
+    add_parser.add_argument("--max-price", type=float, metavar="N", help="Maximum price willing to pay")
+    add_parser.add_argument("--priority", type=int, default=0, metavar="N", help="Priority (higher = more wanted)")
+    add_parser.add_argument("--notes", metavar="TEXT", help="Notes")
+
+    # wishlist list
+    list_parser = sub.add_parser("list", help="List wishlist entries")
+    list_parser.add_argument("--name", metavar="NAME", help="Filter by card name")
+    list_parser.add_argument("--fulfilled", action="store_true", help="Show fulfilled entries")
+    list_parser.add_argument("--all", dest="show_all", action="store_true", help="Show all entries including fulfilled")
+    list_parser.add_argument("--limit", type=int, metavar="N", help="Limit results")
+
+    # wishlist remove
+    remove_parser = sub.add_parser("remove", help="Remove a wishlist entry")
+    remove_parser.add_argument("id", type=int, help="Wishlist entry ID")
+
+    # wishlist fulfill
+    fulfill_parser = sub.add_parser("fulfill", help="Mark a wishlist entry as fulfilled")
+    fulfill_parser.add_argument("id", type=int, help="Wishlist entry ID")
+
+    parser.set_defaults(func=run)
+
+
+def run(args):
+    """Run the wishlist command."""
+    if not args.wishlist_action:
+        print("Usage: mtg wishlist {add,list,remove,fulfill}")
+        return
+
+    conn = get_connection(args.db_path)
+    init_db(conn)
+    wishlist_repo = WishlistRepository(conn)
+
+    if args.wishlist_action == "add":
+        _add(args, conn, wishlist_repo)
+    elif args.wishlist_action == "list":
+        _list(args, wishlist_repo)
+    elif args.wishlist_action == "remove":
+        _remove(args, conn, wishlist_repo)
+    elif args.wishlist_action == "fulfill":
+        _fulfill(args, conn, wishlist_repo)
+
+
+def _add(args, conn, wishlist_repo):
+    """Add a card to the wishlist."""
+    from mtg_collector.db.models import WishlistEntry
+    from mtg_collector.services.scryfall import ScryfallAPI, cache_scryfall_data
+
+    card_repo = CardRepository(conn)
+    set_repo = SetRepository(conn)
+    printing_repo = PrintingRepository(conn)
+    scryfall = ScryfallAPI()
+
+    results = scryfall.search_card(args.name, set_code=args.set_code, collector_number=args.cn)
+    if not results:
+        print(f"No card found matching '{args.name}'")
+        return
+
+    card_data = results[0]
+    cache_scryfall_data(scryfall, card_repo, set_repo, printing_repo, card_data)
+    conn.commit()
+
+    oracle_id = card_data["oracle_id"]
+    scryfall_id = None
+    if args.set_code:
+        scryfall_id = card_data["id"]
+
+    entry = WishlistEntry(
+        id=None,
+        oracle_id=oracle_id,
+        scryfall_id=scryfall_id,
+        max_price=args.max_price,
+        priority=args.priority,
+        notes=args.notes,
+        added_at=now_iso(),
+        source="manual",
+    )
+    new_id = wishlist_repo.add(entry)
+    conn.commit()
+
+    set_info = ""
+    if scryfall_id:
+        set_info = f" ({card_data['set'].upper()} #{card_data['collector_number']})"
+    print(f"Added to wishlist: #{new_id} {card_data['name']}{set_info}")
+
+
+def _list(args, wishlist_repo):
+    """List wishlist entries."""
+    fulfilled = None
+    if args.show_all:
+        fulfilled = None
+    elif args.fulfilled:
+        fulfilled = True
+    else:
+        fulfilled = False
+
+    entries = wishlist_repo.list_all(
+        fulfilled=fulfilled,
+        name=args.name,
+        limit=args.limit,
+    )
+
+    if not entries:
+        print("No wishlist entries found.")
+        return
+
+    print(f"{'ID':>6}  {'Name':<30}  {'Set':<6}  {'Pri':>3}  {'Max$':>7}  {'Status':<10}")
+    print("-" * 75)
+
+    for e in entries:
+        set_code = (e["set_code"] or "any").upper()
+        max_price = f"${e['max_price']:.2f}" if e["max_price"] else ""
+        status = "fulfilled" if e["fulfilled_at"] else "wanted"
+        print(
+            f"{e['id']:>6}  "
+            f"{e['name'][:30]:<30}  "
+            f"{set_code[:6]:<6}  "
+            f"{e['priority']:>3}  "
+            f"{max_price:>7}  "
+            f"{status:<10}"
+        )
+
+    print("-" * 75)
+    print(f"Showing {len(entries)} entry/entries")
+
+
+def _remove(args, conn, wishlist_repo):
+    """Remove a wishlist entry."""
+    entry = wishlist_repo.get(args.id)
+    if not entry:
+        print(f"No wishlist entry found with ID: {args.id}")
+        return
+
+    wishlist_repo.delete(args.id)
+    conn.commit()
+    print(f"Removed wishlist entry #{args.id}")
+
+
+def _fulfill(args, conn, wishlist_repo):
+    """Mark a wishlist entry as fulfilled."""
+    entry = wishlist_repo.get(args.id)
+    if not entry:
+        print(f"No wishlist entry found with ID: {args.id}")
+        return
+
+    if entry.fulfilled_at:
+        print(f"Wishlist entry #{args.id} is already fulfilled")
+        return
+
+    wishlist_repo.fulfill(args.id)
+    conn.commit()
+    print(f"Marked wishlist entry #{args.id} as fulfilled")

--- a/mtg_collector/db/__init__.py
+++ b/mtg_collector/db/__init__.py
@@ -7,6 +7,7 @@ from mtg_collector.db.models import (
     SetRepository,
     PrintingRepository,
     CollectionRepository,
+    WishlistRepository,
 )
 
 __all__ = [
@@ -19,4 +20,5 @@ __all__ = [
     "SetRepository",
     "PrintingRepository",
     "CollectionRepository",
+    "WishlistRepository",
 ]

--- a/mtg_collector/db/models.py
+++ b/mtg_collector/db/models.py
@@ -75,6 +75,22 @@ class CollectionEntry:
     proxy: bool = False
     signed: bool = False
     misprint: bool = False
+    status: str = "owned"
+    sale_price: Optional[float] = None
+
+
+@dataclass
+class WishlistEntry:
+    """A card the user wants to acquire."""
+    id: Optional[int]
+    oracle_id: str
+    scryfall_id: Optional[str] = None
+    max_price: Optional[float] = None
+    priority: int = 0
+    notes: Optional[str] = None
+    added_at: Optional[str] = None
+    source: str = "manual"
+    fulfilled_at: Optional[str] = None
 
 
 class CardRepository:
@@ -341,8 +357,9 @@ class CollectionRepository:
             """
             INSERT INTO collection
             (scryfall_id, finish, condition, language, purchase_price,
-             acquired_at, source, source_image, notes, tags, tradelist, is_alter, proxy, signed, misprint)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             acquired_at, source, source_image, notes, tags, tradelist,
+             is_alter, proxy, signed, misprint, status, sale_price)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 entry.scryfall_id,
@@ -360,9 +377,17 @@ class CollectionRepository:
                 1 if entry.proxy else 0,
                 1 if entry.signed else 0,
                 1 if entry.misprint else 0,
+                entry.status,
+                entry.sale_price,
             ),
         )
-        return cursor.lastrowid
+        new_id = cursor.lastrowid
+        # Log the initial status
+        self.conn.execute(
+            "INSERT INTO status_log (collection_id, from_status, to_status, changed_at) VALUES (?, NULL, ?, ?)",
+            (new_id, entry.status, entry.acquired_at),
+        )
+        return new_id
 
     def get(self, entry_id: int) -> Optional[CollectionEntry]:
         """Get a collection entry by ID."""
@@ -375,10 +400,14 @@ class CollectionRepository:
 
         return self._row_to_entry(row)
 
-    def update(self, entry: CollectionEntry) -> bool:
+    def update(self, entry: CollectionEntry, status_note: Optional[str] = None) -> bool:
         """Update a collection entry. Returns True if updated."""
         if entry.id is None:
             return False
+
+        # Check if status changed for logging
+        old = self.get(entry.id)
+        old_status = old.status if old else None
 
         cursor = self.conn.execute(
             """
@@ -397,7 +426,9 @@ class CollectionRepository:
                 is_alter = ?,
                 proxy = ?,
                 signed = ?,
-                misprint = ?
+                misprint = ?,
+                status = ?,
+                sale_price = ?
             WHERE id = ?
             """,
             (
@@ -416,10 +447,21 @@ class CollectionRepository:
                 1 if entry.proxy else 0,
                 1 if entry.signed else 0,
                 1 if entry.misprint else 0,
+                entry.status,
+                entry.sale_price,
                 entry.id,
             ),
         )
-        return cursor.rowcount > 0
+        updated = cursor.rowcount > 0
+
+        # Log status change
+        if updated and old_status and old_status != entry.status:
+            self.conn.execute(
+                "INSERT INTO status_log (collection_id, from_status, to_status, changed_at, note) VALUES (?, ?, ?, ?, ?)",
+                (entry.id, old_status, entry.status, now_iso(), status_note),
+            )
+
+        return updated
 
     def delete(self, entry_id: int) -> bool:
         """Delete a collection entry. Returns True if deleted."""
@@ -435,6 +477,7 @@ class CollectionRepository:
         foil: Optional[bool] = None,
         condition: Optional[str] = None,
         source: Optional[str] = None,
+        status: Optional[str] = None,
         limit: Optional[int] = None,
         offset: int = 0,
     ) -> List[Dict[str, Any]]:
@@ -447,6 +490,7 @@ class CollectionRepository:
                 c.id, c.scryfall_id, c.finish, c.condition, c.language,
                 c.purchase_price, c.acquired_at, c.source, c.notes, c.tags,
                 c.tradelist, c.is_alter, c.proxy, c.signed, c.misprint,
+                c.status, c.sale_price,
                 p.set_code, p.collector_number, p.rarity, p.artist,
                 card.name, card.type_line, card.mana_cost,
                 s.set_name
@@ -480,6 +524,10 @@ class CollectionRepository:
             query += " AND c.source = ?"
             params.append(source)
 
+        if status:
+            query += " AND c.status = ?"
+            params.append(status)
+
         query += " ORDER BY c.acquired_at DESC"
 
         if limit:
@@ -489,9 +537,14 @@ class CollectionRepository:
         cursor = self.conn.execute(query, params)
         return [dict(row) for row in cursor]
 
-    def count(self) -> int:
+    def count(self, status: Optional[str] = None) -> int:
         """Get total number of entries in collection."""
-        cursor = self.conn.execute("SELECT COUNT(*) FROM collection")
+        if status:
+            cursor = self.conn.execute(
+                "SELECT COUNT(*) FROM collection WHERE status = ?", (status,)
+            )
+        else:
+            cursor = self.conn.execute("SELECT COUNT(*) FROM collection")
         return cursor.fetchone()[0]
 
     def stats(self) -> Dict[str, Any]:
@@ -500,6 +553,12 @@ class CollectionRepository:
 
         # Total count
         stats["total_cards"] = self.count()
+
+        # By status
+        cursor = self.conn.execute(
+            "SELECT status, COUNT(*) as cnt FROM collection GROUP BY status"
+        )
+        stats["by_status"] = {row["status"]: row["cnt"] for row in cursor}
 
         # By finish
         cursor = self.conn.execute(
@@ -544,11 +603,36 @@ class CollectionRepository:
 
         return stats
 
+    def get_status_history(self, collection_id: int) -> List[Dict[str, Any]]:
+        """Get status transition history for a collection entry."""
+        cursor = self.conn.execute(
+            """
+            SELECT from_status, to_status, changed_at, note
+            FROM status_log
+            WHERE collection_id = ?
+            ORDER BY changed_at ASC
+            """,
+            (collection_id,),
+        )
+        return [dict(row) for row in cursor]
+
     def _row_to_entry(self, row: sqlite3.Row) -> CollectionEntry:
-        # Handle source_image which might not exist in older databases
+        # Handle optional columns that might not exist in older databases
         source_image = None
         try:
             source_image = row["source_image"]
+        except (IndexError, KeyError):
+            pass
+
+        status = "owned"
+        try:
+            status = row["status"]
+        except (IndexError, KeyError):
+            pass
+
+        sale_price = None
+        try:
+            sale_price = row["sale_price"]
         except (IndexError, KeyError):
             pass
 
@@ -569,4 +653,158 @@ class CollectionRepository:
             proxy=bool(row["proxy"]),
             signed=bool(row["signed"]),
             misprint=bool(row["misprint"]),
+            status=status,
+            sale_price=sale_price,
+        )
+
+
+class WishlistRepository:
+    """CRUD operations for wishlist table."""
+
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+
+    def add(self, entry: WishlistEntry) -> int:
+        """Add a wishlist entry. Returns the new ID."""
+        if entry.added_at is None:
+            entry.added_at = now_iso()
+
+        cursor = self.conn.execute(
+            """
+            INSERT INTO wishlist
+            (oracle_id, scryfall_id, max_price, priority, notes, added_at, source, fulfilled_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                entry.oracle_id,
+                entry.scryfall_id,
+                entry.max_price,
+                entry.priority,
+                entry.notes,
+                entry.added_at,
+                entry.source,
+                entry.fulfilled_at,
+            ),
+        )
+        return cursor.lastrowid
+
+    def get(self, entry_id: int) -> Optional[WishlistEntry]:
+        """Get a wishlist entry by ID."""
+        cursor = self.conn.execute(
+            "SELECT * FROM wishlist WHERE id = ?", (entry_id,)
+        )
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        return self._row_to_entry(row)
+
+    def update(self, entry: WishlistEntry) -> bool:
+        """Update a wishlist entry. Returns True if updated."""
+        if entry.id is None:
+            return False
+        cursor = self.conn.execute(
+            """
+            UPDATE wishlist SET
+                oracle_id = ?, scryfall_id = ?, max_price = ?,
+                priority = ?, notes = ?, source = ?, fulfilled_at = ?
+            WHERE id = ?
+            """,
+            (
+                entry.oracle_id,
+                entry.scryfall_id,
+                entry.max_price,
+                entry.priority,
+                entry.notes,
+                entry.source,
+                entry.fulfilled_at,
+                entry.id,
+            ),
+        )
+        return cursor.rowcount > 0
+
+    def delete(self, entry_id: int) -> bool:
+        """Delete a wishlist entry. Returns True if deleted."""
+        cursor = self.conn.execute(
+            "DELETE FROM wishlist WHERE id = ?", (entry_id,)
+        )
+        return cursor.rowcount > 0
+
+    def fulfill(self, entry_id: int) -> bool:
+        """Mark a wishlist entry as fulfilled."""
+        cursor = self.conn.execute(
+            "UPDATE wishlist SET fulfilled_at = ? WHERE id = ?",
+            (now_iso(), entry_id),
+        )
+        return cursor.rowcount > 0
+
+    def list_all(
+        self,
+        fulfilled: Optional[bool] = None,
+        oracle_id: Optional[str] = None,
+        name: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
+        """List wishlist entries with card info joined."""
+        query = """
+            SELECT
+                w.id, w.oracle_id, w.scryfall_id, w.max_price,
+                w.priority, w.notes, w.added_at, w.source, w.fulfilled_at,
+                card.name, card.type_line, card.mana_cost,
+                p.set_code, p.collector_number, p.image_uri
+            FROM wishlist w
+            JOIN cards card ON w.oracle_id = card.oracle_id
+            LEFT JOIN printings p ON w.scryfall_id = p.scryfall_id
+            WHERE 1=1
+        """
+        params = []
+
+        if fulfilled is not None:
+            if fulfilled:
+                query += " AND w.fulfilled_at IS NOT NULL"
+            else:
+                query += " AND w.fulfilled_at IS NULL"
+
+        if oracle_id:
+            query += " AND w.oracle_id = ?"
+            params.append(oracle_id)
+
+        if name:
+            query += " AND card.name LIKE ?"
+            params.append(f"%{name}%")
+
+        query += " ORDER BY w.priority DESC, w.added_at DESC"
+
+        if limit:
+            query += " LIMIT ?"
+            params.append(limit)
+
+        cursor = self.conn.execute(query, params)
+        return [dict(row) for row in cursor]
+
+    def count(self, fulfilled: Optional[bool] = None) -> int:
+        """Count wishlist entries."""
+        if fulfilled is not None:
+            if fulfilled:
+                cursor = self.conn.execute(
+                    "SELECT COUNT(*) FROM wishlist WHERE fulfilled_at IS NOT NULL"
+                )
+            else:
+                cursor = self.conn.execute(
+                    "SELECT COUNT(*) FROM wishlist WHERE fulfilled_at IS NULL"
+                )
+        else:
+            cursor = self.conn.execute("SELECT COUNT(*) FROM wishlist")
+        return cursor.fetchone()[0]
+
+    def _row_to_entry(self, row: sqlite3.Row) -> WishlistEntry:
+        return WishlistEntry(
+            id=row["id"],
+            oracle_id=row["oracle_id"],
+            scryfall_id=row["scryfall_id"],
+            max_price=row["max_price"],
+            priority=row["priority"],
+            notes=row["notes"],
+            added_at=row["added_at"],
+            source=row["source"],
+            fulfilled_at=row["fulfilled_at"],
         )

--- a/mtg_collector/exporters/base.py
+++ b/mtg_collector/exporters/base.py
@@ -41,7 +41,7 @@ class BaseExporter(ABC):
 
         Args:
             conn: Database connection
-            filters: Optional filters
+            filters: Optional filters (set_code, name, status)
 
         Returns:
             List of dicts with full card info
@@ -51,6 +51,7 @@ class BaseExporter(ABC):
                 c.id, c.scryfall_id, c.finish, c.condition, c.language,
                 c.purchase_price, c.acquired_at, c.source, c.notes, c.tags,
                 c.tradelist, c.is_alter, c.proxy, c.signed, c.misprint,
+                c.status, c.sale_price,
                 p.set_code, p.collector_number, p.rarity, p.artist, p.finishes,
                 card.oracle_id, card.name, card.type_line, card.mana_cost,
                 s.set_name
@@ -70,6 +71,14 @@ class BaseExporter(ABC):
             if filters.get("name"):
                 query += " AND card.name LIKE ?"
                 params.append(f"%{filters['name']}%")
+
+            if filters.get("status"):
+                query += " AND c.status = ?"
+                params.append(filters["status"])
+
+        # Default: export only owned + listed cards
+        if not filters or "status" not in filters:
+            query += " AND c.status IN ('owned', 'listed')"
 
         query += " ORDER BY card.name, p.set_code, c.id"
 

--- a/mtg_collector/exporters/deckbox.py
+++ b/mtg_collector/exporters/deckbox.py
@@ -51,7 +51,7 @@ class DeckboxExporter(BaseExporter):
             for entry in entries:
                 row = {
                     "Count": 1,
-                    "Tradelist Count": 1 if entry["tradelist"] else "",
+                    "Tradelist Count": 1 if entry.get("status") == "listed" else "",
                     "Name": entry["name"],
                     "Edition": entry["set_name"],  # Deckbox uses full set name
                     "Card Number": entry["collector_number"],

--- a/mtg_collector/exporters/moxfield.py
+++ b/mtg_collector/exporters/moxfield.py
@@ -60,7 +60,7 @@ class MoxfieldExporter(BaseExporter):
                 entry["language"],
             )
             aggregated[key]["count"] += 1
-            if entry["tradelist"]:
+            if entry.get("status") == "listed":
                 aggregated[key]["tradelist_count"] += 1
             aggregated[key]["entries"].append(entry)
 

--- a/mtg_collector/importers/deckbox.py
+++ b/mtg_collector/importers/deckbox.py
@@ -78,12 +78,15 @@ class DeckboxImporter(BaseImporter):
         alter = row.get("Altered Art", "").strip().lower() in ("altered", "yes", "true", "1")
         misprint = row.get("Misprint", "").strip().lower() in ("misprint", "yes", "true", "1")
 
-        # Check tradelist
+        # Check tradelist → status
         tradelist_str = row.get("Tradelist Count", "").strip()
         tradelist = False
+        status = "owned"
         if tradelist_str:
             try:
-                tradelist = int(tradelist_str) > 0
+                if int(tradelist_str) > 0:
+                    tradelist = True
+                    status = "listed"
             except ValueError:
                 pass
 
@@ -103,4 +106,5 @@ class DeckboxImporter(BaseImporter):
             proxy=False,  # Deckbox doesn't have proxy field in standard export
             signed=signed,
             misprint=misprint,
+            status=status,
         )

--- a/mtg_collector/importers/moxfield.py
+++ b/mtg_collector/importers/moxfield.py
@@ -72,12 +72,15 @@ class MoxfieldImporter(BaseImporter):
         alter = row.get("Alter", "").strip().lower() in ("alter", "yes", "true", "1")
         proxy = row.get("Proxy", "").strip().lower() in ("proxy", "yes", "true", "1")
 
-        # Check tradelist
+        # Check tradelist → status
         tradelist_str = row.get("Tradelist Count", "").strip()
         tradelist = False
+        status = "owned"
         if tradelist_str:
             try:
-                tradelist = int(tradelist_str) > 0
+                if int(tradelist_str) > 0:
+                    tradelist = True
+                    status = "listed"
             except ValueError:
                 pass
 
@@ -97,4 +100,5 @@ class MoxfieldImporter(BaseImporter):
             proxy=proxy,
             signed=False,
             misprint=False,
+            status=status,
         )


### PR DESCRIPTION
## Summary

- **Status column** on `collection` — tracks lifecycle of a physical card: `owned`, `ordered`, `listed`, `sold`, `removed`. Supersedes the `tradelist` boolean (migrated automatically). Append-only `status_log` table provides full audit trail.
- **Wishlist table** — standalone entity for cards you want, oracle-level or printing-specific, with priority, max price, and fulfillment tracking.
- **Set browsing** — `/api/set-browse/<set_code>` LEFT JOINs against collection and wishlist to annotate every printing in a set with owned/wanted status.
- **Schema migration** v7 → v8 with backward-compatible column additions and data migration.

### Files changed (15)

| Area | Files |
|------|-------|
| Schema | `db/schema.py` — v8 migration, new tables, updated view |
| Models | `db/models.py` — status/sale_price on CollectionEntry, WishlistEntry + WishlistRepository, status log |
| CLI | `cli/edit.py`, `cli/list_cmd.py`, `cli/show.py`, `cli/stats.py` — status filters and display |
| CLI (new) | `cli/wishlist.py` — `mtg wishlist {add,list,remove,fulfill}` |
| Importers | `importers/moxfield.py`, `importers/deckbox.py` — tradelist → status='listed' |
| Exporters | `exporters/base.py`, `exporters/moxfield.py`, `exporters/deckbox.py` — status-based tradelist mapping |
| Server | `cli/crack_pack_server.py` — status filter on /api/collection, wishlist + set-browse endpoints |

## Test plan

- [x] All 13 existing tests pass
- [ ] `mtg db init` on existing DB — verify status column added, tradelist rows migrated, status_log seeded
- [ ] `mtg ingest-ids --id R 0200 FIN` → `mtg list` shows status=owned → `mtg edit <id> --status listed` → `mtg list --status listed`
- [ ] `mtg show <id>` shows status history
- [ ] `mtg wishlist add "Lightning Bolt"` → `mtg wishlist list` → `mtg wishlist fulfill <id>`
- [ ] Import Moxfield CSV with tradelist entries → verify status='listed'; export back → verify Tradelist Count
- [ ] Start server, verify `/api/collection` returns status field, `/api/set-browse/<code>` returns owned/wanted annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)