### PR TITLE
Fix deploy: add /opt/mtgc as git safe directory

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Pull latest code
-        run: git -C /opt/mtgc pull --ff-only origin main
+        run: git config --global --add safe.directory /opt/mtgc && git -C /opt/mtgc pull --ff-only origin main
 
       - name: Build and restart
         run: bash /opt/mtgc/deploy/deploy.sh


### PR DESCRIPTION
## Summary
- Runner user doesn't own `/opt/mtgc` (owned by `mtgc` from prior bare-metal setup), so git's safe directory check blocks the pull step
- Adds `git config --global --add safe.directory /opt/mtgc` before pulling

## Test plan
- [ ] CI deploy workflow passes the pull step

🤖 Generated with [Claude Code](https://claude.com/claude-code)