### PR TITLE
Fix delete FK bug, filter phantom Claude cards, port default

### DIFF
--- a/mtg_collector/services/claude.py
+++ b/mtg_collector/services/claude.py
@@ -200,6 +200,8 @@ Known hints:
 {hint_block}
 
 Return one object per card. Each object should consolidate ALL fragments from that card.
+Only return cards you can actually identify from the OCR text. Do NOT return empty or
+placeholder objects. Every card must have a non-empty fragment_indices array.
 Include only fields you can confidently identify. Always include fragment_indices.
 Omit any field you are not confident about. Do NOT guess or hallucinate.
 If a hint provides the set code, include "set_code" in every card object.
@@ -275,7 +277,7 @@ OCR FRAGMENTS:
 
                 _status("Parsing Claude response...")
                 result = json.loads(text_content)
-                cards = result["cards"]
+                cards = [c for c in result["cards"] if c.get("fragment_indices")]
 
                 return cards, response.usage
             except anthropic.BadRequestError as e:

--- a/mtg_collector/static/disambiguate.html
+++ b/mtg_collector/static/disambiguate.html
@@ -221,7 +221,7 @@ button.secondary:hover { background: #444; }
 }
 .candidates-list.grid-mode .candidate-row .set-icon {
   position: absolute; top: 3px; left: 3px; z-index: 1;
-  font-size: 1.2rem; width: 28px; height: 28px; line-height: 28px;
+  font-size: 1.8rem; width: 38px; height: 38px; line-height: 38px;
   border: 2px solid #0f3460;
 }
 .candidates-list.grid-mode .card-img-grid {


### PR DESCRIPTION
## Summary
- **Fix remove-card delete**: swapped delete order to remove `ingest_lineage` before `collection` — the FK constraint was silently blocking collection deletion, so clicking the X on the Recents page confirmed but never actually removed the card
- **Filter phantom cards from Claude**: Claude occasionally returns empty card objects with no `fragment_indices` — these now get filtered out post-response and skipped during Scryfall resolution, preventing nonsense matches (e.g. "Aberrant" from an empty search)
- **Default port**: changed from 8081 to 8080 to match documented default
- **Disambiguate UI**: enlarged set icons in grid view

## Test plan
- [ ] Ingest a single-card photo, verify only one card appears (no phantom second card)
- [ ] On Recents page, open a confirmed card's modal, click X to delete — verify card is removed from collection
- [ ] Start server without `--port` flag, verify it binds to 8080

🤖 Generated with [Claude Code](https://claude.com/claude-code)