### PR TITLE
Rootless Podman deployment with per-instance isolation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,13 +4,21 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      instance:
+        description: 'Instance name (e.g. prod, staging)'
+        required: true
+        default: 'prod'
+
+env:
+  INSTANCE: ${{ github.event.inputs.instance || 'prod' }}
 
 jobs:
   deploy:
     runs-on: self-hosted
     steps:
       - name: Pull latest code
-        run: git config --global --add safe.directory /opt/mtgc && git -C /opt/mtgc pull --ff-only origin main
+        run: git -C /opt/mtgc-${{ env.INSTANCE }} pull --ff-only origin ${{ github.ref_name }}
 
       - name: Build and restart
-        run: bash /opt/mtgc/deploy/deploy.sh
+        run: bash /opt/mtgc-${{ env.INSTANCE }}/deploy/deploy.sh ${{ env.INSTANCE }}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,112 +1,72 @@
 # MTGC Deployment
 
-Container-based deployment using Podman Quadlet with CI via GitHub Actions.
+Rootless Podman Quadlet deployment. No sudo required (after initial podman install). Each instance is a separate repo clone with its own image, data, and config.
 
-## Architecture
-
-```
-GitHub repo
-    │
-    │  push to main triggers deploy workflow
-    ▼
-Self-hosted runner
-    │
-    │  deploy.sh (podman build + systemctl restart)
-    ▼
-┌──────────────────────────────────────┐
-│  Server                              │
-│                                      │
-│  Podman container (:8081)            │
-│  Data: mtgc-data volume              │
-│  Env:  ~/.config/mtgc/.env           │
-└──────────────────────────────────────┘
-```
-
-## Prerequisites
-
-- Podman 4.4+
-- Anthropic API key
-- curl (for health checks)
-
-## Setup
-
-### 1. Clone the repo
+## Prerequisites (one-time, needs sudo)
 
 ```bash
-git clone https://github.com/thaen/efj-mtgc.git /opt/mtgc
-```
-
-### 2. Configure environment
-
-```bash
-mkdir -p ~/.config/mtgc
-cp /opt/mtgc/.env.example ~/.config/mtgc/.env
-# Edit ~/.config/mtgc/.env and set ANTHROPIC_API_KEY
-```
-
-### 3. Build the container image
-
-```bash
-cd /opt/mtgc
-podman build -t mtgc -f Containerfile .
-```
-
-### 4. Install the Quadlet
-
-The `.container` file lives in the deploy repo (`efj-mtgc-deploy`). Copy it into place:
-
-```bash
-mkdir -p ~/.config/containers/systemd
-cp deploy/mtgc.container ~/.config/containers/systemd/
-systemctl --user daemon-reload
-```
-
-### 5. Start the service
-
-```bash
-systemctl --user start mtgc
-```
-
-### 6. First-run data initialization
-
-```bash
-podman exec -it mtgc mtg setup
-```
-
-### 7. Enable on boot (optional)
-
-```bash
-systemctl --user enable mtgc
+sudo apt install podman
 loginctl enable-linger $USER
 ```
 
-## Automated Deployment (CI)
+## One-time: set up default env
 
-Register a GitHub Actions self-hosted runner, then pushes to main will automatically rebuild the image and restart the container.
+Create a shared env file so new instances automatically get your API key:
 
-No sudo or special permissions required — everything runs as the runner user via `podman` and `systemctl --user`.
+```bash
+mkdir -p ~/.config/mtgc
+echo "ANTHROPIC_API_KEY=sk-ant-..." > ~/.config/mtgc/default.env
+chmod 600 ~/.config/mtgc/default.env
+```
 
-## What's in `deploy/`
+## Stable deployment (CD)
 
-| File | Purpose |
+Push to main auto-deploys the `prod` instance.
+
+```bash
+git clone https://github.com/thaen/efj-mtgc.git /opt/mtgc-prod
+cd /opt/mtgc-prod
+bash deploy/setup.sh prod 8081
+systemctl --user start mtgc-prod
+podman exec -it systemd-mtgc-prod mtg setup
+```
+
+## Feature / test instances
+
+Each instance runs from its own checkout on any branch. Port is auto-assigned if omitted.
+
+```bash
+git clone https://github.com/thaen/efj-mtgc.git ~/workspace/mtgc-feature-xyz
+cd ~/workspace/mtgc-feature-xyz
+git checkout feature-xyz
+bash deploy/setup.sh feature-xyz
+systemctl --user start mtgc-feature-xyz
+podman exec -it systemd-mtgc-feature-xyz mtg setup
+
+# ... develop and test ...
+
+# Clean up when done
+bash deploy/teardown.sh feature-xyz         # keeps data volume
+bash deploy/teardown.sh feature-xyz --purge  # removes everything
+```
+
+## Scripts
+
+| Script | Purpose |
 |---|---|
-| `deploy.sh` | Called by CI — builds image, restarts service, health check |
+| `setup.sh <name> [port]` | Create instance. Port auto-assigned if omitted. Copies API key from `~/.config/mtgc/default.env` |
+| `deploy.sh <name>` | Rebuild image and restart one instance |
+| `teardown.sh <name> [--purge]` | Stop and remove instance. `--purge` deletes data volume and env file |
 
-The Quadlet `.container` file and sudoers config live in [`efj-mtgc-deploy`](https://github.com/rgantt/efj-mtgc-deploy).
+## CI
+
+Push to main auto-deploys `prod`. Use workflow_dispatch to deploy other instances by name.
 
 ## Troubleshooting
 
 ```bash
-# Check container status
-systemctl --user status mtgc
-podman ps -a
-
-# View logs
-journalctl --user -u mtgc -f
-
-# Shell into the container
-podman exec -it mtgc bash
-
-# Inspect the data volume
-podman volume inspect mtgc-data
+systemctl --user status mtgc-<name>
+journalctl --user -u mtgc-<name> -f
+podman exec -it systemd-mtgc-<name> bash
+podman volume inspect systemd-mtgc-<name>-data
 ```

--- a/deploy/mtgc.container
+++ b/deploy/mtgc.container
@@ -1,0 +1,20 @@
+[Unit]
+Description=MTG Card Collection Server ({{INSTANCE}})
+After=network-online.target
+Wants=network-online.target
+
+[Container]
+Image=localhost/mtgc:{{INSTANCE}}
+EnvironmentFile=%h/.config/mtgc/{{INSTANCE}}.env
+Environment=MTGC_HOME=/data
+PublishPort={{PORT}}:8081
+Volume=mtgc-{{INSTANCE}}-data.volume:/data:Z
+AutoUpdate=local
+
+[Service]
+Restart=on-failure
+RestartSec=10
+TimeoutStartSec=120
+
+[Install]
+WantedBy=default.target

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# Set up an MTGC container instance (rootless Podman).
+# No sudo required — runs entirely as the current user.
+# Run from within the repo clone for this instance.
+#
+# Prerequisites (one-time, requires sudo):
+#   sudo apt install podman
+#   loginctl enable-linger $USER
+#
+# Usage:
+#   bash deploy/setup.sh <instance> [port]
+#
+# Examples:
+#   bash deploy/setup.sh prod 8081        # explicit port
+#   bash deploy/setup.sh feature-xyz      # auto-assigns next free port
+#
+# Env file:
+#   Copies from ~/.config/mtgc/default.env if it exists (set this up once
+#   with your API key). Falls back to .env.example (needs manual editing).
+#
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "Usage: bash deploy/setup.sh <instance> [port]"
+    echo "Example: bash deploy/setup.sh prod 8081"
+    exit 1
+fi
+
+INSTANCE="$1"
+SERVICE_NAME="mtgc-${INSTANCE}"
+QUADLET_DIR="$HOME/.config/containers/systemd"
+MTGC_CONFIG="$HOME/.config/mtgc"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# --- Port assignment ---
+
+if [ $# -ge 2 ]; then
+    PORT="$2"
+else
+    # Auto-assign: find highest port in existing Quadlets, add 1 (start at 8081)
+    MAX_PORT=8080
+    for unit in "$QUADLET_DIR"/mtgc-*.container 2>/dev/null; do
+        [ -f "$unit" ] || continue
+        P=$(grep -oP 'PublishPort=\K[0-9]+' "$unit" 2>/dev/null || true)
+        if [ -n "$P" ] && [ "$P" -gt "$MAX_PORT" ]; then
+            MAX_PORT="$P"
+        fi
+    done
+    PORT=$((MAX_PORT + 1))
+fi
+
+echo "==> MTGC deployment setup"
+echo "    Instance: $INSTANCE"
+echo "    Port:     $PORT"
+echo "    Service:  $SERVICE_NAME"
+echo "    Repo:     $REPO_DIR"
+
+# --- Prerequisites ---
+
+if ! command -v podman &>/dev/null; then
+    echo "ERROR: podman not found. Install it first:"
+    echo "  sudo apt install podman"
+    exit 1
+fi
+
+echo "    podman: $(podman --version)"
+
+if ! loginctl show-user "$USER" -p Linger 2>/dev/null | grep -q "Linger=yes"; then
+    echo "WARNING: linger not enabled — services will stop when you log out."
+    echo "  Fix with: loginctl enable-linger $USER  (may need sudo)"
+fi
+
+# --- Env file ---
+
+ENV_FILE="${MTGC_CONFIG}/${INSTANCE}.env"
+if [ ! -f "$ENV_FILE" ]; then
+    mkdir -p "$MTGC_CONFIG"
+    if [ -f "${MTGC_CONFIG}/default.env" ]; then
+        echo "==> Creating $ENV_FILE from default.env..."
+        cp "${MTGC_CONFIG}/default.env" "$ENV_FILE"
+    else
+        echo "==> Creating $ENV_FILE from .env.example..."
+        echo "    NOTE: Set ANTHROPIC_API_KEY in $ENV_FILE before starting."
+        echo "    (Create ~/.config/mtgc/default.env to skip this for future instances.)"
+        cp "$REPO_DIR/.env.example" "$ENV_FILE"
+    fi
+    chmod 600 "$ENV_FILE"
+else
+    echo "    $ENV_FILE already exists, skipping"
+fi
+
+# --- Build container image ---
+
+echo "==> Building container image (mtgc:$INSTANCE)..."
+podman build -t "mtgc:${INSTANCE}" -f "$REPO_DIR/Containerfile" "$REPO_DIR"
+
+# --- Generate and install Quadlet ---
+
+QUADLET_FILE="${QUADLET_DIR}/${SERVICE_NAME}.container"
+echo "==> Installing Quadlet: $QUADLET_FILE"
+mkdir -p "$QUADLET_DIR"
+
+sed \
+    -e "s|{{INSTANCE}}|${INSTANCE}|g" \
+    -e "s|{{PORT}}|${PORT}|g" \
+    "$REPO_DIR/deploy/mtgc.container" > "$QUADLET_FILE"
+
+systemctl --user daemon-reload
+systemctl --user enable "$SERVICE_NAME"
+
+echo ""
+echo "==> Setup complete!"
+echo ""
+echo "  Start:      systemctl --user start $SERVICE_NAME"
+echo "  Init data:  podman exec -it systemd-${SERVICE_NAME} mtg setup"
+echo "  Logs:       journalctl --user -u $SERVICE_NAME -f"
+echo "  Teardown:   bash deploy/teardown.sh $INSTANCE"

--- a/deploy/teardown.sh
+++ b/deploy/teardown.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Tear down an MTGC container instance.
+# Stops the service, removes the Quadlet, and cleans up the image.
+# Data volume and env file are preserved unless --purge is passed.
+#
+# Usage:
+#   bash deploy/teardown.sh <instance>          # keep data
+#   bash deploy/teardown.sh <instance> --purge  # remove everything
+#
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "Usage: bash deploy/teardown.sh <instance> [--purge]"
+    exit 1
+fi
+
+INSTANCE="$1"
+PURGE="${2:-}"
+SERVICE_NAME="mtgc-${INSTANCE}"
+QUADLET_DIR="$HOME/.config/containers/systemd"
+QUADLET_FILE="${QUADLET_DIR}/${SERVICE_NAME}.container"
+
+if [ ! -f "$QUADLET_FILE" ]; then
+    echo "ERROR: No Quadlet found for instance '$INSTANCE'"
+    echo "    Expected: $QUADLET_FILE"
+    exit 1
+fi
+
+echo "==> Tearing down $SERVICE_NAME..."
+
+# Stop and disable
+systemctl --user stop "$SERVICE_NAME" 2>/dev/null || true
+systemctl --user disable "$SERVICE_NAME" 2>/dev/null || true
+
+# Remove Quadlet
+rm -f "$QUADLET_FILE"
+systemctl --user daemon-reload
+
+# Remove image
+podman rmi "mtgc:${INSTANCE}" 2>/dev/null || true
+
+echo "    Service stopped and Quadlet removed."
+
+if [ "$PURGE" = "--purge" ]; then
+    # Remove data volume
+    podman volume rm "systemd-${SERVICE_NAME}-data" 2>/dev/null || true
+    echo "    Data volume removed."
+
+    # Remove env file
+    rm -f "$HOME/.config/mtgc/${INSTANCE}.env"
+    echo "    Env file removed."
+
+    echo "==> Purge complete — all traces of $INSTANCE removed."
+else
+    echo "    Data volume and env file preserved."
+    echo "    Run with --purge to remove everything."
+fi


### PR DESCRIPTION
## Summary
Replaces the bare-metal systemd deployment with rootless Podman Quadlet. Each instance is a fully isolated repo clone with its own image, data volume, env file, and port. No sudo required.

- `setup.sh <instance> [port]` — creates an instance; auto-assigns port if omitted; inherits API key from `~/.config/mtgc/default.env`
- `deploy.sh <instance>` — rebuilds that instance's image and restarts it
- `teardown.sh <instance> [--purge]` — stops service, removes Quadlet; `--purge` deletes data volume and env file
- `mtgc.container` Quadlet template with `{{INSTANCE}}`/`{{PORT}}` placeholders, filled by setup.sh
- CI workflow deploys `prod` on push to main, supports workflow_dispatch for other instances
- `CLAUDE.md` updated with deployment commands and architecture

Supports running multiple concurrent instances (prod, staging, feature branches) on the same machine from independent checkouts.

## Test plan
- [ ] `bash deploy/setup.sh test` creates instance with auto-port and inherited API key
- [ ] `systemctl --user start mtgc-test` starts the container
- [ ] `bash deploy/deploy.sh test` rebuilds and restarts
- [ ] `bash deploy/teardown.sh test --purge` cleans up completely
- [ ] CI deploy workflow succeeds end-to-end for prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)