### PR TITLE
Fix systemctl --user in CI: set XDG_RUNTIME_DIR

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -25,8 +25,15 @@ REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 cd "$REPO_DIR"
 
+# Ensure XDG_RUNTIME_DIR is set (required for systemctl --user).
+# CI runners and non-interactive sessions often lack this.
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+
 echo "==> Building container image (mtgc:$INSTANCE)..."
 podman build -t "mtgc:${INSTANCE}" -f Containerfile .
+
+echo "==> Reloading systemd (picks up Quadlet changes)..."
+systemctl --user daemon-reload
 
 echo "==> Restarting $SERVICE_NAME..."
 systemctl --user restart "$SERVICE_NAME"

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -21,6 +21,10 @@
 #
 set -euo pipefail
 
+# Ensure XDG_RUNTIME_DIR is set (required for systemctl --user).
+# CI runners and non-interactive sessions often lack this.
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+
 if [ $# -lt 1 ]; then
     echo "Usage: bash deploy/setup.sh <instance> [port]"
     echo "Example: bash deploy/setup.sh prod 8081"

--- a/deploy/teardown.sh
+++ b/deploy/teardown.sh
@@ -10,6 +10,10 @@
 #
 set -euo pipefail
 
+# Ensure XDG_RUNTIME_DIR is set (required for systemctl --user).
+# CI runners and non-interactive sessions often lack this.
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+
 if [ $# -lt 1 ]; then
     echo "Usage: bash deploy/teardown.sh <instance> [--purge]"
     exit 1


### PR DESCRIPTION
## Summary

- Set `XDG_RUNTIME_DIR` in all deploy scripts (`deploy.sh`, `setup.sh`, `teardown.sh`) so `systemctl --user` works in CI runners and non-interactive sessions
- Add `daemon-reload` before restart in `deploy.sh` so Quadlet file changes from `git pull` are picked up

Fixes `Failed to connect to bus: No medium found` error in GitHub Actions.

## Test plan

- [ ] CI deploy workflow completes successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)