### PR TITLE
Fix bash syntax error in setup.sh glob loop

### DIFF
--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -46,7 +46,7 @@ if [ $# -ge 2 ]; then
 else
     # Auto-assign: find highest port in existing Quadlets, add 1 (start at 8081)
     MAX_PORT=8080
-    for unit in "$QUADLET_DIR"/mtgc-*.container 2>/dev/null; do
+    for unit in "$QUADLET_DIR"/mtgc-*.container; do
         [ -f "$unit" ] || continue
         P=$(grep -oP 'PublishPort=\K[0-9]+' "$unit" 2>/dev/null || true)
         if [ -n "$P" ] && [ "$P" -gt "$MAX_PORT" ]; then


### PR DESCRIPTION
Remove invalid `2>/dev/null` from `for` loop in `setup.sh` — bash doesn't allow redirects on `for` statements. The `[ -f ]` guard on the next line already handles non-matching globs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)