### PR TITLE
Remove systemctl enable from setup.sh (Quadlet units are generated)

### DIFF
--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -113,7 +113,6 @@ sed \
     "$REPO_DIR/deploy/mtgc.container" > "$QUADLET_FILE"
 
 systemctl --user daemon-reload
-systemctl --user enable "$SERVICE_NAME"
 
 echo ""
 echo "==> Setup complete!"


### PR DESCRIPTION
Quadlet-generated units can't be explicitly enabled — `systemctl --user enable` fails with "Unit is transient or generated". The `[Install] WantedBy=default.target` in the `.container` file already handles auto-start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)