### PR TITLE
Fix Quadlet volume: use named volume instead of .volume unit

### DIFF
--- a/deploy/mtgc.container
+++ b/deploy/mtgc.container
@@ -8,7 +8,7 @@ Image=localhost/mtgc:{{INSTANCE}}
 EnvironmentFile=%h/.config/mtgc/{{INSTANCE}}.env
 Environment=MTGC_HOME=/data
 PublishPort={{PORT}}:8081
-Volume=mtgc-{{INSTANCE}}-data.volume:/data:Z
+Volume=mtgc-{{INSTANCE}}-data:/data:Z
 AutoUpdate=local
 
 [Service]


### PR DESCRIPTION
`Volume=name.volume:/path` makes systemd look for a `.volume` Quadlet unit file that doesn't exist, causing "Unit mtgc-prod-data-volume.service not found". Changed to `Volume=name:/path` which creates a regular Podman named volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)