### PR TITLE
Fix flaky deploy health check timeout

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -56,15 +56,16 @@ if [ -z "$PORT" ]; then
     exit 1
 fi
 echo "==> Listening on port $PORT"
+MAX_ATTEMPTS=15
 echo "==> Health check: $SERVICE_NAME (port $PORT)..."
-for i in 1 2 3 4 5; do
-    if curl -skf "https://localhost:${PORT}/" > /dev/null 2>&1; then
-        echo "==> Health check passed"
+for i in $(seq 1 $MAX_ATTEMPTS); do
+    if curl -skf --connect-timeout 3 "https://localhost:${PORT}/" > /dev/null 2>&1; then
+        echo "==> Health check passed (attempt $i/$MAX_ATTEMPTS)"
         exit 0
     fi
-    echo "    Attempt $i/5 failed, waiting 2s..."
+    echo "    Attempt $i/$MAX_ATTEMPTS failed, waiting 2s..."
     sleep 2
 done
 
-echo "==> Health check FAILED after 5 attempts"
+echo "==> Health check FAILED after $MAX_ATTEMPTS attempts"
 exit 1


### PR DESCRIPTION
## Summary
- Deploy health check was too tight (5 retries, ~20s window) for a server that takes ~25-30s to start
- Increased to 15 retries (~75s window) with `--connect-timeout 3` on curl
- Successful deploys were passing on attempt 4-5 by 1-2s; failures missed by the same margin

## Test plan
- [x] Validated bash syntax locally
- [x] Tested health check loop against running prod instance (passes on attempt 1)
- [x] Tested failure path against closed port (correctly reports failure)
- [ ] Merge and verify next CI deploy passes reliably

🤖 Generated with [Claude Code](https://claude.com/claude-code)