### PR TITLE
Consolidate CI/CD into single deploy.yml with labeled runners

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,16 +9,115 @@ on:
         description: 'Instance name (e.g. prod, staging)'
         required: true
         default: 'prod'
+      runner:
+        description: 'Runner label (thaen or ryan)'
+        required: true
+        default: 'thaen'
 
 env:
-  INSTANCE: ${{ github.event.inputs.instance || 'prod' }}
+  REPO_URL: https://github.com/thaen/efj-mtgc.git
 
 jobs:
-  deploy:
-    runs-on: self-hosted
+  # ── thaen: staging → smoke test → prod ──
+
+  thaen-staging:
+    if: github.event_name == 'push' && github.repository == 'thaen/efj-mtgc'
+    runs-on: [self-hosted, thaen]
+    outputs:
+      deployed: ${{ steps.deploy.outcome == 'success' }}
+    steps:
+      - name: Check if staging instance exists
+        id: check
+        run: |
+          if [ -d /opt/mtgc-staging ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Pull latest code
+        if: steps.check.outputs.exists == 'true'
+        run: |
+          git -C /opt/mtgc-staging remote set-url origin "$REPO_URL"
+          git -C /opt/mtgc-staging pull --ff-only origin main
+
+      - name: Deploy staging
+        id: deploy
+        if: steps.check.outputs.exists == 'true'
+        run: bash /opt/mtgc-staging/deploy/thaen/deploy.sh staging
+
+  thaen-smoke:
+    needs: thaen-staging
+    if: needs.thaen-staging.outputs.deployed == 'true'
+    runs-on: [self-hosted, thaen]
+    steps:
+      - name: Discover staging port
+        id: port
+        run: |
+          PORT=$(podman port mtgc-staging 8081/tcp 2>/dev/null | sed 's/.*://' | head -1)
+          echo "port=$PORT" >> "$GITHUB_OUTPUT"
+
+      - name: Web server responds
+        run: curl -skf "https://localhost:${{ steps.port.outputs.port }}/" > /dev/null
+
+      - name: Collection value check
+        run: |
+          curl -sk "https://localhost:${{ steps.port.outputs.port }}/api/collection" | \
+            python3 -c "
+          import sys, json
+          cards = json.load(sys.stdin)
+          total = sum(float(c.get('tcg_price') or 0) for c in cards)
+          print(f'Collection value: \${total:.2f} ({len(cards)} cards)')
+          assert total > 50, f'Collection value too low: {total}'
+          "
+
+  thaen-prod:
+    needs: [thaen-staging, thaen-smoke]
+    if: |
+      always() &&
+      github.event_name == 'push' &&
+      github.repository == 'thaen/efj-mtgc' &&
+      needs.thaen-staging.result == 'success' &&
+      needs.thaen-smoke.result != 'failure'
+    runs-on: [self-hosted, thaen]
     steps:
       - name: Pull latest code
-        run: git -C /opt/mtgc-${{ env.INSTANCE }} pull --ff-only origin ${{ github.ref_name }}
+        run: |
+          git -C /opt/mtgc-prod remote set-url origin "$REPO_URL"
+          git -C /opt/mtgc-prod pull --ff-only origin main
 
-      - name: Build and restart
-        run: bash /opt/mtgc-${{ env.INSTANCE }}/deploy/deploy.sh ${{ env.INSTANCE }}
+      - name: Deploy prod
+        run: bash /opt/mtgc-prod/deploy/thaen/deploy.sh prod
+
+  # ── ryan: prod only ──
+
+  ryan-prod:
+    if: github.event_name == 'push' && github.repository == 'thaen/efj-mtgc'
+    runs-on: [self-hosted, ryan]
+    steps:
+      - name: Pull latest code
+        run: |
+          git -C /opt/mtgc-prod remote set-url origin "$REPO_URL"
+          git -C /opt/mtgc-prod pull --ff-only origin main
+
+      - name: Deploy prod
+        run: bash /opt/mtgc-prod/deploy/deploy.sh prod
+
+  # ── manual dispatch ──
+
+  dispatch:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: [self-hosted, '${{ inputs.runner }}']
+    steps:
+      - name: Pull latest code
+        run: |
+          git -C /opt/mtgc-${{ inputs.instance }} remote set-url origin "$REPO_URL"
+          git -C /opt/mtgc-${{ inputs.instance }} pull --ff-only origin main
+
+      - name: Deploy (thaen)
+        if: inputs.runner == 'thaen'
+        run: bash /opt/mtgc-${{ inputs.instance }}/deploy/thaen/deploy.sh ${{ inputs.instance }}
+
+      - name: Deploy (ryan)
+        if: inputs.runner != 'thaen'
+        run: bash /opt/mtgc-${{ inputs.instance }}/deploy/deploy.sh ${{ inputs.instance }}

--- a/deploy/thaen/deploy.sh
+++ b/deploy/thaen/deploy.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Rebuild and restart a single MTGC instance on macOS.
+# No systemd — uses podman directly.
+#
+# Usage:
+#   bash deploy/thaen/deploy.sh <instance>
+#
+# Example:
+#   bash deploy/thaen/deploy.sh prod
+#
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "Usage: bash deploy/thaen/deploy.sh <instance>"
+    echo "Example: bash deploy/thaen/deploy.sh prod"
+    exit 1
+fi
+
+INSTANCE="$1"
+CONTAINER_NAME="mtgc-${INSTANCE}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+cd "$REPO_DIR"
+
+# If container doesn't exist, delegate to setup.sh for initial install
+if ! podman container exists "$CONTAINER_NAME" 2>/dev/null; then
+    echo "==> No container found for $INSTANCE, running initial setup..."
+    bash "$SCRIPT_DIR/setup.sh" "$INSTANCE"
+else
+    # Capture current port mapping before teardown
+    PORT_LINE=$(podman port "$CONTAINER_NAME" 8081/tcp 2>/dev/null || true)
+    CURRENT_PORT=$(echo "$PORT_LINE" | sed 's/.*://' | head -1)
+
+    echo "==> Building container image (mtgc:$INSTANCE)..."
+    podman build -t "mtgc:${INSTANCE}" -f Containerfile .
+
+    echo "==> Replacing container ($CONTAINER_NAME)..."
+    podman stop "$CONTAINER_NAME" 2>/dev/null || true
+    podman rm "$CONTAINER_NAME" 2>/dev/null || true
+
+    ENV_FILE="$HOME/.config/mtgc/${INSTANCE}.env"
+
+    podman run -d \
+        --name "$CONTAINER_NAME" \
+        --restart=on-failure \
+        -p "${CURRENT_PORT}:8081" \
+        -v "mtgc-${INSTANCE}-data:/data" \
+        --env-file "$ENV_FILE" \
+        -e MTGC_HOME=/data \
+        "localhost/mtgc:${INSTANCE}"
+fi
+
+# Discover port and health check
+sleep 2
+PORT_LINE=$(podman port "$CONTAINER_NAME" 8081/tcp 2>/dev/null || true)
+PORT=$(echo "$PORT_LINE" | sed 's/.*://' | head -1)
+if [ -z "$PORT" ]; then
+    echo "==> Could not determine port. Check: podman port $CONTAINER_NAME"
+    exit 1
+fi
+
+echo "==> Listening on port $PORT"
+MAX_ATTEMPTS=15
+echo "==> Health check: $CONTAINER_NAME (port $PORT)..."
+for i in $(seq 1 $MAX_ATTEMPTS); do
+    if curl -skf --connect-timeout 3 "https://localhost:${PORT}/" > /dev/null 2>&1; then
+        echo "==> Health check passed (attempt $i/$MAX_ATTEMPTS)"
+        exit 0
+    fi
+    echo "    Attempt $i/$MAX_ATTEMPTS failed, waiting 2s..."
+    sleep 2
+done
+
+echo "==> Health check FAILED after $MAX_ATTEMPTS attempts"
+exit 1

--- a/deploy/thaen/setup.sh
+++ b/deploy/thaen/setup.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Set up an MTGC container instance on macOS (rootless Podman).
+# No systemd, no Quadlet — just podman run.
+#
+# Usage:
+#   bash deploy/thaen/setup.sh <instance> [port]
+#
+# Examples:
+#   bash deploy/thaen/setup.sh prod 8081        # explicit port
+#   bash deploy/thaen/setup.sh feature-xyz      # auto-assigns next free port
+#
+# Env file:
+#   Copies from ~/.config/mtgc/default.env if it exists (set this up once
+#   with your API key). Falls back to .env.example (needs manual editing).
+#
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "Usage: bash deploy/thaen/setup.sh <instance> [port]"
+    echo "Example: bash deploy/thaen/setup.sh prod 8081"
+    exit 1
+fi
+
+INSTANCE="$1"
+CONTAINER_NAME="mtgc-${INSTANCE}"
+MTGC_CONFIG="$HOME/.config/mtgc"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# --- Port assignment ---
+
+if [ $# -ge 2 ]; then
+    PORT="$2"
+else
+    # Auto-assign: find highest host port among mtgc-* containers, add 1 (start at 8081)
+    MAX_PORT=8080
+    for P in $(podman ps -a --filter "name=^mtgc-" --format '{{.Ports}}' 2>/dev/null | sed 's/.*:\([0-9]*\)->.*/\1/' | sort -n); do
+        if [ "$P" -gt "$MAX_PORT" ] 2>/dev/null; then
+            MAX_PORT="$P"
+        fi
+    done
+    PORT=$((MAX_PORT + 1))
+fi
+
+echo "==> MTGC deployment setup"
+echo "    Instance: $INSTANCE"
+echo "    Port:     $PORT"
+echo "    Repo:     $REPO_DIR"
+
+# --- Prerequisites ---
+
+if ! command -v podman &>/dev/null; then
+    echo "ERROR: podman not found. Install it first:"
+    echo "  brew install podman"
+    exit 1
+fi
+
+echo "    podman: $(podman --version)"
+
+# --- Env file ---
+
+ENV_FILE="${MTGC_CONFIG}/${INSTANCE}.env"
+if [ ! -f "$ENV_FILE" ]; then
+    mkdir -p "$MTGC_CONFIG"
+    if [ -f "${MTGC_CONFIG}/default.env" ]; then
+        echo "==> Creating $ENV_FILE from default.env..."
+        cp "${MTGC_CONFIG}/default.env" "$ENV_FILE"
+    else
+        echo "==> Creating $ENV_FILE from .env.example..."
+        echo "    NOTE: Set ANTHROPIC_API_KEY in $ENV_FILE before starting."
+        echo "    (Create ~/.config/mtgc/default.env to skip this for future instances.)"
+        cp "$REPO_DIR/.env.example" "$ENV_FILE"
+    fi
+    chmod 600 "$ENV_FILE"
+else
+    echo "    $ENV_FILE already exists, skipping"
+fi
+
+# --- Build container image ---
+
+echo "==> Building container image (mtgc:$INSTANCE)..."
+podman build -t "mtgc:${INSTANCE}" -f "$REPO_DIR/Containerfile" "$REPO_DIR"
+
+# --- Run container ---
+
+echo "==> Creating data volume (mtgc-${INSTANCE}-data)..."
+podman volume create "mtgc-${INSTANCE}-data" 2>/dev/null || true
+
+echo "==> Starting container ($CONTAINER_NAME)..."
+podman run -d \
+    --name "$CONTAINER_NAME" \
+    --restart=on-failure \
+    -p "${PORT}:8081" \
+    -v "mtgc-${INSTANCE}-data:/data" \
+    --env-file "$ENV_FILE" \
+    -e MTGC_HOME=/data \
+    "localhost/mtgc:${INSTANCE}"
+
+echo ""
+echo "==> Setup complete!"
+echo ""
+echo "  Port:       podman port $CONTAINER_NAME"
+echo "  Init data:  podman exec -it $CONTAINER_NAME mtg setup"
+echo "  Logs:       podman logs -f $CONTAINER_NAME"
+echo "  Stop:       podman stop $CONTAINER_NAME"
+echo "  Start:      podman start $CONTAINER_NAME"
+echo "  Teardown:   bash deploy/thaen/teardown.sh $INSTANCE"

--- a/deploy/thaen/teardown.sh
+++ b/deploy/thaen/teardown.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Tear down an MTGC container instance on macOS.
+# Stops the container, removes it and its image.
+# Data volume and env file are preserved unless --purge is passed.
+#
+# Usage:
+#   bash deploy/thaen/teardown.sh <instance>          # keep data
+#   bash deploy/thaen/teardown.sh <instance> --purge   # remove everything
+#
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "Usage: bash deploy/thaen/teardown.sh <instance> [--purge]"
+    exit 1
+fi
+
+INSTANCE="$1"
+PURGE="${2:-}"
+CONTAINER_NAME="mtgc-${INSTANCE}"
+
+if ! podman container exists "$CONTAINER_NAME" 2>/dev/null; then
+    echo "ERROR: No container found for instance '$INSTANCE'"
+    exit 1
+fi
+
+echo "==> Tearing down $CONTAINER_NAME..."
+
+podman stop "$CONTAINER_NAME" 2>/dev/null || true
+podman rm "$CONTAINER_NAME" 2>/dev/null || true
+
+# Remove image
+podman rmi "mtgc:${INSTANCE}" 2>/dev/null || true
+
+echo "    Container stopped and removed."
+
+if [ "$PURGE" = "--purge" ]; then
+    podman volume rm "mtgc-${INSTANCE}-data" 2>/dev/null || true
+    echo "    Data volume removed."
+
+    rm -f "$HOME/.config/mtgc/${INSTANCE}.env"
+    echo "    Env file removed."
+
+    echo "==> Purge complete — all traces of $INSTANCE removed."
+else
+    echo "    Data volume and env file preserved."
+    echo "    Run with --purge to remove everything."
+fi


### PR DESCRIPTION
## Summary
- Replace two-repo dispatch pattern (`efj-mtgc-deploy`) with labeled self-hosted runner jobs in a single `deploy.yml`
- Add `deploy/thaen/` scripts for macOS Podman deploy (no systemd/Quadlet)
- thaen push-to-main pipeline: staging → smoke test → prod
- ryan push-to-main: direct prod deploy via existing Linux scripts
- `workflow_dispatch` routes to correct runner + scripts by label

## File layout
```
deploy/                    # Ryan's Linux scripts (unchanged)
├── deploy.sh
├── setup.sh
├── teardown.sh
├── mtgc.container
└── README.md

deploy/thaen/              # Ethan's macOS scripts (new)
├── deploy.sh
├── setup.sh
└── teardown.sh
```

## Runner setup (manual)
- Register self-hosted runner on `thaen/efj-mtgc` with label `thaen`
- Ryan registers his runner with label `ryan`

## Test plan
- [ ] Push to main → `thaen-*` jobs run (staging → smoke → prod), `ryan-prod` runs on his runner
- [ ] If `/opt/mtgc-staging` doesn't exist, staging skips, prod still deploys
- [ ] `workflow_dispatch` with runner=thaen, instance=prod → deploys thaen's prod
- [ ] `workflow_dispatch` with runner=ryan, instance=prod → deploys ryan's prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)