### PR TITLE
Add container validation procedure and fix deploy scripts

### DIFF
--- a/deploy/teardown.sh
+++ b/deploy/teardown.sh
@@ -55,7 +55,7 @@ echo "    Service stopped and Quadlet removed."
 
 if [ "$PURGE" = "--purge" ]; then
     # Remove data volume
-    podman volume rm "systemd-${SERVICE_NAME}-data" 2>/dev/null || true
+    podman volume rm "${SERVICE_NAME}-data" 2>/dev/null || true
     echo "    Data volume removed."
 
     # Remove env file


### PR DESCRIPTION
## Summary
- Add `--init` flag to `deploy/setup.sh` that runs `mtg setup --demo` on the data volume before the service starts, eliminating the crash-loop problem where the container needs data files to start but you can't exec into a crash-looping container
- Fix `deploy/teardown.sh --purge` volume name bug: was prefixed with `systemd-` but Podman 4.x Quadlet uses volume names as-is
- Add AllPricesToday.json fetch to `mtg setup` (step 3b) — the server requires it at startup but setup previously only fetched AllPrintings.json
- Add "Container Validation" section to CLAUDE.md documenting the standard procedure for validating features in isolated containers

## Test plan
- [ ] `bash deploy/setup.sh test-val --init` builds image and initializes data volume with demo dataset
- [ ] `systemctl --user start mtgc-test-val` starts successfully without crash-looping
- [ ] `bash deploy/teardown.sh test-val --purge` removes container, image, volume, and env file (verify with `podman volume ls`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)