### PR TITLE
Add mobile responsive breakpoints to ingestor pages

### DIFF
--- a/mtg_collector/static/import_csv.html
+++ b/mtg_collector/static/import_csv.html
@@ -217,6 +217,25 @@ header h1 { font-size: 1.2rem; color: #e0e0e0; }
   margin-right: 6px;
 }
 @keyframes spin { to { transform: rotate(360deg); } }
+@media (max-width: 768px) {
+  .container { flex-direction: column; }
+  .input-panel {
+    width: 100%;
+    min-width: 0;
+    border-right: none;
+    border-bottom: 1px solid #0f3460;
+    padding: 16px;
+  }
+  .input-panel textarea {
+    flex: none;
+    min-height: 80px;
+    max-height: 120px;
+  }
+  .result-panel { padding: 16px; }
+  .item-table { font-size: 0.75rem; }
+  .item-table th, .item-table td { padding: 4px 6px; }
+  .item-table .card-thumb { width: 24px; height: 33px; }
+}
 </style>
 </head>
 <body>

--- a/mtg_collector/static/ingest_corners.html
+++ b/mtg_collector/static/ingest_corners.html
@@ -217,6 +217,11 @@ button.danger:hover { background: #b71c1c; }
 @media (max-width: 768px) {
   .results-table { font-size: 0.75rem; }
   .results-table th, .results-table td { padding: 6px 8px; }
+  .results-table .thumb { width: 30px; height: 42px; }
+  .results-table select { font-size: 0.75rem; padding: 3px 4px; }
+  #camera-placeholder { padding: 24px 16px; }
+  #drop-zone { margin: 8px; padding: 12px; }
+  .actions { flex-wrap: wrap; }
 }
 </style>
 </head>

--- a/mtg_collector/static/ingest_ids.html
+++ b/mtg_collector/static/ingest_ids.html
@@ -320,6 +320,26 @@ header h1 { font-size: 1.2rem; color: #e0e0e0; }
   margin-right: 6px;
 }
 @keyframes spin { to { transform: rotate(360deg); } }
+@media (max-width: 768px) {
+  .container { flex-direction: column; }
+  .input-panel {
+    width: 100%;
+    min-width: 0;
+    border-right: none;
+    border-bottom: 1px solid #0f3460;
+    padding: 16px;
+  }
+  .entry-list {
+    flex: none;
+    max-height: 150px;
+  }
+  .result-panel { padding: 16px; }
+  .resolved-table { font-size: 0.75rem; }
+  .resolved-table th, .resolved-table td { padding: 4px 6px; }
+  .resolved-table .card-thumb { width: 24px; height: 33px; }
+  .failed-table { font-size: 0.75rem; }
+  .failed-table th, .failed-table td { padding: 4px 6px; }
+}
 </style>
 </head>
 <body>

--- a/mtg_collector/static/ingest_order.html
+++ b/mtg_collector/static/ingest_order.html
@@ -234,6 +234,25 @@ header h1 { font-size: 1.2rem; color: #e0e0e0; }
   margin-right: 6px;
 }
 @keyframes spin { to { transform: rotate(360deg); } }
+@media (max-width: 768px) {
+  .container { flex-direction: column; }
+  .input-panel {
+    width: 100%;
+    min-width: 0;
+    border-right: none;
+    border-bottom: 1px solid #0f3460;
+    padding: 16px;
+  }
+  .input-panel textarea {
+    flex: none;
+    min-height: 80px;
+    max-height: 120px;
+  }
+  .result-panel { padding: 16px; }
+  .item-table { font-size: 0.75rem; }
+  .item-table th, .item-table td { padding: 4px 6px; }
+  .item-table .card-thumb { width: 24px; height: 33px; }
+}
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Add `@media (max-width: 768px)` breakpoints to order, manual ID, and CSV import ingestors — sidebar layouts now stack vertically on mobile with constrained textareas and compact tables
- Enhance existing corners ingestor mobile breakpoint with tighter thumbnails, controls, and drop zone sizing

## Test plan
- [ ] Open each ingestor page on a mobile device or narrow browser window (<768px):
  - `/ingestor-order` — textarea should be compact, results visible below
  - `/ingest-ids` — quick-add form on top, entry list capped, results below
  - `/import-csv` — textarea compact, resolved/failed tables readable
  - `/ingest-corners` — thumbnails and condition dropdowns fit in table cells
- [ ] Verify desktop layout is unchanged at wider viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)