### PR TITLE
Reduce collection page main content padding to 4px

### DIFF
--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -237,7 +237,7 @@ button.secondary.active { background: #0f3460; border-color: #e94560; }
 /* Main content */
 .main {
   flex: 1;
-  padding: 24px;
+  padding: 4px;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
## Summary

- Reduces `.main` CSS padding in the Collection page from `24px` to `4px`

## Changes

- `mtg_collector/static/collection.html`: `.main { padding: 24px; }` → `.main { padding: 4px; }`

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)