### PR TITLE
Style Table/Grid view toggle as a segmented control

### DIFF
--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -69,6 +69,25 @@ button.secondary {
 button.secondary:hover { background: #e94560; border-color: #e94560; }
 button.secondary.active { background: #0f3460; border-color: #e94560; }
 
+/* View toggle group — segmented control */
+.view-toggle-group {
+  display: flex;
+}
+.view-toggle-group button.secondary {
+  border-radius: 0;
+}
+.view-toggle-group button.secondary:first-child {
+  border-radius: 6px 0 0 6px;
+}
+.view-toggle-group button.secondary:last-child {
+  border-radius: 0 6px 6px 0;
+  margin-left: -1px; /* collapse double-border between the two buttons */
+}
+.view-toggle-group button.secondary.active {
+  z-index: 1; /* active button's border-color (#e94560) shows over the adjacent border */
+  position: relative;
+}
+
 #search-input { width: 220px; }
 
 #status {
@@ -973,8 +992,10 @@ tr.ordered td:first-child { border-left: 3px solid #f0a030; }
   <h1><a href="/" style="color:inherit;text-decoration:none">Collection</a></h1>
   <div class="controls">
     <input type="text" id="search-input" placeholder="Search cards...">
-    <button class="secondary" id="view-table-btn" title="Table view">Table</button>
-    <button class="secondary" id="view-grid-btn" title="Grid view">Grid</button>
+    <div class="view-toggle-group">
+      <button class="secondary" id="view-table-btn" title="Table view">Table</button>
+      <button class="secondary" id="view-grid-btn" title="Grid view">Grid</button>
+    </div>
     <button class="secondary" id="sidebar-toggle-btn" title="Toggle filters">Filters</button>
     <div class="col-config-wrap">
       <button class="secondary" id="col-config-btn" title="Configure columns">Columns</button>


### PR DESCRIPTION
## Summary

- Wraps the Table/Grid view buttons in a `.view-toggle-group` flex container, making them flush against each other (joined borders) as a standard segmented control
- Adds CSS for the segmented control pattern: inner border collapsed to 1px via `margin-left: -1px`, and active button gets `z-index: 1` so its accent border (`#e94560`) is never obscured by the adjacent button's neutral border
- No JavaScript changes — `updateViewButtons()` already handles mutual exclusivity correctly

## Screenshot

The Table/Grid buttons now appear as a joined segmented control in the collection header:

- **Table** (active): left-rounded corners, red accent border (`#e94560`) visible on all sides including the shared edge
- **Grid**: right-rounded corners, flush against Table button with no gap

The 10px gap that previously separated them (making them look like independent buttons) is gone.

## Test plan

- [x] Visual: Table and Grid buttons appear as a joined segmented control
- [x] Active state: the active button shows the red accent border correctly, including over the shared edge with the adjacent button
- [x] No regression: existing test suite passes (25 tests)
- [x] Linting: no new ruff issues in changed files

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)