### PR TITLE
Convert Columns button from dropdown to slide-in drawer

### DIFF
--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -128,6 +128,25 @@ button.secondary.active { background: #0f3460; border-color: #e94560; }
 
 .sidebar.open { left: 0; }
 
+/* Columns drawer — slides in from the right */
+.col-drawer-backdrop {
+  display: none;
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(0,0,0,0.4);
+  z-index: 90;
+}
+.col-drawer-backdrop.active { display: block; }
+
+.col-drawer {
+  left: auto;
+  right: -320px;
+  border-right: none;
+  border-left: 2px solid #0f3460;
+  transition: right 0.25s ease;
+}
+.col-drawer.open { right: 0; left: auto; }
+
 .sidebar h3 {
   font-size: 0.85rem;
   color: #888;
@@ -674,17 +693,6 @@ a.lineage-link {
   box-shadow: 0 4px 12px rgba(0,0,0,0.4);
 }
 .col-config-dropdown.open { display: block; }
-.col-config-dropdown label {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 5px 14px;
-  font-size: 0.82rem;
-  cursor: pointer;
-  white-space: nowrap;
-}
-.col-config-dropdown label:hover { background: #0f3460; }
-.col-config-dropdown input[type="checkbox"] { accent-color: #e94560; }
 
 /* Sort arrow */
 .sort-arrow { font-size: 0.7rem; margin-left: 2px; }
@@ -1134,10 +1142,7 @@ tr.ordered td:first-child { border-left: 3px solid #f0a030; }
       <button class="secondary" id="view-grid-btn" title="Grid view">Grid</button>
     </div>
     <button class="secondary" id="sidebar-toggle-btn" title="Toggle filters">Filters</button>
-    <div class="col-config-wrap">
-      <button class="secondary" id="col-config-btn" title="Configure columns">Columns</button>
-      <div class="col-config-dropdown" id="col-config-dropdown"></div>
-    </div>
+    <button class="secondary" id="col-config-btn" title="Configure columns">Columns</button>
     <div class="col-config-wrap">
       <button class="secondary" id="more-menu-btn">More</button>
       <div class="col-config-dropdown" id="more-menu-dropdown">
@@ -1170,6 +1175,12 @@ tr.ordered td:first-child { border-left: 3px solid #f0a030; }
 </div>
 
 <div class="sidebar-backdrop" id="sidebar-backdrop"></div>
+<div class="col-drawer-backdrop" id="col-drawer-backdrop"></div>
+
+<aside class="sidebar col-drawer" id="col-drawer">
+  <h3>Columns</h3>
+  <div class="pill-group" id="col-config-dropdown"></div>
+</aside>
 <div class="layout">
   <aside class="sidebar" id="sidebar">
     <h3>Color</h3>
@@ -1328,6 +1339,8 @@ const modalClose = document.getElementById('modal-close');
 const clearFiltersBtn = document.getElementById('clear-filters-btn');
 const colConfigBtn = document.getElementById('col-config-btn');
 const colConfigDropdown = document.getElementById('col-config-dropdown');
+const colDrawer = document.getElementById('col-drawer');
+const colDrawerBackdrop = document.getElementById('col-drawer-backdrop');
 const moreMenuBtn = document.getElementById('more-menu-btn');
 const moreMenuDropdown = document.getElementById('more-menu-dropdown');
 const selectionBar = document.getElementById('selection-bar');
@@ -1446,12 +1459,12 @@ const COL_SORT_MAP = Object.fromEntries(ALL_COLUMNS.map(c => [c.key, c.sort]));
 function renderColConfig() {
   colConfigDropdown.innerHTML = '';
   for (const col of ALL_COLUMNS) {
-    const label = document.createElement('label');
-    const cb = document.createElement('input');
-    cb.type = 'checkbox';
-    cb.checked = enabledCols.includes(col.key);
-    cb.addEventListener('change', () => {
-      if (cb.checked) {
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    input.id = 'cc-' + col.key;
+    input.checked = enabledCols.includes(col.key);
+    input.addEventListener('change', () => {
+      if (input.checked) {
         if (!enabledCols.includes(col.key)) enabledCols.push(col.key);
       } else {
         enabledCols = enabledCols.filter(k => k !== col.key);
@@ -1459,27 +1472,31 @@ function renderColConfig() {
       saveColumns();
       render();
     });
-    label.appendChild(cb);
-    label.appendChild(document.createTextNode(col.label));
+    const label = document.createElement('label');
+    label.htmlFor = 'cc-' + col.key;
+    label.textContent = col.label;
+    colConfigDropdown.appendChild(input);
     colConfigDropdown.appendChild(label);
   }
 }
 renderColConfig();
 
-colConfigBtn.addEventListener('click', (e) => {
-  e.stopPropagation();
-  colConfigDropdown.classList.toggle('open');
-  moreMenuDropdown.classList.remove('open');
-});
+function toggleColDrawer(open) {
+  if (open === undefined) open = !colDrawer.classList.contains('open');
+  colDrawer.classList.toggle('open', open);
+  colDrawerBackdrop.classList.toggle('active', open);
+  colConfigBtn.classList.toggle('active', open);
+}
+
+colConfigBtn.addEventListener('click', () => toggleColDrawer());
+colDrawerBackdrop.addEventListener('click', () => toggleColDrawer(false));
+
 moreMenuBtn.addEventListener('click', (e) => {
   e.stopPropagation();
   moreMenuDropdown.classList.toggle('open');
-  colConfigDropdown.classList.remove('open');
+  toggleColDrawer(false);
 });
 document.addEventListener('click', (e) => {
-  if (!colConfigDropdown.contains(e.target) && e.target !== colConfigBtn) {
-    colConfigDropdown.classList.remove('open');
-  }
   if (!moreMenuDropdown.contains(e.target) && e.target !== moreMenuBtn) {
     moreMenuDropdown.classList.remove('open');
   }
@@ -2217,7 +2234,8 @@ function updateViewButtons() {
   viewTableBtn.classList.toggle('active', currentView === 'table');
   viewGridBtn.classList.toggle('active', currentView === 'grid');
   gridSizeWrap.style.display = currentView === 'grid' ? '' : 'none';
-  document.querySelector('.col-config-wrap').style.display = currentView === 'table' ? '' : 'none';
+  colConfigBtn.style.display = currentView === 'table' ? '' : 'none';
+  if (currentView !== 'table') toggleColDrawer(false);
 }
 updateViewButtons();
 


### PR DESCRIPTION
## Summary

- Replaces the absolute-positioned Columns dropdown (which overflows off-screen on mobile) with a right-side slide-in drawer matching the existing Filters sidebar pattern
- Column toggles use the existing `.pill-group` pill-style checkboxes (hidden input + `for`-linked label)
- Backdrop overlay closes the drawer on tap/click; switching to grid view auto-closes the drawer

## Changes

- **HTML**: Remove `.col-config-wrap` wrapper around the Columns button; add `#col-drawer` aside and `#col-drawer-backdrop` after the existing sidebar backdrop; keep `id="col-config-dropdown"` on the inner div so existing JS requires no renames
- **CSS**: Add `.col-drawer`/`.col-drawer-backdrop` positioning rules (slides from right); remove the label/checkbox styles that were specific to the old dropdown; note `.col-config-wrap` and the base `.col-config-dropdown` display rules are kept since the More menu still uses them
- **JS**: Add `toggleColDrawer()` function; update `renderColConfig()` to emit pill items; fix `updateViewButtons()` to use `colConfigBtn` directly and close the drawer on grid view

## Test plan

- [x] All 94 tests pass (`uv run pytest --ignore=tests/test_ocr_identification.py`)
- [x] Ruff lint clean for modified file (pre-existing lint warnings in `crack_pack_server.py` are unrelated)
- [x] Screenshot verified: drawer slides in from right on mobile viewport with pill-style toggles

## Deviations from plan

The plan's Change 3 said to remove all `.col-config-dropdown` CSS, but the More menu dropdown (`#more-menu-dropdown`) also uses the `col-config-dropdown` class for its `display:none`/`.open` show-hide behavior. Only the label/checkbox-specific styles were removed to avoid breaking the More menu.

Also added `left: auto` to `.col-drawer.open` to prevent `.sidebar.open { left: 0; }` from pulling the drawer to the left side (since `.col-drawer` inherits the `.sidebar` class).

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)