### PR TITLE
Fix setup to import prices into SQLite

### DIFF
--- a/mtg_collector/cli/setup_cmd.py
+++ b/mtg_collector/cli/setup_cmd.py
@@ -70,8 +70,9 @@ def run(args):
         print("\n=== Step 3b: MTGJSON prices (skipped) ===")
     else:
         print("\n=== Step 3b: MTGJSON prices ===")
-        from mtg_collector.cli.data_cmd import _fetch_prices
+        from mtg_collector.cli.data_cmd import _fetch_prices, import_prices
         _fetch_prices(force=False)
+        import_prices(db_path)
 
     # Step 4: Load demo data
     if args.demo:


### PR DESCRIPTION
## Summary
- Step 3b of `mtg setup` fetched `AllPricesToday.json` but never called `import_prices()`, leaving the `prices` table empty and all price columns blank in the collection UI
- Adds the missing `import_prices(db_path)` call after `_fetch_prices()`

## Test plan
- [ ] Run `mtg setup` on a fresh instance and verify `prices` table is populated
- [ ] Confirm collection view shows non-zero prices

🤖 Generated with [Claude Code](https://claude.com/claude-code)