### PR TITLE
Fix v17 migration: drop collection_view before table rebuild

### DIFF
--- a/tests/test_price_import.py
+++ b/tests/test_price_import.py
@@ -422,6 +422,12 @@ class TestMigrationV14ToV15:
                 raw_json TEXT,
                 UNIQUE(set_code, collector_number)
             );
+            CREATE TABLE IF NOT EXISTS orders (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                order_number TEXT,
+                seller_name TEXT,
+                created_at TEXT NOT NULL
+            );
             CREATE TABLE IF NOT EXISTS collection (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 scryfall_id TEXT NOT NULL REFERENCES printings(scryfall_id),
@@ -441,8 +447,20 @@ class TestMigrationV14ToV15:
                 misprint INTEGER DEFAULT 0,
                 status TEXT NOT NULL DEFAULT 'owned',
                 sale_price REAL,
-                order_id INTEGER
+                order_id INTEGER REFERENCES orders(id)
             );
+            CREATE VIEW IF NOT EXISTS collection_view AS
+            SELECT c.id, card.name, s.set_name, p.set_code,
+                   p.collector_number, p.rarity, p.promo,
+                   c.finish, c.condition, c.language,
+                   c.purchase_price, c.acquired_at, c.source,
+                   c.source_image, c.notes, c.tags, c.tradelist,
+                   c.status, c.sale_price, c.scryfall_id, p.oracle_id,
+                   c.order_id
+            FROM collection c
+            JOIN printings p ON c.scryfall_id = p.scryfall_id
+            JOIN cards card ON p.oracle_id = card.oracle_id
+            JOIN sets s ON p.set_code = s.set_code;
             CREATE TABLE IF NOT EXISTS ingest_cache (
                 image_md5 TEXT PRIMARY KEY,
                 image_path TEXT NOT NULL,


### PR DESCRIPTION
## Summary

- The v16→v17 migration rebuilds the `collection` table to expand the status CHECK constraint (adding `traded`, `gifted`, `lost`). It drops and renames the table, but `collection_view` still references it. SQLite 3.25+ validates schema on `ALTER TABLE RENAME`, causing `error in view collection_view: no such table: main.collection`.
- Fix: drop `collection_view` *before* the table rebuild, not after. Add recovery logic for databases left in a partially-migrated state (`collection_new` exists but `collection` was already dropped by a previous failed run).
- Update migration test fixtures in `test_mtgjson_import.py` and `test_price_import.py` to include tables needed by the v16→v17 migration (`orders`, `printings`, `collection`, `collection_view`).

## Test plan

- [x] `uv run mtg setup --skip-cache --skip-data` succeeds on a dirty DB (partially-migrated from prior failure)
- [x] DB state verified: `collection` exists, `collection_new` gone, `collection_view` present, schema v17
- [x] All 105 tests pass, 11 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)