### PR TITLE
Restructure CLAUDE.md with file index and auto-update hook

### DIFF
--- a/.claude/hooks/pre-commit-hook.sh
+++ b/.claude/hooks/pre-commit-hook.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Runs scripts/update-file-index.py before git commit commands.
+# Configured as a Claude Code PreToolUse hook in .claude/settings.json.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if [[ "$COMMAND" == *"git commit"* ]]; then
+  python3 "$CLAUDE_PROJECT_DIR/scripts/update-file-index.py"
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/pre-commit-hook.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,6 @@ moxfield_collection.csv
 *.swp
 
 # Claude
-.claude/
+.claude/*
+!.claude/settings.json
+!.claude/hooks/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,50 +1,29 @@
-# CLAUDE.md
-
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
 ## Project Overview
 
-MTG Card Collection Builder - A Python CLI + web UI tool for managing Magic: The Gathering collections. Cards can be identified via Claude Vision (corner photos), local OCR (full card photos), manual ID entry, or order ingestion (TCGPlayer/Card Kingdom). Card data is sourced from Scryfall and stored in SQLite. Includes a web UI for collection browsing, virtual booster pack generation, image-based card ingestion, and order import. Supports import/export to Moxfield, Archidekt, and Deckbox formats.
+MTG Card Collection Builder — Python CLI + web UI for managing Magic: The Gathering collections. Cards enter via Claude Vision (corner photos), OCR (full card photos), manual ID entry, or order ingestion (TCGPlayer/Card Kingdom). Card data is sourced from Scryfall, stored in SQLite. Web UI for collection browsing, virtual booster pack generation, image-based card ingestion, and order import. Import/export to Moxfield, Archidekt, Deckbox.
 
-## Environment
-- **Always use `uv`** for all Python operations (not pip/venv/make). Examples:
-  - `uv sync` to install deps
-  - `uv run pytest ...` to run tests
-  - `uv run ruff check mtg_collector/` to lint
-  - `uv run mtg ...` to run CLI
+## Development notes
+
+- **Always use `uv`** for all Python operations (not pip/venv/make): `uv sync`, `uv run pytest`, `uv run ruff check mtg_collector/`, `uv run mtg ...`
+- Code, models, deploy scripts, all go in the repo.
+- STORE DATA IN THE LOCAL DB. DO NOT add website queries that require the internet at runtime.
 - `ruff` is a dev dependency — always available via `uv run ruff`
-
-## Error Handling Philosophy
 - **NEVER add fallback logic.** Errors should propagate to the user.
 - No fallback content, no silent defaults, no swallowed exceptions.
 - As few error paths as possible. Let it crash visibly.
+- Tests use pre-populated `tests/fixtures/scryfall-cache.sqlite` for offline testing. Corner identification tests require `ANTHROPIC_API_KEY`.
+- Aggressively limit modality. Defaults are good enough for everyone.
 
 ## Commands
 
 ```bash
-# Setup
-uv sync
+uv sync                                                # Install deps
+uv run pytest                                          # All tests
+uv run ruff check mtg_collector/                       # Lint
 
-# Run tests (corner identification tests require ANTHROPIC_API_KEY)
-uv run pytest                                # All tests
-uv run pytest tests/test_ingest_ids.py -v    # Single test file
-uv run pytest tests/test_ingest_ids.py::TestResolveAndAddIds::test_single_card_happy_path -v  # Single test
-
-# Linting
-uv run ruff check mtg_collector/
-
-# CLI usage
-mtg setup                                              # Initialize DB + cache Scryfall + fetch MTGJSON
+mtg setup                                              # Init DB + cache Scryfall + fetch MTGJSON
 mtg setup --demo                                       # Full setup + load demo data (~50 cards)
-mtg setup --skip-cache --skip-data                     # DB init only (no network)
-mtg db init                                            # Initialize database
-mtg ingest-ids --id R 0200 EOE --id C 0075 EOE foil   # Add cards by rarity/CN/set
-mtg ingest-corners photo.jpg                           # Read card corners via Claude Vision
-mtg ingest-order order.html                            # Import TCGPlayer/CK orders
-mtg orders list                                        # List imported orders
-mtg cache all                                          # Bulk-cache all Scryfall data
-mtg list                                               # List collection
-mtg export -f moxfield -o out.csv
+mtg setup --skip-cache --skip-data                     # Fast start if data is already loaded. 
 mtg crack-pack-server                                  # Start web UI on port 8080
 
 # Deployment — rootless Podman, per-instance isolation
@@ -56,105 +35,178 @@ systemctl --user start mtgc-my-feature   # Start instance
 systemctl --user status mtgc-my-feature  # Check status
 ```
 
-## Architecture
+## File Index
 
-See `architecture/CARD_DATA_ACCESS.md` for the card data access policy -- all runtime
-card lookups MUST use the local database, never the Scryfall API.
+Files not listed here are smaller.
+
+### `mtg_collector/cli/` — CLI subcommands
+
+Each module has `register(subparsers)` and `run(args)`.
+
+| File | Lines | Purpose |
+|------|------:|---------|
+| `crack_pack_server.py` | 4088 | **Web server**: all HTTP routes, API handlers, SSE endpoints |
+| `data_cmd.py` | 518 | MTGJSON + price data import/export commands |
+| `ingest_ocr.py` | 411 | CLI image-based card ingestion via EasyOCR + Claude |
+| `ingest_corners.py` | 340 | CLI corner-photo card ingestion via Claude Vision |
+| `ingest_ids.py` | 286 | Manual card entry by rarity/collector-number/set |
+| `demo_data.py` | 254 | Load demo collection for testing |
+
+### `mtg_collector/db/` — SQLite layer
+
+| File | Lines | Purpose |
+|------|------:|---------|
+| `models.py` | 1251 | Dataclasses + repository classes (CRUD for every table) |
+| `schema.py` | 1076 | Schema DDL, all migrations, `init_db()` |
+
+Repository classes in `models.py`: `CardRepository`, `SetRepository`, `PrintingRepository`, `CollectionRepository`, `OrderRepository`, `WishlistRepository`.
+
+### `mtg_collector/services/` — External integrations
+
+| File | Lines | Purpose |
+|------|------:|---------|
+| `agent.py` | 528 | Agentic OCR: Claude tool-use loop with `query_local_db` and `analyze_image` tools |
+| `claude.py` | 504 | Claude Vision API: corner reading, card identification |
+| `scryfall.py` | 450 | `ScryfallAPI` class, caching, `cache_scryfall_data()`, `ensure_set_cached()` |
+| `order_parser.py` | 414 | Parse TCGPlayer HTML/text and Card Kingdom text into `ParsedOrder` |
+| `order_resolver.py` | 353 | Resolve parsed orders to Scryfall cards, treatment-aware matching |
+| `pack_generator.py` | 329 | MTGJSON-based booster pack simulation from SQLite |
+
+### `mtg_collector/static/` — Web UI (single-file HTML pages)
+
+| File | Lines | Purpose |
+|------|------:|---------|
+| `collection.html` | 3187 | **Collection browser**: filters, sorting, card grid, inline editing. Canonical card display. |
+| `correct.html` | 1048 | Fix misidentified cards in ingest pipeline |
+| `crack_pack.html` | 1007 | Booster pack simulator with rarity borders and badge system |
+| `explore_sheets.html` | 824 | Browse MTGJSON booster sheet layouts |
+| `ingest_ids.html` | 680 | Manual card entry web UI |
+| `disambiguate.html` | 634 | Resolve ambiguous Scryfall matches |
+| `ingest_corners.html` | 561 | Corner photo ingest web UI |
+| `recent.html` | 507 | Recently ingested images gallery |
+| `ingest_order.html` | 494 | Order ingestion web UI |
+| `import_csv.html` | 492 | CSV import web UI |
+| `process.html` | 406 | OCR processing + Claude identification |
+| `upload.html` | 395 | Photo upload for image ingest |
+| `index.html` | 308 | Homepage / navigation |
+
+### `mtg_collector/importers/` and `exporters/`
+
+| File | Lines | Purpose |
+|------|------:|---------|
+
+### Other key files
+
+| File | Lines | Purpose |
+|------|------:|---------|
+| `mtg_collector.py` | 470 | Legacy entrypoint (predates package structure) |
+
+### Tests
+
+| File | Lines | What it covers |
+|------|------:|---------|
+| `test_import.py` | 620 | CSV import (Moxfield, Archidekt, Deckbox, decklist) |
+| `test_price_import.py` | 526 | MTGJSON price import pipeline |
+| `test_mtgjson_import.py` | 516 | MTGJSON AllPrintings import |
+| `test_ingest_ids.py` | 423 | Manual card entry + `resolve_and_add_ids()` |
+| `test_order_parser.py` | 368 | Order parsing (TCGPlayer HTML/text, Card Kingdom) |
+| `test_order_resolver.py` | 302 | Order resolution to Scryfall cards |
+
+## Data Model
+
+### Core join chain
 
 ```
-mtg_collector/
-├── cli/           # Subcommands, each with register(subparsers) and run(args)
-│                  #   setup_cmd, ingest_ids, ingest_corners, ingest_ocr, ingest_order,
-│                  #   ingest_retry, orders, import_cmd, export, list_cmd, show, edit,
-│                  #   delete, stats, db_cmd, cache_cmd, data_cmd, demo_data,
-│                  #   crack_pack, crack_pack_server, wishlist
-├── db/            # SQLite layer (connection.py, schema.py, models.py with repositories)
-├── services/      # claude.py (Vision API), scryfall.py (card data + caching),
-│                  #   ocr.py (EasyOCR), pack_generator.py (MTGJSON booster sim),
-│                  #   order_parser.py, order_resolver.py
-├── static/        # Web UI: collection.html, crack_pack.html, explore_sheets.html,
-│                  #   ingest_order.html, upload.html, recent.html, process.html,
-│                  #   disambiguate.html, correct.html, index.html
-├── importers/     # CSV parsers for moxfield, archidekt, deckbox
-└── exporters/     # CSV writers for moxfield, archidekt, deckbox
+cards (oracle_id PK)          — Abstract card identity (name, colors, mana cost)
+  └─ printings (scryfall_id PK, FK oracle_id, FK set_code)  — Specific printing (art, rarity, image)
+       └─ collection (id PK, FK scryfall_id, FK? order_id)  — One row per physical card owned
+            └─ orders (id PK)  — Purchase order (TCGPlayer/CK seller, totals, shipping)
+
+sets (set_code PK)            — Set metadata, cards_fetched_at for cache status
 ```
 
-## Database Schema
+This is the fundamental chain: **card** → **printing** → **collection entry** (→ optional **order**).
 
-Schema version tracked in `schema_version` table with auto-migrations (current: v15).
+- `collection_view` (VIEW) denormalizes this entire chain into one queryable view.
+- `latest_prices` (VIEW) gives most recent price per card/source/type.
 
-Core tables with foreign key relationships:
-- `cards` (oracle_id PK) → Oracle-level card identity
-- `sets` (set_code PK) → Set info + `cards_fetched_at` for cache status
-- `printings` (scryfall_id PK) → Specific printings, FK to cards and sets
-- `orders` (id PK) → Purchase orders from TCGPlayer/Card Kingdom with seller, totals, shipping status
-- `collection` (id PK) → Owned cards, FK to printings and optionally orders (one row per physical card). Status lifecycle: owned/ordered/listed/sold/removed
-- `wishlist` (id PK) → Cards user wants, FK to cards (oracle-level) or printings (specific)
-- `mtgjson_uuid_map` (uuid PK) → Maps MTGJSON UUIDs to (set_code, collector_number) for price lookups
-- `prices` → Append-only price time series (set_code, collector_number, source, price_type, price, observed_at)
-- `price_fetch_log` → Audit trail of price imports with stats
-- `latest_prices` (VIEW) → Most recent prices per card/source/type (global max observed_at)
-- `status_log` → Append-only audit trail of collection status changes
-- `ingest_cache` (image_md5 PK) → Cached OCR + Claude results to avoid reprocessing
-- `ingest_lineage` → Tracks which collection entry came from which image
-- `settings` (key PK) → Global key-value config (e.g. price_sources, image_display)
+### Key lookups
 
-Default location: `~/.mtgc/collection.sqlite` (override with `--db` or `MTGC_DB` env)
+- Card by name: `cards.name` (indexed)
+- Printing by set+CN: `printings(set_code, collector_number)` (unique)
+- Collection by Scryfall ID: `collection.scryfall_id` (indexed)
+- Prices join to printings via `(set_code, collector_number)` — **not** by scryfall_id
 
-## Data Flow: Card Ingestion
+### Price data pipeline
 
-Four ingestion methods:
+MTGJSON UUIDs → `mtgjson_uuid_map(uuid → set_code, collector_number)` → `prices` table (append-only time series). `latest_prices` view uses global max `observed_at`. Sources: TCGplayer, CardKingdom.
 
-1. **ingest-ids**: User provides rarity code, collector number, set code, and optional foil flag directly
-2. **ingest-corners**: Claude Vision reads card corner text (rarity/CN/set/foil) from photos
-3. **ingest-ocr** (CLI) / **ingest2** (web UI): EasyOCR extracts text, Claude identifies card names, Scryfall resolves. Web UI adds multi-step workflow: upload → process → disambiguate → correct → confirm
-4. **ingest-order**: Parses TCGPlayer HTML/text or Card Kingdom text orders, resolves items to Scryfall cards with treatment-aware matching (borderless, extended art, showcase), creates collection entries linked to order records
+### Other tables
 
-Methods 1 and 2 feed into `resolve_and_add_ids()` which:
-1. Looks up printing in local cache, falls back to Scryfall API by set+collector number
-2. Caches Scryfall data (card, set, printing) in SQLite
-3. Creates collection entry with finish, condition, source metadata
+- `wishlist` — FK to `cards` (oracle-level) or `printings` (specific). Priority, max price, fulfilled status.
+- `ingest_cache` — Cached OCR + Claude results by image MD5 (avoids reprocessing).
+- `ingest_images` — Persistent web UI ingest pipeline state (READY_FOR_OCR → PROCESSING → DONE/ERROR).
+- `ingest_lineage` — Maps collection entries back to source images.
+- `status_log` — Append-only audit of collection status changes.
+- `settings` — Key-value config (e.g. `price_sources`, `image_display`).
+- Schema v17 with auto-migrations in `schema.py`.
 
-Method 4 uses `order_parser.py` → `order_resolver.py` → `commit_orders()`:
-1. Auto-detects format (tcg_html, tcg_text, ck_text) and parses into `ParsedOrder` objects
-2. Maps vendor set names to Scryfall set codes (hardcoded map + DB lookup)
-3. Resolves each item to a Scryfall card, matching treatment to correct printing variant
-4. Creates order record + collection entries with `status='ordered'` and `order_id` FK
-5. Idempotent — duplicate order_number + seller_name combinations are skipped
+Default DB location: `~/.mtgc/collection.sqlite` (override: `--db` or `MTGC_DB` env).
 
-## Web UI (crack_pack_server.py)
+### Conventions
 
-Threaded HTTP server serving static HTML pages and JSON APIs. Start with `mtg crack-pack-server`.
+- Collection status lifecycle: `owned` → `ordered` → `listed` → `sold` → `removed`
+- RARITY_MAP codes: `C` common, `U` uncommon, `R` rare, `M` mythic, `P` promo, `L` land (treated as common), `T` token
+- `colors`, `finishes`, `promo_types` columns store JSON arrays as TEXT — use `json.loads()`, not SQL array ops
 
-Key pages: `/collection` (browse/filter/manage collection), `/crack` (booster pack simulator), `/sheets` (explore booster sheet layouts), `/ingestor-order` (order ingestion from TCGPlayer/Card Kingdom).
+## Key Patterns
 
-Ingest2 pages (image-based card ingestion pipeline): `/upload` (photo upload), `/recent` (recently ingested images), `/process` (OCR + Claude processing), `/disambiguate` (resolve ambiguous Scryfall matches), `/correct` (fix misidentified cards).
+### Card image display
 
-Collection page filtering architecture: only search queries and include-unowned toggle trigger server fetches. All other filters (color, rarity, set, type, finish, status, CMC, date, price) and sorting are applied client-side for instant responsiveness.
+`collection.html` is the canonical reference for how cards are displayed. Card images come from Scryfall CDN via `printings.image_uri`. The `image_display` setting (`crop` or `normal`) controls which Scryfall image size is used.
 
-Key API patterns:
-- `/api/collection?[filters]` — aggregated collection with server-side search, include_unowned mode; response enriched with order data (seller, order number) via JOIN
-- `/api/cached-sets` — all sets with cached card lists (for set filter dropdown)
-- `/api/set-browse/{set_code}` — all printings in a set with owned/wanted annotations
-- `/api/fetch-prices` (POST) — batch price lookup from Scryfall
-- `/api/ingest2/*` — DB-backed OCR ingestion pipeline (upload, process via SSE, confirm/skip/correct/disambiguate)
-- `/api/order/*` — order parse/resolve/commit pipeline
-- `/api/orders` — list orders, show order cards, receive (batch flip ordered→owned)
+### Rarity/set border gradients
 
-## Key Implementation Details
+Cards use CSS custom properties `--rarity-color` and `--set-color` with `linear-gradient(to bottom, ...)`. Shared JS helpers in `crack_pack.html`: `getRarityColor(rarity)`, `getSetColor(cardSetCode, packSetCode)`. `buildCardBadges(card, packSetCode)` generates SF/CK price links, foil/treatment badges. Use these for any new card display.
 
-- Scryfall API rate limited to 100ms between requests (via `_rate_limit()`)
-- Claude API retries with exponential backoff (3s, 6s, 12s, 24s) but bails immediately on 400 errors
-- JSON arrays stored as TEXT in SQLite (colors, finishes, promo_types)
-- RARITY_MAP: C (common), U (uncommon), R (rare), M (mythic), P (promo), L (land, treated as common), T (token)
-- Tests use a pre-populated `tests/fixtures/scryfall-cache.sqlite` for offline testing
-- `mtg cache all` uses Scryfall bulk data endpoint (3 HTTP requests total) to cache all ~80k cards
-- Price data comes from MTGJSON AllPricesToday.json (TCGplayer + CardKingdom), imported into SQLite `prices` table as time series. `mtg data import-prices` for manual import, `mtg data fetch-prices` auto-imports after download
-- Order resolver uses `SET_NAME_MAP` for vendor→Scryfall set code mapping (e.g. "FINAL FANTASY" → "fin")
+### Collection page filtering
+
+Only search queries and include-unowned toggle trigger server fetches. All other filters (color, rarity, set, type, finish, status, CMC, date, price) and sorting are applied **client-side** for instant responsiveness.
+
+### Card data access policy
+
+All runtime card lookups MUST use the local database, never the Scryfall API. See `architecture/CARD_DATA_ACCESS.md`. Scryfall API is only used during `mtg setup` / `mtg cache` to populate the local DB.
+
+### Scryfall API rate limiting
+
+100ms between requests (via `ScryfallAPI._rate_limit()`). Bulk caching uses the Scryfall bulk data endpoint (3 HTTP requests total for ~80k cards).
+
+### Web server architecture
+
+`crack_pack_server.py` is a single-file threaded HTTP server (stdlib `http.server`). Routes are dispatched in `do_GET`/`do_POST`/`do_PUT`/`do_DELETE` via URL path matching. SSE for long-running operations (ingest processing). No framework — raw request handling.
+
+### Order ingestion
+
+`order_parser.py` auto-detects format (tcg_html, tcg_text, ck_text) → `ParsedOrder`. `order_resolver.py` maps vendor set names to Scryfall codes via `SET_NAME_MAP` + DB lookup, then resolves to specific printings with treatment-aware matching. Idempotent — duplicate order_number + seller_name skipped.
+
+### Agentic OCR (`services/agent.py`)
+
+Claude tool-use loop with two tools: `query_local_db` (SQL against local SQLite) and `analyze_image` (Claude Vision). Used by the web UI ingest pipeline for card identification from photos.
+
+### Claude API retry behavior
+
+Exponential backoff at 3s, 6s, 12s, 24s intervals. Bails immediately on 400 errors (no retry). See `services/claude.py`.
+
+### Card ingestion via `resolve_and_add_ids()`
+
+Both `ingest-ids` and `ingest-corners` funnel through `resolve_and_add_ids()` in `cli/ingest_ids.py`:
+1. Look up printing in local DB, fall back to Scryfall API by set + collector number
+2. Cache Scryfall response (card, set, printing) in SQLite
+3. Create collection entry with finish, condition, source metadata
 
 ## Deployment
 
-Rootless Podman Quadlet. Each instance is a separate repo clone with its own image (`mtgc:<instance>`), data volume, env file, and port. No sudo required. See `deploy/README.md` for full docs.
+Rootless Podman Quadlet. Each instance: separate repo clone, own image (`mtgc:<instance>`), data volume, env file, port. No sudo.
 
 Key files: `Containerfile` (multi-stage build), `deploy/setup.sh`, `deploy/deploy.sh`, `deploy/teardown.sh`, `deploy/mtgc.container` (Quadlet template with `{{INSTANCE}}`/`{{PORT}}` placeholders).
 

--- a/scripts/update-file-index.py
+++ b/scripts/update-file-index.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Update file index line counts in CLAUDE.md / CLAUDE_NEW.md.
+
+Scans project directories for source files >= 200 lines. Updates line counts,
+adds new files with blank summaries, removes files below threshold or deleted.
+Preserves hand-written purpose/summary strings.
+
+Usage:
+    python3 scripts/update-file-index.py          # manual run
+    # Also runs automatically via .git/hooks/pre-commit
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+MIN_LINES = 200
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+ROW_RE = re.compile(r"^\|\s*`([^`]+)`\s*\|\s*(\d+)\s*\|\s*(.*?)\s*\|$")
+SKIP = frozenset({"__init__.py", "__main__.py"})
+
+
+def find_target():
+    for name in ("CLAUDE.md", "CLAUDE_NEW.md"):
+        p = REPO_ROOT / name
+        if p.exists() and "## File Index" in p.read_text():
+            return p
+    sys.exit("No file with '## File Index' section found")
+
+
+def count_lines(path):
+    with open(path, errors="replace") as f:
+        return sum(1 for _ in f)
+
+
+def scan(base, pattern, exclude=frozenset()):
+    d = REPO_ROOT / base
+    if not d.is_dir():
+        return []
+    return sorted(
+        f for f in d.glob(pattern) if f.is_file() and f.name not in exclude
+    )
+
+
+def files_for_section(header):
+    """Return [(display_name, line_count)] or None if section not recognized."""
+    pairs = []
+
+    if "`mtg_collector/cli/`" in header:
+        pairs = [(f.name, f) for f in scan("mtg_collector/cli", "*.py", SKIP)]
+    elif "`mtg_collector/db/`" in header:
+        pairs = [(f.name, f) for f in scan("mtg_collector/db", "*.py", SKIP)]
+    elif "`mtg_collector/services/`" in header:
+        pairs = [(f.name, f) for f in scan("mtg_collector/services", "*.py", SKIP)]
+    elif "`mtg_collector/static/`" in header:
+        pairs = [(f.name, f) for f in scan("mtg_collector/static", "*.html")]
+    elif "importers" in header.lower() and "exporters" in header.lower():
+        pairs = [
+            (f"importers/{f.name}", f)
+            for f in scan("mtg_collector/importers", "*.py", SKIP)
+        ]
+        pairs += [
+            (f"exporters/{f.name}", f)
+            for f in scan("mtg_collector/exporters", "*.py", SKIP)
+        ]
+    elif "other key files" in header.lower():
+        pairs = [(f.name, f) for f in scan(".", "*.py", SKIP)]
+        pairs += [(f.name, f) for f in scan("mtg_collector", "*.py", SKIP)]
+        pairs += [(f.name, f) for f in scan("scripts", "*.py")]
+        for name in ("pyproject.toml", "Containerfile"):
+            f = REPO_ROOT / name
+            if f.is_file():
+                pairs.append((name, f))
+    elif "test" in header.lower():
+        pairs = [(f.name, f) for f in scan("tests", "test_*.py")]
+    else:
+        return None
+
+    results = []
+    for display, path in pairs:
+        n = count_lines(path)
+        if n >= MIN_LINES:
+            results.append((display, n))
+    results.sort(key=lambda x: -x[1])
+    return results
+
+
+def update(content):
+    lines = content.split("\n")
+
+    # Find ## File Index boundaries
+    idx_start = idx_end = None
+    for i, ln in enumerate(lines):
+        if ln.strip() == "## File Index":
+            idx_start = i
+        elif idx_start is not None and ln.startswith("## ") and i > idx_start:
+            idx_end = i
+            break
+    if idx_start is None:
+        return content
+    if idx_end is None:
+        idx_end = len(lines)
+
+    # Collect subsections: (header_line, table_data_start, table_data_end)
+    subs = []
+    i = idx_start + 1
+    while i < idx_end:
+        if lines[i].startswith("### "):
+            hdr = i
+            j = i + 1
+            tbl_start = tbl_end = None
+            while j < idx_end and not lines[j].startswith("### "):
+                stripped = lines[j].strip()
+                if (
+                    tbl_start is None
+                    and stripped.startswith("|")
+                    and j + 1 < idx_end
+                    and re.match(r"^\|[-\s:]+\|", lines[j + 1].strip())
+                ):
+                    tbl_start = j + 2  # data rows start after header + separator
+                    k = tbl_start
+                    while (
+                        k < idx_end
+                        and lines[k].strip().startswith("|")
+                        and not lines[k].startswith("### ")
+                    ):
+                        k += 1
+                    tbl_end = k
+                    break
+                j += 1
+            if tbl_start is not None:
+                subs.append((hdr, tbl_start, tbl_end))
+            i = tbl_end if tbl_end is not None else j + 1
+        else:
+            i += 1
+
+    # Process in reverse to keep line indices valid
+    for hdr, tbl_start, tbl_end in reversed(subs):
+        header = lines[hdr]
+        new_files = files_for_section(header)
+        if new_files is None:
+            continue
+
+        # Parse existing purposes
+        purposes = {}
+        for row in lines[tbl_start:tbl_end]:
+            m = ROW_RE.match(row.strip())
+            if m:
+                purposes[m.group(1)] = m.group(3).strip()
+
+        # Build new rows
+        new_rows = []
+        for display, n in new_files:
+            purpose = purposes.get(display, "")
+            new_rows.append(f"| `{display}` | {n} | {purpose} |")
+
+        lines[tbl_start:tbl_end] = new_rows
+
+    return "\n".join(lines)
+
+
+def main():
+    target = find_target()
+    original = target.read_text()
+    updated = update(original)
+
+    if original == updated:
+        return
+
+    target.write_text(updated)
+
+    # Stage the changed file for the current commit
+    subprocess.run(
+        ["git", "add", str(target)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Rewrites CLAUDE.md with agent-oriented structure: file index with line counts, data model join chain diagram, key patterns section
- Adds `scripts/update-file-index.py` to auto-update line counts (files >= 200 lines, preserves hand-written summaries)
- Adds Claude Code `PreToolUse` hook (`.claude/settings.json`) to run the script before every `git commit` — zero setup required

## References

Based on recent prompt engineering research for AI coding agents:
- [1] [AGENTS.md impact study](https://arxiv.org/abs/2601.20404) — 16.6% fewer output tokens, 28.6% faster runtime
- [2] [Evaluating AGENTS.md](https://arxiv.org/abs/2602.11988) — verbose context hurts; summaries kept to 7-10 words
- [3] [REprompt](https://arxiv.org/abs/2601.16507) — dependency-ordered content reduces first-attempt failures
- [4] [Enhancing LLM Instruction Following](https://arxiv.org/abs/2601.03359) — constraints and task descriptions are separate optimization problems
- [5] [Guidelines to Prompt LLMs for Code Generation](https://arxiv.org/abs/2601.13118v1)

## Test plan

- [ ] Verify `python3 scripts/update-file-index.py` runs cleanly and updates line counts
- [ ] Verify Claude Code hook fires before `git commit` (check `.claude/settings.json` loads)
- [ ] Confirm new CLAUDE.md is picked up by Claude Code sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)