### PR TITLE
Fix ordered banner breaking collection page layout

### DIFF
--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -2373,7 +2373,7 @@ function renderOrderedBanner() {
   banner.id = 'ordered-banner';
   banner.className = 'ordered-banner';
   banner.innerHTML = `<span>${orderedCount} card${orderedCount !== 1 ? 's' : ''} awaiting delivery</span><button id="view-ordered-btn">View Ordered</button>`;
-  main.parentElement.insertBefore(banner, main);
+  main.insertBefore(banner, main.firstChild);
   document.getElementById('view-ordered-btn').addEventListener('click', () => {
     document.getElementById('sf-ordered').checked = true;
     document.getElementById('sf-wanted').checked = false;


### PR DESCRIPTION
## Summary
- The ordered-banner div was inserted as a sibling of `#main` inside `div.layout` (a horizontal flex container), causing it to stretch to the full content height (~64,000px) and render as a huge orange box on the left side
- Fix: insert the banner inside `#main` as its first child instead

## Test plan
- [ ] Load collection page with ordered cards present — banner should appear inline above the card list
- [ ] Verify table and grid views both display correctly without the orange box
- [ ] Check mobile viewport — layout should no longer be broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)