### PR TITLE
Fix ordered banner destroyed by grid/table render

### DIFF
--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -2698,10 +2698,10 @@ function isOrderedOnlyFilter() {
 }
 
 function render() {
-  renderOrderedBanner();
   if (currentView === 'table') renderTable();
   else if (isOrderedOnlyFilter()) renderOrderGrouped();
   else renderGrid();
+  renderOrderedBanner();
 }
 
 function renderOrderedBanner() {


### PR DESCRIPTION
## Summary
- `renderOrderedBanner()` was called **before** `renderTable()`/`renderGrid()` in `render()`
- Those functions set `main.innerHTML = ''`, which immediately destroyed the banner that was just inserted
- Fix: call `renderOrderedBanner()` **after** the content render so the banner is prepended on top of the rendered content

## Root cause
```js
// Before (broken): banner created, then wiped
function render() {
  renderOrderedBanner();  // inserts banner into main
  renderGrid();           // sets main.innerHTML = '' — banner gone
}

// After (fixed): content rendered first, then banner prepended
function render() {
  renderGrid();           // sets main.innerHTML
  renderOrderedBanner();  // inserts banner as firstChild — survives
}
```

## Test plan
- [ ] Load collection page with ordered cards — amber banner should appear above the card list
- [ ] Click "View Ordered" — should switch to ordered-only grouped view (banner disappears)
- [ ] Switch back to default view — banner reappears
- [ ] Verify table view also shows the banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)