### PR TITLE
Prune dangling Podman images before deploy builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,5 +20,8 @@ jobs:
       - name: Pull latest code
         run: git -C /opt/mtgc-${{ env.INSTANCE }} pull --ff-only origin ${{ github.ref_name }}
 
+      - name: Prune dangling images
+        run: podman image prune -f
+
       - name: Build and restart
         run: bash /opt/mtgc-${{ env.INSTANCE }}/deploy/deploy.sh ${{ env.INSTANCE }}


### PR DESCRIPTION
## Summary
- Adds a `podman image prune -f` step to the deploy workflow before the build step
- Prevents "no space left on device" failures caused by accumulated dangling images from previous builds (~23 GB reclaimed today)

## Test plan
- [x] Manually pruned images on the self-hosted runner (84% → 66% disk usage)
- [x] Re-ran the failed deploy (attempt 3) — succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)