### PR TITLE
Add native auto-deploy and CI scripts

### DIFF
--- a/.github/unready/ci/agents/screenshot.md
+++ b/.github/unready/ci/agents/screenshot.md
@@ -1,0 +1,62 @@
+You are a screenshot subagent. Your ONLY job is to capture a screenshot of the web app UI using Playwright and describe what you see.
+
+## Constraints
+
+- Do NOT modify any source code files.
+- Do NOT create git commits or push anything.
+- Do NOT install packages (everything is pre-installed).
+
+## Context
+
+You are working on issue #${ISSUE_NUMBER} in ${REPO_FULL_NAME}. The main agent has just finished implementing changes and wants a screenshot of the result.
+
+When invoked, you will be told which feature/page changed and which URL to visit. Use that to decide the target URL and viewport. Common pages for reference:
+- `/` — homepage
+- `/collection` — full collection view
+- `/crack` — crack-a-pack UI
+- `/upload` — photo upload
+
+## Important notes
+
+- The server and Playwright MUST run in a **single** Bash command (chained with `&&`). Shell state (like `$SERVER_PID`) does not persist between separate Bash tool calls.
+- Do NOT pass `--db` to the server. The `MTGC_DB` environment variable is pre-configured by the entrypoint to point at a writable database copy. The server finds it automatically.
+- If the server fails to start, check `/tmp/server.log` for errors.
+- If Playwright fails, make sure you're using `node -e` (not Python) — Playwright is installed as a Node.js global package.
+
+## How to take a screenshot
+
+Run this **single** Bash command, replacing `<TARGET_PATH>` (e.g. `/collection`) and optionally adjusting the viewport size:
+
+```bash
+cd /workspace && \
+uv run mtg crack-pack-server --port 8555 > /tmp/server.log 2>&1 & \
+SERVER_PID=$! && \
+for i in $(seq 1 30); do curl -sf http://localhost:8555/ > /dev/null && break; sleep 1; done && \
+node -e "
+  const { chromium } = require('playwright');
+  (async () => {
+    const browser = await chromium.launch();
+    const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+    await page.goto('http://localhost:8555<TARGET_PATH>', { waitUntil: 'networkidle' });
+    await page.screenshot({ path: '/tmp/after-screenshot.png', fullPage: true });
+    console.log('Screenshot saved');
+    await browser.close();
+  })();
+" && \
+kill $SERVER_PID 2>/dev/null; \
+ls -la /tmp/after-screenshot.png
+```
+
+If you need a mobile viewport, change `{ width: 1280, height: 800 }` to `{ width: 375, height: 812 }`.
+
+If you need to interact with the page (click buttons, open drawers, etc.), add Playwright actions between `page.goto()` and `page.screenshot()`. For example:
+```javascript
+await page.locator('button:has-text("Columns")').click();
+await page.waitForTimeout(500);
+```
+
+## Return your results
+
+Your response MUST include:
+- The file path: `/tmp/after-screenshot.png`
+- A detailed text description of what the screenshot shows: layout, colors, key UI elements, any visible data, and whether the feature from the issue appears to be working correctly.

--- a/.github/unready/ci/entrypoint.sh
+++ b/.github/unready/ci/entrypoint.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- Auth ---
+# gh uses GH_TOKEN from the environment automatically; no login needed.
+git config --global credential.helper \
+    '!f() { echo "password=${GH_TOKEN}"; }; f'
+git config --global user.name "claude-ci[bot]"
+git config --global user.email "claude-ci[bot]@users.noreply.github.com"
+
+REPO_URL="https://x-access-token:${GH_TOKEN}@github.com/${REPO_FULL_NAME}.git"
+
+# --- Clone or update repo ---
+if [ ! -d /workspace/.git ]; then
+    git clone "$REPO_URL" /workspace
+else
+    git -C /workspace remote set-url origin "$REPO_URL"
+fi
+
+cd /workspace
+git clean -fd
+git checkout -- .
+git fetch origin
+git config core.hooksPath hooks/
+
+# Use BASE_BRANCH if set, otherwise default to main
+BASE="${BASE_BRANCH:-main}"
+git checkout "$BASE"
+git rebase "origin/$BASE"
+
+# --- Install/update deps (fast no-op if unchanged) ---
+uv sync --group dev
+
+# --- Prepare writable DB copy for server/screenshots ---
+# /data is mounted read-only; the server needs a writable DB.
+# MTGC_DB is checked by get_db_path() before MTGC_HOME, so the server
+# (and all CLI commands) find the writable copy automatically — no --db flag needed.
+if [ -f /data/collection.sqlite ]; then
+    cp /data/collection.sqlite /tmp/collection.sqlite
+    chmod 644 /tmp/collection.sqlite
+    export MTGC_DB=/tmp/collection.sqlite
+fi
+
+# For implement mode, create/checkout an issue branch
+if [ "$MODE" = "implement" ]; then
+    BRANCH="claude/issue-${ISSUE_NUMBER}"
+    git checkout -B "$BRANCH"
+fi
+
+# --- Dispatch ---
+PROMPT_FILE="/app/ci/prompts/${MODE}.md"
+PROMPT=$(ISSUE_NUMBER="$ISSUE_NUMBER" REPO_FULL_NAME="$REPO_FULL_NAME" envsubst < "$PROMPT_FILE")
+
+# --- Build --agents flag for implement mode ---
+AGENTS_ARGS=()
+if [ "$MODE" = "implement" ]; then
+    SCREENSHOT_PROMPT=$(ISSUE_NUMBER="$ISSUE_NUMBER" REPO_FULL_NAME="$REPO_FULL_NAME" \
+        envsubst < /app/ci/agents/screenshot.md)
+    SCREENSHOT_PROMPT_JSON=$(printf '%s' "$SCREENSHOT_PROMPT" | \
+        python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))')
+    AGENTS_JSON=$(cat <<AGENTEOF
+{"screenshot":{"description":"Takes screenshots of the web app UI using Playwright. Use after implementing UI changes.","prompt":${SCREENSHOT_PROMPT_JSON},"tools":["Bash","Read","Glob","Grep"],"model":"sonnet","maxTurns":15}}
+AGENTEOF
+    )
+    AGENTS_ARGS=(--agents "$AGENTS_JSON")
+fi
+
+claude --dangerously-skip-permissions \
+    -p "$PROMPT" \
+    --max-turns 50 \
+    --verbose \
+    --output-format stream-json \
+    "${AGENTS_ARGS[@]}"

--- a/.github/unready/ci/file-purposes.yaml
+++ b/.github/unready/ci/file-purposes.yaml
@@ -1,0 +1,83 @@
+# File Index purposes for CLAUDE.md
+# Keys are paths relative to repo root. Values are purpose strings.
+# Run `uv run scripts/update-file-index.py` to regenerate the File Index section.
+# New files without entries here will appear as "TODO: add purpose".
+
+# ── CLI subcommands ──
+mtg_collector/cli/crack_pack_server.py: "**Web server**: all HTTP routes, API handlers, SSE endpoints"
+mtg_collector/cli/data_cmd.py: "MTGJSON + price data import/export commands"
+mtg_collector/cli/ingest_ocr.py: "CLI image-based card ingestion via EasyOCR + Claude"
+mtg_collector/cli/ingest_corners.py: "CLI corner-photo card ingestion via Claude Vision"
+mtg_collector/cli/ingest_ids.py: "Manual card entry by rarity/collector-number/set"
+mtg_collector/cli/demo_data.py: "Load demo collection for testing"
+mtg_collector/cli/cache_cmd.py: "Scryfall bulk data caching commands"
+mtg_collector/cli/db_cmd.py: "Database init/reset/migrate commands"
+mtg_collector/cli/ingest_order.py: "CLI order ingestion from TCGPlayer/Card Kingdom"
+mtg_collector/cli/wishlist.py: "Wishlist management commands"
+mtg_collector/cli/edit.py: "Edit collection entries"
+mtg_collector/cli/show.py: "Show card details"
+mtg_collector/cli/list_cmd.py: "List collection entries"
+mtg_collector/cli/import_cmd.py: "CSV import (Moxfield, Archidekt, Deckbox)"
+mtg_collector/cli/orders.py: "Order listing and management"
+mtg_collector/cli/ingest_requeue.py: "Re-queue failed ingest images"
+mtg_collector/cli/setup_cmd.py: "`mtg setup` orchestration"
+mtg_collector/cli/crack_pack.py: "CLI booster pack generation"
+mtg_collector/cli/stats.py: "Collection statistics"
+mtg_collector/cli/delete.py: "Delete collection entries"
+mtg_collector/cli/export.py: "CSV export"
+mtg_collector/cli/debug_ingest.py: "Debug ingest pipeline"
+
+# ── Database layer ──
+mtg_collector/db/schema.py: "Schema DDL, all migrations, `init_db()`"
+mtg_collector/db/models.py: "Dataclasses + repository classes (CRUD for every table)"
+mtg_collector/db/connection.py: "`get_db_path()`, connection factory"
+
+# ── Services ──
+mtg_collector/services/agent.py: "Agentic OCR: Claude tool-use loop with `query_local_db` and `analyze_image` tools"
+mtg_collector/services/claude.py: "Claude Vision API: corner reading, card identification"
+mtg_collector/services/scryfall.py: "`ScryfallAPI` class, caching, `cache_scryfall_data()`, `ensure_set_cached()`"
+mtg_collector/services/order_parser.py: "Parse TCGPlayer HTML/text and Card Kingdom text into `ParsedOrder`"
+mtg_collector/services/order_resolver.py: "Resolve parsed orders to Scryfall cards, treatment-aware matching"
+mtg_collector/services/pack_generator.py: "MTGJSON-based booster pack simulation from SQLite"
+mtg_collector/services/ocr.py: "EasyOCR wrapper for card text extraction"
+
+# ── Web UI ──
+mtg_collector/static/collection.html: "**Collection browser**: filters, sorting, card grid, inline editing. Canonical card display."
+mtg_collector/static/crack_pack.html: "Booster pack simulator with rarity borders and badge system"
+mtg_collector/static/correct.html: "Fix misidentified cards in ingest pipeline"
+mtg_collector/static/explore_sheets.html: "Browse MTGJSON booster sheet layouts"
+mtg_collector/static/ingest_ids.html: "Manual card entry web UI"
+mtg_collector/static/ingest_corners.html: "Corner photo ingest web UI"
+mtg_collector/static/recent.html: "Recently ingested images gallery"
+mtg_collector/static/import_csv.html: "CSV import web UI"
+mtg_collector/static/ingest_order.html: "Order ingestion web UI"
+mtg_collector/static/process.html: "OCR processing + Claude identification"
+mtg_collector/static/upload.html: "Photo upload for image ingest"
+mtg_collector/static/disambiguate.html: "Resolve ambiguous Scryfall matches"
+mtg_collector/static/index.html: "Homepage / navigation"
+
+# ── Importers / Exporters ──
+mtg_collector/importers/base.py: "Shared importer interface"
+mtg_collector/importers/moxfield.py: "Moxfield CSV parser"
+mtg_collector/importers/archidekt.py: "Archidekt CSV parser"
+mtg_collector/importers/deckbox.py: "Deckbox CSV parser"
+mtg_collector/importers/decklist.py: "Moxfield paste/text deck list parser"
+mtg_collector/exporters/base.py: "Shared exporter interface"
+mtg_collector/exporters/moxfield.py: "Moxfield CSV writer"
+mtg_collector/exporters/archidekt.py: "Archidekt CSV writer"
+mtg_collector/exporters/deckbox.py: "Deckbox CSV writer"
+
+# ── Other ──
+mtg_collector.py: "Legacy entrypoint (predates package structure)"
+mtg_collector/utils.py: "`get_mtgc_home()`, `now_iso()`, JSON array helpers, condition/finish normalizers"
+Containerfile: "Multi-stage Podman build"
+pyproject.toml: "Package config, dependencies, CLI entrypoint"
+scripts/agent_ingest.py: "Standalone script to run agentic ingest"
+
+# ── Tests ──
+tests/test_import.py: "CSV import (Moxfield, Archidekt, Deckbox, decklist)"
+tests/test_price_import.py: "MTGJSON price import pipeline"
+tests/test_mtgjson_import.py: "MTGJSON AllPrintings import"
+tests/test_ingest_ids.py: "Manual card entry + `resolve_and_add_ids()`"
+tests/test_order_parser.py: "Order parsing (TCGPlayer HTML/text, Card Kingdom)"
+tests/test_order_resolver.py: "Order resolution to Scryfall cards"

--- a/.github/unready/ci/parse-log.py
+++ b/.github/unready/ci/parse-log.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Parse Claude Code CI sandbox JSON logs into a readable summary.
+
+Usage:
+    python3 ci/parse-log.py ci/logs/implement-60-20260220-131244.log
+    python3 ci/parse-log.py ci/logs/*.log          # multiple files
+    python3 ci/parse-log.py ci/logs/foo.log -v     # verbose: include tool results
+"""
+import json
+import sys
+
+DIMMED = "\033[2m"
+BOLD = "\033[1m"
+RED = "\033[31m"
+GREEN = "\033[32m"
+YELLOW = "\033[33m"
+CYAN = "\033[36m"
+RESET = "\033[0m"
+
+
+def shorten(text, max_len=200):
+    if not text:
+        return ""
+    text = str(text).replace("\n", "\\n")
+    if len(text) > max_len:
+        return text[:max_len] + "..."
+    return text
+
+
+def extract_content_blocks(obj):
+    """Extract content blocks from the stream-json format.
+
+    Messages are wrapped: {"type":"assistant","message":{"role":"assistant","content":[...]}}
+    """
+    msg = obj.get("message", {})
+    if msg:
+        return msg.get("content", [])
+    return obj.get("content", [])
+
+
+def extract_tool_result(obj):
+    """Extract tool result content from user messages (tool_result type)."""
+    msg = obj.get("message", {})
+    if msg:
+        content = msg.get("content", [])
+    else:
+        content = obj.get("content", [])
+    if isinstance(content, str):
+        return content
+    results = []
+    for block in content:
+        if isinstance(block, dict):
+            if block.get("type") == "tool_result":
+                results.append(block.get("content", ""))
+    return "\n".join(str(r) for r in results) if results else ""
+
+
+def is_error_text(text):
+    """Check if text contains error indicators."""
+    lower = text.lower()
+    for kw in ["error", "traceback", "failed", "errno", "exception"]:
+        if kw in lower:
+            # Exclude false positives
+            if "is_error" in lower or "iserror" in lower:
+                continue
+            return True
+    return False
+
+
+def parse_log(path, verbose=False):
+    print(f"\n{BOLD}{'='*60}{RESET}")
+    print(f"{BOLD}Log: {path}{RESET}")
+    print(f"{BOLD}{'='*60}{RESET}\n")
+
+    entries = []
+    with open(path) as f:
+        for line_no, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                # Non-JSON preamble (git output, uv sync, etc.)
+                if verbose:
+                    print(f"{DIMMED}[{line_no}] {shorten(line, 100)}{RESET}")
+                continue
+            entries.append((line_no, obj))
+
+    tool_calls = 0
+    errors = []
+    edits = []
+    bash_cmds = []
+
+    for line_no, obj in entries:
+        obj_type = obj.get("type", "")
+        msg = obj.get("message", {})
+        role = msg.get("role", "") if msg else ""
+
+        # System messages (init, task_started, etc.)
+        if obj_type == "system":
+            subtype = obj.get("subtype", "")
+            if subtype == "task_started":
+                desc = obj.get("description", "")
+                task_type = obj.get("task_type", "")
+                print(f"{GREEN}[{line_no}] system: task_started{RESET} ({task_type}) {desc}")
+            elif verbose:
+                print(f"{DIMMED}[{line_no}] system: {subtype}{RESET}")
+            continue
+
+        # Final result
+        if obj_type == "result":
+            text = obj.get("result", "")
+            cost = obj.get("total_cost_usd", 0)
+            duration = obj.get("duration_ms", 0)
+            duration_s = duration / 1000 if duration else 0
+            is_error = obj.get("is_error", False)
+            subtype = obj.get("subtype", "")
+            num_turns = obj.get("num_turns", "?")
+            prefix = f"{RED}RESULT ({subtype})" if is_error or "error" in subtype else f"{GREEN}RESULT ({subtype})"
+            print(f"\n{prefix}:{RESET} {shorten(text, 400)}")
+            print(f"  Cost: ${cost:.4f} | Duration: {duration_s:.0f}s | Turns: {num_turns}")
+            if is_error or "error" in subtype:
+                errors.append((line_no, f"{subtype}: {shorten(text, 200)}"))
+            continue
+
+        # Assistant messages
+        if obj_type == "assistant" or role == "assistant":
+            content = extract_content_blocks(obj)
+            if isinstance(content, str):
+                content = [{"type": "text", "text": content}]
+
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                btype = block.get("type", "")
+
+                if btype == "thinking":
+                    # Skip thinking blocks unless verbose
+                    if verbose:
+                        text = block.get("thinking", "")
+                        print(f"{DIMMED}[{line_no}] thinking: {shorten(text, 150)}{RESET}")
+                    continue
+
+                if btype == "text":
+                    text = block.get("text", "").strip()
+                    if text:
+                        print(f"{CYAN}[{line_no}] assistant:{RESET} {shorten(text, 300)}")
+                    continue
+
+                if btype == "tool_use":
+                    tool_calls += 1
+                    name = block.get("name", "?")
+                    inp = block.get("input", {})
+
+                    if name == "Edit":
+                        fp = inp.get("file_path", "?")
+                        edits.append(fp)
+                        print(f"{YELLOW}[{line_no}] Edit{RESET} {fp}")
+                        if verbose:
+                            print(f"    old: {shorten(inp.get('old_string', ''), 80)}")
+                            print(f"    new: {shorten(inp.get('new_string', ''), 80)}")
+
+                    elif name == "Write":
+                        fp = inp.get("file_path", "?")
+                        print(f"{YELLOW}[{line_no}] Write{RESET} {fp}")
+
+                    elif name == "Read":
+                        fp = inp.get("file_path", "?")
+                        if verbose:
+                            print(f"{DIMMED}[{line_no}] Read {fp}{RESET}")
+
+                    elif name == "Bash":
+                        cmd = shorten(inp.get("command", ""), 120)
+                        bash_cmds.append(inp.get("command", ""))
+                        print(f"{YELLOW}[{line_no}] Bash{RESET} {cmd}")
+
+                    elif name == "Glob":
+                        if verbose:
+                            pat = inp.get("pattern", "?")
+                            print(f"{DIMMED}[{line_no}] Glob {pat}{RESET}")
+
+                    elif name == "Grep":
+                        if verbose:
+                            pat = inp.get("pattern", "?")
+                            print(f"{DIMMED}[{line_no}] Grep {pat}{RESET}")
+
+                    elif name == "Task":
+                        desc = inp.get("description", "?")
+                        prompt = shorten(inp.get("prompt", ""), 150)
+                        print(f"{GREEN}[{line_no}] Task{RESET} ({desc}) {prompt}")
+
+                    elif name == "TodoWrite":
+                        todos = inp.get("todos", [])
+                        items = [t.get("content", "?") for t in todos if t.get("status") != "completed"]
+                        print(f"{YELLOW}[{line_no}] TodoWrite{RESET} {len(todos)} items")
+                        if verbose:
+                            for item in items[:5]:
+                                print(f"    - {shorten(item, 80)}")
+
+                    else:
+                        print(f"{YELLOW}[{line_no}] {name}{RESET} {shorten(str(inp), 120)}")
+            continue
+
+        # User/tool result messages
+        if obj_type == "user" or role == "user":
+            result_text = extract_tool_result(obj)
+            # Also check the tool_use_result shortcut
+            tur = obj.get("tool_use_result", {})
+            if isinstance(tur, str):
+                tur = {"stdout": tur}
+            stdout = tur.get("stdout", "") if tur else ""
+            stderr = tur.get("stderr", "") if tur else ""
+            combined = result_text or stdout
+            if stderr:
+                combined = combined + " STDERR: " + stderr if combined else stderr
+
+            if combined and is_error_text(combined):
+                errors.append((line_no, shorten(combined, 300)))
+                print(f"{RED}[{line_no}] result (ERROR):{RESET} {shorten(combined, 300)}")
+            elif verbose and combined:
+                print(f"{DIMMED}[{line_no}] result: {shorten(combined, 150)}{RESET}")
+            continue
+
+    # Summary
+    print(f"\n{BOLD}--- Summary ---{RESET}")
+    print(f"  JSON lines: {len(entries)}")
+    print(f"  Tool calls: {tool_calls}")
+    print(f"  Edits: {len(edits)}")
+    if edits:
+        from collections import Counter
+        for fp, count in Counter(edits).most_common():
+            print(f"    {fp}: {count} edits")
+    print(f"  Bash commands: {len(bash_cmds)}")
+    print(f"  Errors/failures: {len(errors)}")
+    if errors:
+        for line_no, err in errors:
+            print(f"    {RED}[{line_no}] {err}{RESET}")
+
+
+def main():
+    args = sys.argv[1:]
+    verbose = "-v" in args or "--verbose" in args
+    files = [a for a in args if not a.startswith("-")]
+
+    if not files:
+        print(f"Usage: {sys.argv[0]} <log_file> [-v]")
+        sys.exit(1)
+
+    for path in files:
+        parse_log(path, verbose=verbose)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/unready/ci/prompts/implement.md
+++ b/.github/unready/ci/prompts/implement.md
@@ -1,0 +1,74 @@
+You are implementing the approved plan for issue #${ISSUE_NUMBER} in ${REPO_FULL_NAME}.
+
+## Environment
+
+You are running inside a Podman container with:
+- Python 3.12, uv (package manager), ruff (linter)
+- Node.js 22, npm
+- Playwright with headless Chromium (for UI screenshots)
+- gh CLI (authenticated via GH_TOKEN)
+- git (configured with push access)
+
+The repo is cloned at `/workspace` on a branch called `claude/issue-${ISSUE_NUMBER}` (based on `main`). Everything is pre-installed and ready:
+- Project dependencies including dev/test (pytest, ruff, etc.) — do not reinstall them.
+- Card database and price data are at `$MTGC_HOME`. The server starts without additional setup.
+
+## Constraints
+
+- **Always `Read` a file before editing it.** The `Edit` tool will reject your change if you haven't read the file first. Using `grep` or `wc` does not count.
+- Do NOT use `grep`, `cat`, `head`, or `tail` to read files — use the `Read` tool.
+- Do NOT reinstall dependencies — everything is pre-installed.
+- Do NOT use `git add -A` or `git add .` — stage specific files by path.
+
+## Steps
+
+1. **Find the plan.** Run `gh issue view ${ISSUE_NUMBER} --repo ${REPO_FULL_NAME} --comments` and look for a comment starting with `## Claude Implementation Plan`. If no plan is found, post a comment saying "No implementation plan found for this issue. Please run the planning phase first." and stop.
+
+2. **Understand the project.** Read `CLAUDE.md` for project conventions, structure, and coding standards.
+
+3. **Implement the plan.** Follow the plan step by step. Adhere to the coding conventions in `CLAUDE.md`.
+
+4. **Run tests and linting.** Execute:
+   ```
+   uv run pytest
+   uv run ruff check $(git diff --name-only main -- '*.py')
+   ```
+   This lints only files you changed, avoiding pre-existing warnings in other files. If there are failures, fix them and re-run until tests pass and linting is clean.
+
+5. **Screenshot UI changes.** If your changes affect the UI (templates, styles, frontend logic), delegate to the `screenshot` subagent. Tell it what feature/page changed and which URL to visit (e.g., `/` for the collection page, `/decks` for the deck list). It will capture a screenshot, save it to `/tmp/after-screenshot.png`, and return a text description. Skip this step for backend-only changes. If you changed multiple pages in a similar way (e.g., adding a shared style), one screenshot of the most representative page is sufficient.
+
+6. **Commit and push.** Stage only the files you changed (use `git add` with specific file paths, not `git add -A`). If the screenshot subagent ran and `/tmp/after-screenshot.png` exists, copy it into the repo and stage it too:
+   ```bash
+   cp /tmp/after-screenshot.png docs/screenshots/issue-${ISSUE_NUMBER}.png
+   git add docs/screenshots/issue-${ISSUE_NUMBER}.png
+   ```
+   Commit with a descriptive message summarizing the changes. Push to the branch `claude/issue-${ISSUE_NUMBER}`.
+
+7. **Open a pull request.** Use:
+   ```
+   gh pr create --repo ${REPO_FULL_NAME} --title '<descriptive title>' --body '<body referencing issue>'
+   ```
+   Reference the issue with `Closes #${ISSUE_NUMBER}` in the PR body. If a screenshot was committed, embed it in the PR body using a raw GitHub URL (relative paths don't work in PR descriptions):
+   ```
+   ![screenshot](https://raw.githubusercontent.com/${REPO_FULL_NAME}/claude/issue-${ISSUE_NUMBER}/docs/screenshots/issue-${ISSUE_NUMBER}.png)
+   ```
+   Include the text description from the screenshot subagent.
+
+8. **Post a summary comment on the issue.** Use:
+   ```
+   gh issue comment ${ISSUE_NUMBER} --repo ${REPO_FULL_NAME} --body '<your summary>'
+   ```
+   The comment MUST start with the heading `## Claude Implementation Summary`. Include:
+   - What was implemented
+   - Link to the PR
+   - Test results
+   - Any deviations from the plan and why
+
+## Before you finish
+
+Verify all of these before stopping:
+- `uv run pytest` exits 0
+- `uv run ruff check` passes on your changed files
+- Your branch is pushed
+- A PR is open and references the issue
+- A summary comment is posted on the issue

--- a/.github/unready/ci/prompts/plan.md
+++ b/.github/unready/ci/prompts/plan.md
@@ -1,0 +1,39 @@
+You are creating an implementation plan for issue #${ISSUE_NUMBER} in ${REPO_FULL_NAME}.
+
+## Environment
+
+You are running inside a Podman container with:
+- Python 3.12, uv (package manager), ruff (linter)
+- Node.js 22, npm
+- Playwright with headless Chromium (for UI screenshots)
+- gh CLI (authenticated via GH_TOKEN)
+- git (configured with push access)
+
+The repo is cloned at `/workspace` on the `main` branch.
+
+## Steps
+
+1. **Read the issue.** Run `gh issue view ${ISSUE_NUMBER} --repo ${REPO_FULL_NAME}` to read the issue title and description. If the issue does not exist or is closed, post an error comment and stop.
+
+2. **Understand the project.** Read `CLAUDE.md` for project conventions, structure, and coding standards.
+
+3. **Explore the codebase.** Based on the issue description, identify which source files, tests, and configuration are relevant. Read them to understand the current state.
+
+4. **Create a concrete implementation plan.** Your plan should include:
+   - Which files to create, modify, or delete
+   - What changes to make in each file (be specific — reference functions, classes, and line ranges)
+   - What tests to add or update
+   - Any potential risks or edge cases
+   - If the issue involves UI changes, include a step to start the server, take a screenshot with Playwright, and attach it to the PR
+
+5. **Post the plan as an issue comment.** Use:
+   ```
+   gh issue comment ${ISSUE_NUMBER} --repo ${REPO_FULL_NAME} --body '<your plan>'
+   ```
+   Format the plan in markdown. The comment MUST start with the heading `## Claude Implementation Plan` — this exact heading is used to identify the plan in the next phase.
+
+## Boundaries
+
+- Do NOT implement any changes. Do not modify, create, or delete any source files.
+- Do NOT commit or push anything.
+- Only read files and post the plan comment.

--- a/.github/unready/ci/refresh-data.sh
+++ b/.github/unready/ci/refresh-data.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Refreshes the mtgc-ci-data volume with latest card database and prices.
+#
+# Runs on the macOS HOST (not inside Podman) so the AllPrintings.json import
+# has access to full host RAM instead of competing with prod/staging containers
+# inside the 8GB Podman VM.
+#
+# Requires: uv, git, and a checkout of efj-mtgc somewhere on the host.
+#
+# Usage: ci/refresh-data.sh <repo_checkout_path> [branch]
+# Example:
+#   bash ci/refresh-data.sh ~/efj-mtgc
+#   bash ci/refresh-data.sh ~/efj-mtgc sqlite-pack-generator
+# Cron:
+#   0 3 * * 0  bash /path/to/ci/refresh-data.sh /path/to/efj-mtgc
+
+REPO_CHECKOUT="${1:?Usage: refresh-data.sh <repo_checkout_path> [branch]}"
+BRANCH="${2:-main}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Temp dir for the data files (avoids clobbering the user's ~/.mtgc)
+STAGING_DIR="$(mktemp -d)"
+trap 'rm -rf "$STAGING_DIR"' EXIT
+
+echo "=== Step 1: Update repo (branch: $BRANCH) ==="
+cd "$REPO_CHECKOUT"
+git fetch origin
+git checkout "$BRANCH"
+git rebase "origin/$BRANCH"
+uv sync --group dev
+
+echo ""
+echo "=== Step 2: Fetch + import data on host ==="
+export MTGC_HOME="$STAGING_DIR"
+
+# Fetch AllPrintings.json (download only, ~130MB compressed → ~514MB)
+# Use --force to always re-download for freshness.
+# The auto-import after fetch handles the SQLite import.
+uv run mtg data fetch --force
+
+# Fetch + import prices
+uv run mtg data fetch-prices
+
+echo ""
+echo "=== Step 3: Copy into Podman volume ==="
+ls -lh "$STAGING_DIR/"
+
+# Use a lightweight helper container to copy host files into the named volume.
+# Mount the host staging dir read-only, the volume read-write.
+podman run --rm \
+    -v "$STAGING_DIR":/src:ro \
+    -v mtgc-ci-data:/data \
+    docker.io/library/alpine:3.19 sh -c '
+        cp /src/AllPrintings.json /data/
+        cp /src/AllPricesToday.json /data/
+        cp /src/collection.sqlite /data/
+        echo "Files copied into mtgc-ci-data:"
+        ls -lh /data/
+    '
+
+echo ""
+echo "=== Done ==="

--- a/.github/unready/ci/sandbox-run.sh
+++ b/.github/unready/ci/sandbox-run.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ci/sandbox-run.sh <mode> <issue_number> <repo_full_name>
+# Env:   ANTHROPIC_API_KEY, GH_TOKEN
+#
+# Volumes (created automatically, refreshed via ci/refresh-data.sh):
+#   mtgc-ci-workspace  — persistent git clone + .venv
+#   mtgc-ci-data       — card database + price data (read-only)
+
+MODE="$1"          # "plan" or "implement"
+ISSUE_NUMBER="$2"  # e.g. "52"
+REPO="$3"          # e.g. "thaen/efj-mtgc"
+BASE_BRANCH="${4:-main}"  # optional, e.g. "sqlite-pack-generator"
+
+if [[ "$MODE" != "plan" && "$MODE" != "implement" ]]; then
+    echo "Error: mode must be 'plan' or 'implement', got '$MODE'" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+LOG_DIR="$REPO_DIR/ci/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${MODE}-${ISSUE_NUMBER}-$(date +%Y%m%d-%H%M%S).log"
+
+# For implement mode, require approval from thaen ("Make it so")
+if [[ "$MODE" == "implement" ]]; then
+    if ! gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" --jq '
+        .[] | select(.user.login == "thaen") | .body
+    ' | grep -q "Make it so"; then
+        echo "Error: no 'Make it so' comment from thaen on issue #${ISSUE_NUMBER}. Aborting." >&2
+        exit 1
+    fi
+    echo "Approval found. Proceeding with implementation."
+fi
+
+podman build -t mtgc:ci-sandbox -f "$REPO_DIR/Containerfile.ci-sandbox" "$REPO_DIR"
+
+echo "Logging to $LOG_FILE"
+
+podman run --rm \
+    --memory=4g \
+    -v mtgc-ci-workspace:/workspace \
+    -v mtgc-ci-data:/data:ro \
+    -e ANTHROPIC_API_KEY \
+    -e GH_TOKEN \
+    -e ISSUE_NUMBER="$ISSUE_NUMBER" \
+    -e REPO_FULL_NAME="$REPO" \
+    -e MODE="$MODE" \
+    -e MTGC_HOME=/data \
+    -e BASE_BRANCH="$BASE_BRANCH" \
+    localhost/mtgc:ci-sandbox 2>&1 | tee "$LOG_FILE"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,3 +25,28 @@ jobs:
 
       - name: Build and restart
         run: bash /opt/mtgc-${{ env.INSTANCE }}/deploy/deploy.sh ${{ env.INSTANCE }}
+
+  deploy-native:
+    runs-on: [self-hosted, thaen]
+    steps:
+      - name: Pull latest code
+        run: git -C /opt/deckdumpster-code pull --ff-only origin main
+
+      - name: Sync dependencies
+        run: cd /opt/deckdumpster-code && uv sync --no-dev
+
+      - name: Restart server
+        run: launchctl kickstart -k gui/$(id -u)/com.deckdumpster.server
+
+      - name: Health check
+        run: |
+          for i in 1 2 3 4 5; do
+            if curl -sk --max-time 5 https://localhost:8080/ > /dev/null 2>&1; then
+              echo "Health check passed"
+              exit 0
+            fi
+            echo "Attempt $i/5 — waiting..."
+            sleep 5
+          done
+          echo "Health check failed"
+          exit 1


### PR DESCRIPTION
## Summary
- Add `deploy-native` job to the deploy workflow — on push to main, pulls code, syncs deps with `uv`, restarts via `launchctl`, and runs a health check
- Add CI scaffolding scripts under `.github/unready/ci/` (entrypoint, sandbox runner, log parser, prompt templates, screenshot agent)

## Test plan
- [ ] Merge and confirm the `deploy-native` job runs on the self-hosted `thaen` runner
- [ ] `curl -sk https://localhost:8080/` returns a response after deploy
- [ ] `launchctl list | grep deckdumpster` shows the service running

🤖 Generated with [Claude Code](https://claude.com/claude-code)