### PR TITLE
Replace card size sliders with +/- column count controls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,11 +85,11 @@ Repository classes in `models.py`: `CardRepository`, `SetRepository`, `PrintingR
 
 | File | Lines | Purpose |
 |------|------:|---------|
-| `collection.html` | 3462 | **Collection browser**: filters, sorting, card grid, inline editing. Canonical card display. |
+| `collection.html` | 3504 | **Collection browser**: filters, sorting, card grid, inline editing. Canonical card display. |
 | `sealed.html` | 2116 |  |
 | `recent.html` | 1358 | Recently ingested images gallery |
 | `correct.html` | 1048 | Fix misidentified cards in ingest pipeline |
-| `crack_pack.html` | 1007 | Booster pack simulator with rarity borders and badge system |
+| `crack_pack.html` | 1040 | Booster pack simulator with rarity borders and badge system |
 | `explore_sheets.html` | 824 | Browse MTGJSON booster sheet layouts |
 | `ingest_ids.html` | 680 | Manual card entry web UI |
 | `disambiguate.html` | 634 | Resolve ambiguous card matches |

--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -394,13 +394,12 @@ button.secondary.active { background: #0f3460; border-color: #e94560; }
 }
 
 .sheet-card {
-  width: var(--grid-card-width, 264px);
   position: relative;
   cursor: pointer;
 }
 
 .sheet-card-img-wrap {
-  width: var(--grid-card-width, 264px);
+  width: 100%;
   aspect-ratio: 488 / 680;
   border-radius: 8px;
   position: relative;
@@ -760,17 +759,46 @@ a.lineage-link {
 .sort-btn:hover { color: #e94560; border-color: #e94560; }
 .sort-btn.active { color: #e94560; border-color: #e94560; background: #1a1a2e; }
 
-.size-slider-wrap {
+.col-controls {
   display: flex;
   align-items: center;
-  gap: 6px;
-  font-size: 0.8rem;
-  color: #888;
+  gap: 0;
 }
 
-.size-slider-wrap input[type="range"] {
-  width: 100px;
-  accent-color: #e94560;
+.col-btn {
+  width: 28px;
+  height: 28px;
+  border: 1px solid #0f3460;
+  background: #16213e;
+  color: #888;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+}
+
+.col-btn:first-child { border-radius: 6px 0 0 6px; }
+.col-btn:last-child { border-radius: 0 6px 6px 0; }
+.col-btn + .col-btn { border-left: none; }
+.col-btn:hover { border-color: #e94560; color: #e0e0e0; }
+.col-btn:disabled { opacity: 0.3; cursor: not-allowed; }
+
+.col-count {
+  width: 28px;
+  height: 28px;
+  border: 1px solid #0f3460;
+  border-left: none;
+  border-right: none;
+  background: #16213e;
+  color: #e0e0e0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .filterable { cursor: pointer; }
@@ -1290,7 +1318,7 @@ tr.ordered td:first-child { border-left: 3px solid #f0a030; }
         </div>
       </div>
     </div>
-    <div class="size-slider-wrap" id="grid-size-wrap" style="display:none"><span>Size</span><input type="range" id="grid-size-slider" min="100" max="500" value="264"></div>
+    <div class="col-controls" id="grid-size-wrap" style="display:none"><button class="col-btn" id="col-minus">&minus;</button><div class="col-count" id="col-count"></div><button class="col-btn" id="col-plus">+</button></div>
   </div>
   <div id="status"></div>
 </header>
@@ -1490,7 +1518,6 @@ const dateMinEl = document.getElementById('date-min');
 const dateMaxEl = document.getElementById('date-max');
 
 const gridSizeWrap = document.getElementById('grid-size-wrap');
-const gridSizeSlider = document.getElementById('grid-size-slider');
 
 const includeUnownedBtn = document.getElementById('include-unowned-btn');
 let includeUnowned = '';  // '' | 'base' | 'full'
@@ -1530,18 +1557,25 @@ function getWishlistEntry(card) {
   return wishlistByPrinting[card.printing_id] || wishlistByOracle[card.oracle_id] || null;
 }
 
-// Grid size slider
-const savedGridSize = localStorage.getItem('collectionGridCardSize');
-if (savedGridSize) {
-  gridSizeSlider.value = savedGridSize;
-  document.documentElement.style.setProperty('--grid-card-width', savedGridSize + 'px');
+// Grid column count (+/- buttons)
+const COL_MIN = 1, COL_MAX = 12;
+let gridCols = parseInt(localStorage.getItem('collectionGridCols')) || (window.innerWidth < 600 ? 2 : 6);
+
+function applyGridCols() {
+  document.getElementById('col-count').textContent = gridCols;
+  document.getElementById('col-minus').disabled = gridCols <= COL_MIN;
+  document.getElementById('col-plus').disabled = gridCols >= COL_MAX;
+  localStorage.setItem('collectionGridCols', gridCols);
 }
 
-gridSizeSlider.addEventListener('input', () => {
-  const w = gridSizeSlider.value;
-  document.documentElement.style.setProperty('--grid-card-width', w + 'px');
-  localStorage.setItem('collectionGridCardSize', w);
+document.getElementById('col-minus').addEventListener('click', () => {
+  if (gridCols > COL_MIN) { gridCols--; applyGridCols(); if (currentView === 'grid') renderGrid(); }
 });
+document.getElementById('col-plus').addEventListener('click', () => {
+  if (gridCols < COL_MAX) { gridCols++; applyGridCols(); if (currentView === 'grid') renderGrid(); }
+});
+
+applyGridCols();
 
 const KEYRUNE_FALLBACKS = {
   tsb: 'tsp',
@@ -3151,10 +3185,10 @@ function renderGrid() {
   }
 
   // Grid dimensions for virtual scrolling
-  const cardWidth = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--grid-card-width')) || 264;
   const gap = 10;
   const viewportWidth = main.clientWidth || window.innerWidth;
-  const cols = Math.max(1, Math.floor((viewportWidth + gap) / (cardWidth + gap)));
+  const cols = gridCols;
+  const cardWidth = Math.floor((viewportWidth - (cols - 1) * gap) / cols);
   const cardHeight = Math.round(cardWidth * (680 / 488)) + gap; // aspect ratio + gap
   const totalRows = Math.ceil(allCards.length / cols);
   const totalHeight = totalRows * cardHeight;

--- a/mtg_collector/static/crack_pack.html
+++ b/mtg_collector/static/crack_pack.html
@@ -172,8 +172,8 @@ button:disabled { opacity: 0.4; cursor: not-allowed; }
 }
 
 .pack-grid {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(var(--grid-cols, 5), 1fr);
   gap: 12px;
   align-content: flex-start;
   flex: 1;
@@ -183,21 +183,49 @@ button:disabled { opacity: 0.4; cursor: not-allowed; }
   position: relative;
   cursor: pointer;
   transition: transform 0.15s, box-shadow 0.15s;
-  height: var(--card-height, 280px);
   perspective: 800px;
 }
 
-.size-slider-wrap {
+.col-controls {
   display: flex;
   align-items: center;
-  gap: 6px;
-  font-size: 0.8rem;
-  color: #888;
+  gap: 0;
 }
 
-.size-slider-wrap input[type="range"] {
-  width: 100px;
-  accent-color: #e94560;
+.col-btn {
+  width: 28px;
+  height: 28px;
+  border: 1px solid #0f3460;
+  background: #16213e;
+  color: #888;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+}
+
+.col-btn:first-child { border-radius: 6px 0 0 6px; }
+.col-btn:last-child { border-radius: 0 6px 6px 0; }
+.col-btn + .col-btn { border-left: none; }
+.col-btn:hover { border-color: #e94560; color: #e0e0e0; }
+.col-btn:disabled { opacity: 0.3; cursor: not-allowed; }
+
+.col-count {
+  width: 28px;
+  height: 28px;
+  border: 1px solid #0f3460;
+  border-left: none;
+  border-right: none;
+  background: #16213e;
+  color: #e0e0e0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 #zoom-overlay {
@@ -239,7 +267,7 @@ button:disabled { opacity: 0.4; cursor: not-allowed; }
 }
 
 .card-img-wrap {
-  height: calc(100% - 20px);
+  width: 100%;
   aspect-ratio: 488 / 680;
   border-radius: 12px;
   position: relative;
@@ -484,7 +512,7 @@ a.badge.link:hover { color: #fff; background: #555; border-color: #777; }
     <div class="product-radios"><input type="checkbox" id="open-mode" checked><label for="open-mode">Surprise</label></div>
     <button id="reveal-all-btn" disabled>Reveal All</button>
     <button id="sheets-btn" disabled style="background:#333;border-color:#555">Explore Sheets</button>
-    <div class="size-slider-wrap"><span>Size</span><input type="range" id="card-size-slider" min="120" max="500" value="280"></div>
+    <div class="col-controls"><button class="col-btn" id="col-minus">&minus;</button><div class="col-count" id="col-count"></div><button class="col-btn" id="col-plus">+</button></div>
   </div>
   <div id="status">
     <span class="prices-status" id="prices-status" title="Click to update CK prices"></span>
@@ -534,21 +562,26 @@ let currentPackSeed = null;
 let currentPackSetCode = null;
 let _settings = {};
 
-const cardSizeSlider = document.getElementById('card-size-slider');
+// Column count (+/- buttons)
+const COL_MIN = 1, COL_MAX = 12;
+let gridCols = parseInt(localStorage.getItem('crackPackGridCols')) || (window.innerWidth < 600 ? 3 : 5);
 
-function applyCardSize(h) {
-  packGrid.style.setProperty('--card-height', h + 'px');
-  localStorage.setItem('crackPackCardSize', h);
+function applyGridCols() {
+  packGrid.style.setProperty('--grid-cols', gridCols);
+  document.getElementById('col-count').textContent = gridCols;
+  document.getElementById('col-minus').disabled = gridCols <= COL_MIN;
+  document.getElementById('col-plus').disabled = gridCols >= COL_MAX;
+  localStorage.setItem('crackPackGridCols', gridCols);
 }
 
-// Restore saved size
-const savedSize = localStorage.getItem('crackPackCardSize');
-if (savedSize) {
-  cardSizeSlider.value = savedSize;
-  applyCardSize(savedSize);
-}
+document.getElementById('col-minus').addEventListener('click', () => {
+  if (gridCols > COL_MIN) { gridCols--; applyGridCols(); }
+});
+document.getElementById('col-plus').addEventListener('click', () => {
+  if (gridCols < COL_MAX) { gridCols++; applyGridCols(); }
+});
 
-cardSizeSlider.addEventListener('input', () => applyCardSize(cardSizeSlider.value));
+applyGridCols();
 
 // --- Prices status ---
 


### PR DESCRIPTION
## Summary
- Replaces range sliders in Collection Grid and Crack-a-Pack with the same `- N +` column count buttons used on the Recent Images page
- Collection grid: switches from flexbox with fixed card width to column-count-driven virtual scrolling (1-12 cols, default 6)
- Crack-a-Pack: switches from flexbox with fixed card height to CSS grid with column count (1-12 cols, default 5)
- Both persist column count to localStorage

## Test plan
- [ ] Collection grid: switch to grid view, verify `- N +` control appears and adjusts columns
- [ ] Crack-a-Pack: verify `- N +` control appears and adjusts columns when a pack is opened
- [ ] Both: verify column count persists across page reloads
- [ ] Mobile: verify sensible defaults (2 cols for collection, 3 for crack-a-pack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)