### PR TITLE
Target Linux deploy job at rgantt runner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   deploy:
-    runs-on: self-hosted
+    runs-on: [self-hosted, rgantt]
     steps:
       - name: Pull latest code
         run: git -C /opt/mtgc-${{ env.INSTANCE }} pull --ff-only origin ${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- Changes `deploy` job from `runs-on: self-hosted` to `runs-on: [self-hosted, rgantt]`
- Ensures the Linux/Podman deploy only runs on ryangantt's runner, not thaen's macOS box

## Context
Previously, ryangantt's runner was registered on the fork `rgantt/efj-mtgc`, and a separate sync repo
(`rgantt/efj-mtgc-deploy`) polled every 5 minutes to propagate changes. The runner is now registered
directly on this repo, so the intermediary repos are no longer needed.