### PR TITLE
Fix zero-width cards in orders grouped view

### DIFF
--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -2942,10 +2942,14 @@ function renderOrderGrouped() {
 
     const grid = document.createElement('div');
     grid.className = 'card-grid';
+    const gap = 10;
+    const viewportWidth = main.clientWidth || window.innerWidth;
+    const cardWidth = Math.floor((viewportWidth - (gridCols - 1) * gap) / gridCols);
     for (const card of cards) {
       const isOrdered = card.status === 'ordered';
       const cardEl = document.createElement('div');
       cardEl.className = 'sheet-card' + (isOrdered ? ' ordered' : '');
+      cardEl.style.width = cardWidth + 'px';
       const rarityColor = getRarityColor(card.rarity);
       const foilClass = (card.finish === 'foil' || card.finish === 'etched') ? ' foil' : '';
       const qtyBadge = card.qty > 1 ? `<span class="qty-badge">${card.qty}x</span>` : '';

--- a/tests/ui/scenarios/collection_orders_view.yaml
+++ b/tests/ui/scenarios/collection_orders_view.yaml
@@ -1,0 +1,14 @@
+# Scenario: Orders view shows card images in collection
+#
+# Related:
+#   issues: []
+#   pull_requests: []
+
+description: >
+  Navigate to the collection page. There should be a banner at the top
+  saying "5 cards awaiting delivery" with a "View Ordered" button.
+  Click "View Ordered". The view should switch to show ordered cards
+  grouped by order. Verify that card images are visible (not blank or
+  broken) — you should see actual Magic card art thumbnails for at least
+  one card. If the cards appear but have no images (empty/broken img tags),
+  that is a failure. If card images are visible, the test passes.


### PR DESCRIPTION
## Summary
- The virtual-scroll refactor (642f6d6) removed the CSS `width` from `.sheet-card` in favor of inline JS positioning, but `renderOrderGrouped()` was not updated — cards collapsed to 0x0, showing order headers with no visible card images
- Compute card width from `gridCols` (same formula as `renderGrid`) and set it inline on each card in the order-grouped view
- Add UI scenario test for the orders view

## Test plan
- [x] Verified fix by injecting width into live prod page via Playwright — 18 cards rendered at 205px width with all images loaded
- [x] Verified test instance renders order-grouped view correctly with demo data
- [ ] Deploy to container instance and visually confirm orders view shows card images

🤖 Generated with [Claude Code](https://claude.com/claude-code)