### PR TITLE
Filter digital-only sets from card identification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Each module has `register(subparsers)` and `run(args)`.
 
 | File | Lines | Purpose |
 |------|------:|---------|
-| `crack_pack_server.py` | 4696 | **Web server**: all HTTP routes, API handlers, SSE endpoints |
+| `crack_pack_server.py` | 4633 | **Web server**: all HTTP routes, API handlers, SSE endpoints |
 | `data_cmd.py` | 922 | MTGJSON + price data import/export commands |
 | `ingest_ocr.py` | 393 | CLI image-based card ingestion via EasyOCR + Claude |
 | `ingest_corners.py` | 320 | CLI corner-photo card ingestion via Claude Vision |
@@ -65,8 +65,8 @@ Each module has `register(subparsers)` and `run(args)`.
 
 | File | Lines | Purpose |
 |------|------:|---------|
-| `models.py` | 1604 | Dataclasses + repository classes (CRUD for every table) |
-| `schema.py` | 1450 | Schema DDL, all migrations, `init_db()` |
+| `models.py` | 1577 | Dataclasses + repository classes (CRUD for every table) |
+| `schema.py` | 1481 | Schema DDL, all migrations, `init_db()` |
 
 Repository classes in `models.py`: `CardRepository`, `SetRepository`, `PrintingRepository`, `CollectionRepository`, `OrderRepository`, `WishlistRepository`.
 
@@ -74,18 +74,18 @@ Repository classes in `models.py`: `CardRepository`, `SetRepository`, `PrintingR
 
 | File | Lines | Purpose |
 |------|------:|---------|
-| `agent.py` | 562 | Agentic OCR: Claude tool-use loop with `query_local_db` and `analyze_image` tools |
+| `agent.py` | 552 | Agentic OCR: Claude tool-use loop with `query_local_db` and `analyze_image` tools |
 | `claude.py` | 504 | Claude Vision API: corner reading, card identification |
 | `order_parser.py` | 414 | Parse TCGPlayer HTML/text and Card Kingdom text into `ParsedOrder` |
 | `pack_generator.py` | 329 | MTGJSON-based booster pack simulation from SQLite |
 | `order_resolver.py` | 303 | Resolve parsed orders to local DB cards, treatment-aware matching |
-| `bulk_import.py` | 263 | `ScryfallBulkClient` class (bulk cache only), `cache_card_data()`, `ensure_set_populated()` |
+| `bulk_import.py` | 264 | `ScryfallBulkClient` class (bulk cache only), `cache_card_data()`, `ensure_set_populated()` |
 
 ### `mtg_collector/static/` — Web UI (single-file HTML pages)
 
 | File | Lines | Purpose |
 |------|------:|---------|
-| `collection.html` | 3504 | **Collection browser**: filters, sorting, card grid, inline editing. Canonical card display. |
+| `collection.html` | 3508 | **Collection browser**: filters, sorting, card grid, inline editing. Canonical card display. |
 | `sealed.html` | 2116 |  |
 | `recent.html` | 1380 | Recently ingested images gallery |
 | `correct.html` | 1048 | Fix misidentified cards in ingest pipeline |

--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -339,28 +339,6 @@ def _format_candidates(raw_cards):
     return formatted
 
 
-def _narrow_candidates(candidates, card_info):
-    """Progressively filter candidates by artist, set_code, collector_number."""
-    if len(candidates) <= 1:
-        return candidates
-    result = candidates
-    artist = (card_info.get("artist") or "").lower()
-    if artist:
-        matched = [c for c in result if artist in (c.get("artist") or "").lower()]
-        if matched:
-            result = matched
-    sc = (card_info.get("set_code") or "").lower()
-    if sc:
-        matched = [c for c in result if (c.get("set_code") or "").lower() == sc]
-        if matched:
-            result = matched
-    cn = card_info.get("collector_number") or ""
-    if cn:
-        matched = [c for c in result if c.get("collector_number") == cn]
-        if matched:
-            result = matched
-    return result
-
 
 def _local_name_search(conn, name, set_code=None, limit=20):
     """Search local DB for cards by name, return card dicts for _format_candidates."""
@@ -404,8 +382,6 @@ def _process_image_core(conn, image_id, img, log_fn):
     Used by both the SSE endpoint and background workers.
     log_fn(event_type, data_dict) is called for progress events.
     """
-    from mtg_collector.cli.ingest_ocr import _build_scryfall_query
-    from mtg_collector.db.models import PrintingRepository
     from mtg_collector.services.agent import run_agent
     from mtg_collector.services.ocr import run_ocr_with_boxes
     from mtg_collector.utils import now_iso
@@ -465,22 +441,13 @@ def _process_image_core(conn, image_id, img, log_fn):
             raise
         elapsed = time.time() - t0
         _log_ingest(f"Agent complete: {len(claude_cards)} cards in {elapsed:.1f}s")
+        _log_ingest(f"Agent structured output: {json.dumps(claude_cards, indent=2)}")
         log_fn("claude_complete", {"cards": claude_cards})
 
     # Merge cards whose fragment bboxes heavily overlap (e.g. ghost artist-only card)
     claude_cards = _merge_overlapping_cards(claude_cards, ocr_fragments)
 
-    # Single-card assumption: all Claude entries are printing candidates for one card.
-    # Pick the highest-confidence entry as the representative.
-    _CONF = {"high": 0, "medium": 1, "low": 2}
-    all_entries = list(claude_cards)
-    if all_entries:
-        best = min(all_entries, key=lambda c: _CONF.get(c.get("confidence", "low"), 2))
-        extras = [c for c in all_entries if c is not best]
-    else:
-        best = None
-        extras = []
-    claude_cards = [best] if best else []
+    best = claude_cards[0] if claude_cards else None
 
     # Save to cache
     conn.execute(
@@ -495,55 +462,35 @@ def _process_image_core(conn, image_id, img, log_fn):
 
     # Step 3: Local DB resolution
     log_fn("status", {"message": "Resolving card..."})
-    printing_repo = PrintingRepository(conn)
-
-    def _resolve_candidate(card_info) -> list:
-        """Resolve one agent card_info to a list of raw card dicts."""
-        set_code, cn_or_query = _build_scryfall_query(card_info, {})
-        candidates = []
-        if set_code and cn_or_query:
-            cn_raw = cn_or_query
-            cn_stripped = cn_raw.lstrip("0") or "0"
-            printing = printing_repo.get_by_set_cn(set_code, cn_stripped)
-            if not printing:
-                printing = printing_repo.get_by_set_cn(set_code, cn_raw)
-            if printing:
-                card_data = printing.get_card_data()
-                if card_data:
-                    candidates = [card_data]
-                    extracted_name = card_info.get("name", "")
-                    returned_name = card_data.get("name", "")
-                    if extracted_name and extracted_name.lower() != returned_name.lower():
-                        _log_ingest(f"Name mismatch: Claude='{extracted_name}' vs DB='{returned_name}', adding name search")
-                        name_results = _local_name_search(conn, extracted_name)
-                        seen_ids = {c.get("id") for c in candidates}
-                        for r in name_results:
-                            if r.get("id") not in seen_ids:
-                                candidates.append(r)
-        if not candidates:
-            name = card_info.get("name")
-            search_set = card_info.get("set_code")
-            if name:
-                candidates = _local_name_search(conn, name, set_code=search_set)
-        return candidates
 
     all_matches = []
     all_crops = []
 
     if best:
-        candidates = _resolve_candidate(best)
-        if not candidates:
-            set_code, cn_or_query = _build_scryfall_query(best, {})
-            if cn_or_query and not set_code:
-                candidates = _local_name_search(conn, cn_or_query)
+        # Build (set_code, collector_number) pairs for all candidates,
+        # including stripped-leading-zero variants.
+        cn_pairs = []
+        for card_info in claude_cards:
+            sc = (card_info.get("set_code") or "").strip().lower()
+            cn = (card_info.get("collector_number") or "").strip()
+            if sc and cn:
+                stripped = cn.lstrip("0") or "0"
+                cn_pairs.append((sc, cn))
+                if stripped != cn:
+                    cn_pairs.append((sc, stripped))
 
-        # Resolve extra entries (different printing guesses) and merge
-        seen_ids = {c.get("id") for c in candidates}
-        for extra_info in extras:
-            for r in _resolve_candidate(extra_info):
-                if r.get("id") not in seen_ids:
-                    candidates.append(r)
-                    seen_ids.add(r.get("id"))
+        candidates = []
+        if cn_pairs:
+            placeholders = ",".join(["(?,?)"] * len(cn_pairs))
+            params = [v for pair in cn_pairs for v in pair]
+            rows = conn.execute(
+                f"""SELECT DISTINCT p.raw_json FROM printings p
+                    JOIN sets s ON p.set_code = s.set_code
+                    WHERE (p.set_code, p.collector_number) IN ({placeholders})
+                    AND s.digital = 0""",
+                params,
+            ).fetchall()
+            candidates = [json.loads(r[0]) for r in rows if r[0]]
 
         formatted = _format_candidates(candidates)
         all_matches.append(formatted)
@@ -655,15 +602,13 @@ def _process_image_background(db_path, image_id):
             and all_matches
             and all_matches[0]
         ):
-            narrowed = _narrow_candidates(all_matches[0], claude_cards[0])
-            unique_ids = {c["printing_id"] for c in narrowed}
+            # Digital sets already filtered during resolution.
+            unique_ids = {c["printing_id"] for c in all_matches[0]}
             if len(unique_ids) == 1:
-                sid = next(iter(unique_ids))
-                all_finishes = set()
-                for c in narrowed:
-                    for f in c.get("finishes", ["nonfoil"]):
-                        all_finishes.add(f)
-                finish = "nonfoil" if "nonfoil" in all_finishes else sorted(all_finishes)[0]
+                first = all_matches[0][0]
+                sid = first["printing_id"]
+                finishes = first.get("finishes", ["nonfoil"])
+                finish = "nonfoil" if "nonfoil" in finishes else finishes[0]
                 disambiguated[0] = sid
                 confirmed_finishes[0] = finish
                 final_status = "DONE"
@@ -2713,31 +2658,23 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         ocr_fragments = json.loads(img["ocr_result"]) if img.get("ocr_result") else []
 
         # Resolve corrected card list against local DB
-        from mtg_collector.cli.ingest_ocr import _build_scryfall_query
         from mtg_collector.db.models import PrintingRepository
         printing_repo = PrintingRepository(conn)
 
         all_matches = []
         all_crops = []
         for ci, card_info in enumerate(corrected_cards):
-            set_code, cn_or_query = _build_scryfall_query(card_info, {})
+            set_code = (card_info.get("set_code") or "").strip().lower()
+            cn = (card_info.get("collector_number") or "").strip()
             candidates = []
-
-            if set_code and cn_or_query:
-                cn_raw = cn_or_query
-                cn_stripped = cn_raw.lstrip("0") or "0"
-                printing = printing_repo.get_by_set_cn(set_code, cn_stripped)
+            if set_code and cn:
+                printing = printing_repo.get_by_set_cn(set_code, cn.lstrip("0") or "0")
                 if not printing:
-                    printing = printing_repo.get_by_set_cn(set_code, cn_raw)
+                    printing = printing_repo.get_by_set_cn(set_code, cn)
                 if printing:
                     card_data = printing.get_card_data()
                     if card_data:
                         candidates = [card_data]
-
-            if not candidates:
-                name = card_info.get("name")
-                if name:
-                    candidates = _local_name_search(conn, name, set_code=card_info.get("set_code"))
 
             formatted = _format_candidates(candidates)
             all_matches.append(formatted)

--- a/mtg_collector/db/models.py
+++ b/mtg_collector/db/models.py
@@ -27,6 +27,7 @@ class Set:
     set_name: str
     set_type: Optional[str] = None
     released_at: Optional[str] = None
+    digital: int = 0  # 1 if MTGO/Arena-only set
     cards_fetched_at: Optional[str] = None  # When full card list was cached
 
 
@@ -311,15 +312,16 @@ class SetRepository:
         """Insert or update a set."""
         self.conn.execute(
             """
-            INSERT INTO sets (set_code, set_name, set_type, released_at, cards_fetched_at)
-            VALUES (?, ?, ?, ?, ?)
+            INSERT INTO sets (set_code, set_name, set_type, released_at, digital, cards_fetched_at)
+            VALUES (?, ?, ?, ?, ?, ?)
             ON CONFLICT(set_code) DO UPDATE SET
                 set_name = excluded.set_name,
                 set_type = excluded.set_type,
                 released_at = excluded.released_at,
+                digital = excluded.digital,
                 cards_fetched_at = COALESCE(excluded.cards_fetched_at, sets.cards_fetched_at)
             """,
-            (s.set_code, s.set_name, s.set_type, s.released_at, s.cards_fetched_at),
+            (s.set_code, s.set_name, s.set_type, s.released_at, s.digital, s.cards_fetched_at),
         )
 
     def get(self, set_code: str) -> Optional[Set]:
@@ -336,6 +338,7 @@ class SetRepository:
             set_name=row["set_name"],
             set_type=row["set_type"],
             released_at=row["released_at"],
+            digital=row["digital"] if "digital" in row.keys() else 0,
             cards_fetched_at=row["cards_fetched_at"],
         )
 
@@ -368,6 +371,7 @@ class SetRepository:
             set_name=row["set_name"],
             set_type=row["set_type"],
             released_at=row["released_at"],
+            digital=row["digital"] if "digital" in row.keys() else 0,
             cards_fetched_at=row["cards_fetched_at"],
         )
 
@@ -732,37 +736,6 @@ class CollectionRepository:
             query += " LIMIT ? OFFSET ?"
             params.extend([limit, offset])
 
-        cursor = self.conn.execute(query, params)
-        return [dict(row) for row in cursor]
-
-    def get_copies(
-        self,
-        printing_id: str,
-        finish: Optional[str] = None,
-        condition: Optional[str] = None,
-        status: Optional[str] = None,
-    ) -> List[Dict[str, Any]]:
-        """Return individual (unaggregated) collection rows for a printing, joined with order data."""
-        query = """
-            SELECT c.id, c.printing_id, c.finish, c.condition, c.language,
-                   c.purchase_price, c.acquired_at, c.source, c.status, c.order_id,
-                   o.seller_name as order_seller, o.order_number as order_number,
-                   o.order_date as order_date
-            FROM collection c
-            LEFT JOIN orders o ON c.order_id = o.id
-            WHERE c.printing_id = ?
-        """
-        params: list = [printing_id]
-        if finish:
-            query += " AND c.finish = ?"
-            params.append(finish)
-        if condition:
-            query += " AND c.condition = ?"
-            params.append(condition)
-        if status:
-            query += " AND c.status = ?"
-            params.append(status)
-        query += " ORDER BY c.acquired_at DESC"
         cursor = self.conn.execute(query, params)
         return [dict(row) for row in cursor]
 

--- a/mtg_collector/db/schema.py
+++ b/mtg_collector/db/schema.py
@@ -2,7 +2,7 @@
 
 import sqlite3
 
-SCHEMA_VERSION = 24
+SCHEMA_VERSION = 25
 
 SCHEMA_SQL = """
 -- Abstract cards (oracle-level, cached from Scryfall)
@@ -23,6 +23,7 @@ CREATE TABLE IF NOT EXISTS sets (
     set_name TEXT NOT NULL,
     set_type TEXT,
     released_at TEXT,
+    digital INTEGER NOT NULL DEFAULT 0,  -- 1 if MTGO/Arena-only set
     cards_fetched_at TEXT  -- NULL = card list not cached, otherwise ISO timestamp
 );
 
@@ -496,6 +497,8 @@ def init_db(conn: sqlite3.Connection, force: bool = False) -> bool:
             _migrate_v22_to_v23(conn)
         if current < 24:
             _migrate_v23_to_v24(conn)
+        if current < 25:
+            _migrate_v24_to_v25(conn)
 
     # Record schema version
     conn.execute(
@@ -1426,10 +1429,23 @@ def _migrate_v22_to_v23(conn: sqlite3.Connection):
 
 def _migrate_v23_to_v24(conn: sqlite3.Connection):
     """Add confirmed_finishes column to ingest_images."""
+    table_exists = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='ingest_images'"
+    ).fetchone()
+    if not table_exists:
+        return
     cursor = conn.execute("PRAGMA table_info(ingest_images)")
     cols = [r[1] for r in cursor.fetchall()]
     if "confirmed_finishes" not in cols:
         conn.execute("ALTER TABLE ingest_images ADD COLUMN confirmed_finishes TEXT")
+
+
+def _migrate_v24_to_v25(conn: sqlite3.Connection):
+    """Add digital column to sets table."""
+    cursor = conn.execute("PRAGMA table_info(sets)")
+    cols = [r[1] for r in cursor.fetchall()]
+    if "digital" not in cols:
+        conn.execute("ALTER TABLE sets ADD COLUMN digital INTEGER NOT NULL DEFAULT 0")
 
 
 def drop_all_tables(conn: sqlite3.Connection):

--- a/mtg_collector/services/agent.py
+++ b/mtg_collector/services/agent.py
@@ -85,20 +85,16 @@ Card text can be used also, but older card rules text wording may not match the 
 
 DISAMBIGUATION RULE — this is critical:
 If you cannot distinguish between printings of a card, you MUST return one entry for EVERY
-plausible printing with confidence "low" or "medium". This is not a failure — returning
+plausible printing. This is not a failure — returning
 multiple candidates IS the correct output. A human will pick the right one.
 In particular, you can NEVER tell "foil" from "nonfoil" from OCR text alone. In these
 cases, return both options.
 
-Do NOT pick one and declare confidence "high" based solely on artist name or rules text match
-unless you have other reasons to be certain (such as a high-confidence date stamp from OCR).
-If your DB query returns N plausible printings and you cannot rule any out, return all N.
-
 Example: OCR shows card name "Grizzly Bears" with artist "Jeff A. Menges" and no date.
 DB query returns many printings, all with identical features: Unlimited (2ed), Revised (3ed)
 both do not have dates, and on several sets, dates are extremely small: OCR may have just missed it.
-CORRECT: return ALL the separate printings, each with confidence "low".
-WRONG: return a single entry with set_code="sum", confidence="high".
+CORRECT: return ALL the separate printings.
+WRONG: return a single entry with set_code="sum".
 
 This rule applies even after calling analyze_image — if vision analysis cannot definitively
 resolve the printing, still return all remaining plausible candidates.
@@ -137,15 +133,11 @@ OUTPUT_SCHEMA = {
                         "type": "array",
                         "items": {"type": "integer"},
                     },
-                    "confidence": {
-                        "type": "string",
-                        "enum": ["high", "medium", "low"],
-                    },
                     "notes": {"type": "string"},
                     "type": {"type": "string"},
                     "artist": {"type": "string"},
                 },
-                "required": ["name", "set_code", "collector_number", "fragment_indices", "confidence"],
+                "required": ["name", "set_code", "collector_number", "fragment_indices"],
                 "additionalProperties": False,
             },
         }
@@ -510,12 +502,9 @@ def run_agent(
     _trace(f"[FINAL] Tool calls used: {tool_call_count}/{max_calls}", status_callback, trace_lines)
 
     FINAL_PROMPT = (
-        "Output your final identification now. "
-        "Include one entry per plausible printing "
-        "(same name, different set_code/collector_number). "
-        "If you discussed N candidate printings above, you MUST return N entries. "
-        "Use confidence 'low' or 'medium' when multiple candidates remain. "
-        "Only use 'high' if a single printing is definitively identified."
+        "Output ALL IDENTIFIED CANDIDATES for the card now "
+        "Include one entry per plausible printing! "
+        "IMPORTANT: Most likely printing FIRST, then the rest. "
     )
     # If the last response was end_turn it hasn't been appended to messages yet.
     # Add it so the conversation is complete, then ask for the final answer.
@@ -559,4 +548,5 @@ def run_agent(
     )
 
     result = json.loads(final_response.content[0].text)
+    _trace(f"[FINAL OUTPUT]\n{json.dumps(result, indent=2)}", status_callback, trace_lines)
     return result["cards"], trace_lines, usage

--- a/mtg_collector/services/bulk_import.py
+++ b/mtg_collector/services/bulk_import.py
@@ -154,6 +154,7 @@ class ScryfallBulkClient:
             set_name=data["name"],
             set_type=data.get("set_type"),
             released_at=data.get("released_at"),
+            digital=1 if data.get("digital") else 0,
         )
 
     def to_printing_model(self, data: Dict) -> Printing:


### PR DESCRIPTION
## Summary
- Adds `digital` column to `sets` table (schema v25), populated from Scryfall bulk data during `mtg cache all`
- Filters out MTGO/Arena-only sets during candidate resolution via SQL JOIN (`s.digital = 0`), not Python post-processing
- Resolves all agent candidates in a single SQL query instead of per-card round-trips
- Removes `_narrow_candidates`, `_build_scryfall_query` usage, and the confidence-based candidate squash — agent output is used directly
- Auto-selects when candidates narrow to a single printing after digital filtering
- Removes duplicate `get_copies` from `CollectionRepository`
- Fixes v23→v24 migration crash when `ingest_images` table doesn't exist
- Simplifies agent prompting: drops `confidence` field, clarifies disambiguation rule

## Test plan
- [x] `uv run pytest` — 190 passed
- [x] `uv run ruff check` — clean
- [x] Verified `digital` flag populates correctly after `mtg cache all` (e.g. `om1` = digital, `om2` = paper)
- [ ] Re-ingest a card photo and confirm digital-only printings are excluded from candidates
- [ ] Confirm auto-select works when only one paper printing remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)