### PR TITLE
Add 10s connect timeout to Anthropic API clients

### DIFF
--- a/mtg_collector/services/agent.py
+++ b/mtg_collector/services/agent.py
@@ -6,6 +6,7 @@ import sys
 import time
 
 import anthropic
+import httpx
 
 from mtg_collector.db.connection import get_db_path
 from mtg_collector.services.claude import ClaudeVision
@@ -385,7 +386,9 @@ def run_agent(
         max_calls = max(DEFAULT_MAX_CALLS, int(DEFAULT_MAX_CALLS * n / 10))
     agent_model = AGENT_MODEL_SONNET if n > LARGE_FRAGMENT_THRESHOLD else AGENT_MODEL_HAIKU
 
-    client = anthropic.Anthropic()
+    client = anthropic.Anthropic(
+        timeout=httpx.Timeout(600.0, connect=10.0),
+    )
     conn = sqlite3.connect(get_db_path())
     conn.row_factory = sqlite3.Row
     tools = _build_tools(conn)

--- a/mtg_collector/services/claude.py
+++ b/mtg_collector/services/claude.py
@@ -7,13 +7,16 @@ from pathlib import Path
 from typing import Dict, List
 
 import anthropic
+import httpx
 
 
 class ClaudeVision:
     """Interface to Claude API for card image analysis."""
 
     def __init__(self, model: str = "claude-opus-4-6", max_retries: int = 4):
-        self.client = anthropic.Anthropic()
+        self.client = anthropic.Anthropic(
+            timeout=httpx.Timeout(600.0, connect=10.0),
+        )
         self.model = model
         self.max_retries = max_retries
 


### PR DESCRIPTION
## Summary
- Adds `httpx.Timeout(600.0, connect=10.0)` to both Anthropic client instantiation sites (`claude.py` and `agent.py`)
- Fixes server hang caused by indefinite blocking on an SSL handshake to the Anthropic API — the main thread was stuck in `ssl3_read_bytes → read()` with no connect timeout, freezing all request handling

## Context
Diagnosed via `sample` (macOS profiler) on the hung process. The main thread was blocked on a TLS handshake to `160.79.104.10` (Anthropic). 8 connections were in `CLOSE_WAIT`. The SDK default is a single 600s timeout with no granular connect timeout, so a stalled handshake blocks for 10 minutes.

## Test plan
- [x] Server restarted and responding (200 in 24ms)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)