### PR TITLE
Resolve candidates using all available agent data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Each module has `register(subparsers)` and `run(args)`.
 
 | File | Lines | Purpose |
 |------|------:|---------|
-| `crack_pack_server.py` | 4764 | **Web server**: all HTTP routes, API handlers, SSE endpoints |
+| `crack_pack_server.py` | 4782 | **Web server**: all HTTP routes, API handlers, SSE endpoints |
 | `data_cmd.py` | 922 | MTGJSON + price data import/export commands |
 | `ingest_ocr.py` | 393 | CLI image-based card ingestion via EasyOCR + Claude |
 | `ingest_corners.py` | 320 | CLI corner-photo card ingestion via Claude Vision |
@@ -118,9 +118,9 @@ Repository classes in `models.py`: `CardRepository`, `SetRepository`, `PrintingR
 |------|------:|---------|
 | `test_sealed_products.py` | 1346 |  |
 | `test_order_parser.py` | 622 | Order parsing (TCGPlayer HTML/text, Card Kingdom) |
-| `test_import.py` | 620 | CSV import (Moxfield, Archidekt, Deckbox, decklist) |
 | `test_price_import.py` | 530 | MTGJSON price import pipeline |
 | `test_mtgjson_import.py` | 515 | MTGJSON AllPrintings import |
+| `test_import.py` | 484 | CSV import (Moxfield, Archidekt, Deckbox, decklist) |
 | `test_ingest_ids.py` | 392 | Manual card entry + `resolve_and_add_ids()` |
 | `test_order_resolver.py` | 302 | Order resolution to local DB cards |
 
@@ -132,9 +132,9 @@ Claude Vision agent loop that drives a headless browser through UX flows. Each s
 |------|---------|
 | `test_sealed_products.py` | 1346 |  |
 | `test_order_parser.py` | 622 |  |
-| `test_import.py` | 620 |  |
 | `test_price_import.py` | 530 |  |
 | `test_mtgjson_import.py` | 515 |  |
+| `test_import.py` | 484 |  |
 | `test_ingest_ids.py` | 392 |  |
 | `test_order_resolver.py` | 302 |  |
 

--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -360,6 +360,61 @@ def _local_name_search(conn, name, set_code=None, limit=20):
     return results
 
 
+def _resolve_candidates(conn, card_infos):
+    """Resolve agent card entries to candidate printings.
+
+    One query per entry, AND'ing all available fields.
+    Results merged and deduplicated across entries.
+    """
+    all_candidates = {}  # scryfall_id → raw dict (dedup)
+
+    for ci in card_infos:
+        conditions = ["s.digital = 0"]
+        params = []
+
+        name = (ci.get("name") or "").strip()
+        sc = (ci.get("set_code") or "").strip().lower()
+        cn = (ci.get("collector_number") or "").strip()
+        artist = (ci.get("artist") or "").strip()
+
+        if name:
+            conditions.append("c.name COLLATE NOCASE = ?")
+            params.append(name)
+        if sc:
+            conditions.append("p.set_code = ?")
+            params.append(sc)
+        if cn:
+            stripped = cn.lstrip("0") or "0"
+            if stripped != cn:
+                conditions.append("p.collector_number IN (?, ?)")
+                params.extend([cn, stripped])
+            else:
+                conditions.append("p.collector_number = ?")
+                params.append(cn)
+        if artist:
+            conditions.append("p.artist LIKE ? COLLATE NOCASE")
+            params.append(f"%{artist}%")
+
+        if len(conditions) == 1:  # only s.digital = 0, no usable data
+            continue
+
+        where = " AND ".join(conditions)
+        rows = conn.execute(
+            f"""SELECT DISTINCT p.raw_json FROM printings p
+                JOIN cards c ON p.oracle_id = c.oracle_id
+                JOIN sets s ON p.set_code = s.set_code
+                WHERE {where}""",
+            params,
+        ).fetchall()
+
+        for r in rows:
+            if r[0]:
+                data = json.loads(r[0])
+                all_candidates[data["id"]] = data
+
+    return list(all_candidates.values())
+
+
 def _log_ingest(msg):
     sys.stderr.write(f"[INGEST] {msg}\n")
     sys.stderr.flush()
@@ -467,30 +522,7 @@ def _process_image_core(conn, image_id, img, log_fn):
     all_crops = []
 
     if best:
-        # Build (set_code, collector_number) pairs for all candidates,
-        # including stripped-leading-zero variants.
-        cn_pairs = []
-        for card_info in claude_cards:
-            sc = (card_info.get("set_code") or "").strip().lower()
-            cn = (card_info.get("collector_number") or "").strip()
-            if sc and cn:
-                stripped = cn.lstrip("0") or "0"
-                cn_pairs.append((sc, cn))
-                if stripped != cn:
-                    cn_pairs.append((sc, stripped))
-
-        candidates = []
-        if cn_pairs:
-            placeholders = ",".join(["(?,?)"] * len(cn_pairs))
-            params = [v for pair in cn_pairs for v in pair]
-            rows = conn.execute(
-                f"""SELECT DISTINCT p.raw_json FROM printings p
-                    JOIN sets s ON p.set_code = s.set_code
-                    WHERE (p.set_code, p.collector_number) IN ({placeholders})
-                    AND s.digital = 0""",
-                params,
-            ).fetchall()
-            candidates = [json.loads(r[0]) for r in rows if r[0]]
+        candidates = _resolve_candidates(conn, claude_cards)
 
         formatted = _format_candidates(candidates)
         all_matches.append(formatted)
@@ -2689,24 +2721,10 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         ocr_fragments = json.loads(img["ocr_result"]) if img.get("ocr_result") else []
 
         # Resolve corrected card list against local DB
-        from mtg_collector.db.models import PrintingRepository
-        printing_repo = PrintingRepository(conn)
-
         all_matches = []
         all_crops = []
         for ci, card_info in enumerate(corrected_cards):
-            set_code = (card_info.get("set_code") or "").strip().lower()
-            cn = (card_info.get("collector_number") or "").strip()
-            candidates = []
-            if set_code and cn:
-                printing = printing_repo.get_by_set_cn(set_code, cn.lstrip("0") or "0")
-                if not printing:
-                    printing = printing_repo.get_by_set_cn(set_code, cn)
-                if printing:
-                    card_data = printing.get_card_data()
-                    if card_data:
-                        candidates = [card_data]
-
+            candidates = _resolve_candidates(conn, [card_info])
             formatted = _format_candidates(candidates)
             all_matches.append(formatted)
 

--- a/tests/integration/test_import_container.py
+++ b/tests/integration/test_import_container.py
@@ -1,0 +1,198 @@
+"""
+Integration test: builds a container image, starts the server, and hits /api/import/resolve.
+
+Moved from tests/test_import.py — this test spins up a Podman container,
+which is too heavy for the unit test suite.
+
+To run: uv run pytest tests/integration/test_import_container.py -v
+Requires: podman
+"""
+
+import sqlite3
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+import requests
+import urllib3
+
+from mtg_collector.db.schema import init_db as schema_init_db
+
+
+# ── Test data ────────────────────────────────────────────────────────
+
+ORACLE_ALPHA = "aaaa-aaaa-aaaa-aaaa"
+ORACLE_BETA = "bbbb-bbbb-bbbb-bbbb"
+
+PRINTING_ALPHA_TST = "1111-1111-1111-1111"
+PRINTING_BETA_TST = "2222-2222-2222-2222"
+
+
+def _insert_test_data(conn):
+    """Insert test cards, sets, and printings directly via SQL."""
+    conn.execute(
+        "INSERT INTO sets (set_code, set_name, set_type, released_at) VALUES (?, ?, ?, ?)",
+        ("tst", "Test Set", "expansion", "2025-01-01"),
+    )
+
+    conn.execute(
+        "INSERT INTO cards (oracle_id, name, type_line, mana_cost, cmc, colors, color_identity) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (ORACLE_ALPHA, "Test Card Alpha", "Creature", "{W}", 1.0, '["W"]', '["W"]'),
+    )
+    conn.execute(
+        "INSERT INTO cards (oracle_id, name, type_line, mana_cost, cmc, colors, color_identity) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (ORACLE_BETA, "Test Card Beta", "Instant", "{U}", 1.0, '["U"]', '["U"]'),
+    )
+
+    conn.execute(
+        "INSERT INTO printings (printing_id, oracle_id, set_code, collector_number, rarity, "
+        "frame_effects, border_color, full_art, promo, promo_types, finishes, artist, image_uri) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (PRINTING_ALPHA_TST, ORACLE_ALPHA, "tst", "001", "rare",
+         "[]", "black", 0, 0, "[]", '["nonfoil","foil"]', "Artist A", None),
+    )
+    conn.execute(
+        "INSERT INTO printings (printing_id, oracle_id, set_code, collector_number, rarity, "
+        "frame_effects, border_color, full_art, promo, promo_types, finishes, artist, image_uri) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (PRINTING_BETA_TST, ORACLE_BETA, "tst", "002", "common",
+         "[]", "black", 0, 0, "[]", '["nonfoil"]', "Artist B", None),
+    )
+
+    conn.commit()
+
+
+# ── Podman helpers ───────────────────────────────────────────────────
+
+CONTAINER_NAME = "mtgc-test-import-resolve"
+IMAGE_NAME = "mtgc:test-import"
+
+
+def _podman_available():
+    try:
+        return subprocess.run(
+            ["podman", "--version"], capture_output=True,
+        ).returncode == 0
+    except FileNotFoundError:
+        return False
+
+
+# ── Tests ────────────────────────────────────────────────────────────
+
+@pytest.mark.skipif(not _podman_available(), reason="podman not available")
+class TestWebImportResolve:
+    """Integration test: builds the container image, starts the server via
+    the same entrypoint as production, and hits /api/import/resolve."""
+
+    @pytest.fixture(scope="class")
+    def container_url(self, tmp_path_factory):
+        """Build image, seed DB, start container, yield base URL."""
+        repo_dir = Path(__file__).resolve().parent.parent.parent
+
+        # 1. Create and seed a temp DB on the host
+        db_dir = tmp_path_factory.mktemp("import-test-db")
+        db_path = db_dir / "collection.sqlite"
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        schema_init_db(conn)
+        _insert_test_data(conn)
+        conn.close()
+
+        # 2. Build the container image from the same Containerfile as prod
+        subprocess.run(
+            ["podman", "build", "-t", IMAGE_NAME, "-f", "Containerfile", "."],
+            cwd=str(repo_dir), check=True,
+            capture_output=True,
+        )
+
+        # 3. Clean up any stale container from a previous run
+        subprocess.run(
+            ["podman", "rm", "-f", CONTAINER_NAME],
+            capture_output=True,
+        )
+
+        # 4. Start container — same entrypoint as production, seeded DB mounted in
+        subprocess.run(
+            [
+                "podman", "run", "-d",
+                "--name", CONTAINER_NAME,
+                "-p", ":8081",
+                "-e", "ANTHROPIC_API_KEY=test-dummy",
+                "-v", f"{db_path}:/data/collection.sqlite:Z",
+                IMAGE_NAME,
+            ],
+            check=True, capture_output=True,
+        )
+
+        # 5. Discover the auto-assigned host port
+        port_output = subprocess.check_output(
+            ["podman", "port", CONTAINER_NAME, "8081/tcp"], text=True,
+        ).strip()
+        port = port_output.split(":")[-1]
+
+        # 6. Wait for the server to accept connections
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        base_url = f"https://127.0.0.1:{port}"
+        for attempt in range(30):
+            try:
+                requests.get(f"{base_url}/", verify=False, timeout=2)
+                break
+            except Exception:
+                time.sleep(1)
+        else:
+            logs = subprocess.check_output(
+                ["podman", "logs", CONTAINER_NAME], text=True,
+                stderr=subprocess.STDOUT,
+            )
+            subprocess.run(["podman", "rm", "-f", CONTAINER_NAME], capture_output=True)
+            pytest.fail(f"Container failed to start within 30s.\nLogs:\n{logs}")
+
+        yield base_url
+
+        subprocess.run(["podman", "rm", "-f", CONTAINER_NAME], capture_output=True)
+
+    def test_resolve_via_web_api(self, container_url):
+        """/api/import/resolve resolves cards using local DB, not Scryfall."""
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        resp = requests.post(
+            f"{container_url}/api/import/resolve",
+            json={
+                "format": "moxfield",
+                "rows": [
+                    {"name": "Test Card Alpha", "set_code": "tst",
+                     "collector_number": "001", "quantity": 1, "raw": {}},
+                    {"name": "Test Card Beta", "set_code": "tst",
+                     "collector_number": "002", "quantity": 1, "raw": {}},
+                ],
+            },
+            verify=False,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["summary"]["resolved"] == 2
+        assert data["summary"]["failed"] == 0
+        assert data["resolved"][0]["printing_id"] == PRINTING_ALPHA_TST
+        assert data["resolved"][1]["printing_id"] == PRINTING_BETA_TST
+
+    def test_resolve_wrong_set_cn_via_web_api(self, container_url):
+        """Web UI Doctor Doom test: wrong set/cn falls back to name."""
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        resp = requests.post(
+            f"{container_url}/api/import/resolve",
+            json={
+                "format": "moxfield",
+                "rows": [
+                    {"name": "Test Card Alpha", "set_code": "tst",
+                     "collector_number": "002", "quantity": 1, "raw": {}},
+                ],
+            },
+            verify=False,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["summary"]["resolved"] == 1
+        # Must resolve to Alpha, not Beta (whose set/cn was provided)
+        assert data["resolved"][0]["printing_id"] == PRINTING_ALPHA_TST

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -7,14 +7,10 @@ To run: pytest tests/test_import.py -v
 import csv
 import os
 import sqlite3
-import subprocess
 import tempfile
-import time
 from pathlib import Path
 
 import pytest
-import requests
-import urllib3
 
 from mtg_collector.db import (
     CardRepository,
@@ -25,7 +21,6 @@ from mtg_collector.db import (
     init_db,
 )
 from mtg_collector.db.connection import close_connection
-from mtg_collector.db.schema import init_db as schema_init_db
 from mtg_collector.importers.moxfield import MoxfieldImporter
 
 # ── Test data ────────────────────────────────────────────────────────
@@ -487,134 +482,3 @@ class TestDecklistImport:
         with pytest.raises(ParseError) as exc_info:
             parse_line("garbage", 42)
         assert exc_info.value.line_number == 42
-
-
-# ── TestWebImportResolve ─────────────────────────────────────────────
-
-CONTAINER_NAME = "mtgc-test-import"
-IMAGE_NAME = "mtgc:test-import"
-
-
-def _podman_available():
-    try:
-        return subprocess.run(
-            ["podman", "--version"], capture_output=True,
-        ).returncode == 0
-    except FileNotFoundError:
-        return False
-
-
-@pytest.mark.skipif(not _podman_available(), reason="podman not available")
-class TestWebImportResolve:
-    """Integration test: builds the container image, starts the server via
-    the same entrypoint as production, and hits /api/import/resolve."""
-
-    @pytest.fixture(scope="class")
-    def container_url(self, tmp_path_factory):
-        """Build image, seed DB, start container, yield base URL."""
-        repo_dir = Path(__file__).resolve().parent.parent
-
-        # 1. Create and seed a temp DB on the host
-        db_dir = tmp_path_factory.mktemp("import-test-db")
-        db_path = db_dir / "collection.sqlite"
-        conn = sqlite3.connect(str(db_path))
-        conn.row_factory = sqlite3.Row
-        schema_init_db(conn)
-        _insert_test_data(conn)
-        conn.close()
-
-        # 2. Build the container image from the same Containerfile as prod
-        subprocess.run(
-            ["podman", "build", "-t", IMAGE_NAME, "-f", "Containerfile", "."],
-            cwd=str(repo_dir), check=True,
-            capture_output=True,
-        )
-
-        # 3. Clean up any stale container from a previous run
-        subprocess.run(
-            ["podman", "rm", "-f", CONTAINER_NAME],
-            capture_output=True,
-        )
-
-        # 4. Start container — same entrypoint as production, seeded DB mounted in
-        subprocess.run(
-            [
-                "podman", "run", "-d",
-                "--name", CONTAINER_NAME,
-                "-p", ":8081",
-                "-e", "ANTHROPIC_API_KEY=test-dummy",
-                "-v", f"{db_path}:/data/collection.sqlite:Z",
-                IMAGE_NAME,
-            ],
-            check=True, capture_output=True,
-        )
-
-        # 5. Discover the auto-assigned host port
-        port_output = subprocess.check_output(
-            ["podman", "port", CONTAINER_NAME, "8081/tcp"], text=True,
-        ).strip()
-        port = port_output.split(":")[-1]
-
-        # 6. Wait for the server to accept connections
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-        base_url = f"https://127.0.0.1:{port}"
-        for attempt in range(30):
-            try:
-                requests.get(f"{base_url}/", verify=False, timeout=2)
-                break
-            except Exception:
-                time.sleep(1)
-        else:
-            logs = subprocess.check_output(
-                ["podman", "logs", CONTAINER_NAME], text=True,
-                stderr=subprocess.STDOUT,
-            )
-            subprocess.run(["podman", "rm", "-f", CONTAINER_NAME], capture_output=True)
-            pytest.fail(f"Container failed to start within 30s.\nLogs:\n{logs}")
-
-        yield base_url
-
-        subprocess.run(["podman", "rm", "-f", CONTAINER_NAME], capture_output=True)
-
-    def test_resolve_via_web_api(self, container_url):
-        """/api/import/resolve resolves cards using local DB, not Scryfall."""
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-        resp = requests.post(
-            f"{container_url}/api/import/resolve",
-            json={
-                "format": "moxfield",
-                "rows": [
-                    {"name": "Test Card Alpha", "set_code": "tst",
-                     "collector_number": "001", "quantity": 1, "raw": {}},
-                    {"name": "Test Card Beta", "set_code": "tst",
-                     "collector_number": "002", "quantity": 1, "raw": {}},
-                ],
-            },
-            verify=False,
-        )
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["summary"]["resolved"] == 2
-        assert data["summary"]["failed"] == 0
-        assert data["resolved"][0]["printing_id"] == PRINTING_ALPHA_TST
-        assert data["resolved"][1]["printing_id"] == PRINTING_BETA_TST
-
-    def test_resolve_wrong_set_cn_via_web_api(self, container_url):
-        """Web UI Doctor Doom test: wrong set/cn falls back to name."""
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-        resp = requests.post(
-            f"{container_url}/api/import/resolve",
-            json={
-                "format": "moxfield",
-                "rows": [
-                    {"name": "Test Card Alpha", "set_code": "tst",
-                     "collector_number": "002", "quantity": 1, "raw": {}},
-                ],
-            },
-            verify=False,
-        )
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["summary"]["resolved"] == 1
-        # Must resolve to Alpha, not Beta (whose set/cn was provided)
-        assert data["resolved"][0]["printing_id"] == PRINTING_ALPHA_TST


### PR DESCRIPTION
## Summary

- Extract `_resolve_candidates(conn, card_infos)` helper that runs one SQL query per agent entry, AND'ing all non-empty fields (name, set_code, collector_number, artist) together
- Fixes resolution when agent returns empty `collector_number` but correct name/set/artist (e.g. Infuse from Ice Age — image 4188)
- Replaces resolution logic in both `_process_image_core` and `_api_ingest2_update_cards`
- Moves `TestWebImportResolve` (Podman container test) from `tests/test_import.py` to `tests/integration/` — it was hanging the unit test suite on hosts with podman available

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/ui --ignore=tests/integration -x` passes (206 passed, 7 skipped, 30s)
- [ ] Reset and re-process image 4188 (Infuse) on prod to confirm candidates appear
- [ ] Deploy to test container instance + validate with curl

🤖 Generated with [Claude Code](https://claude.com/claude-code)