### PR TITLE
Remove time-window tabs from recents page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,11 +53,11 @@ Each module has `register(subparsers)` and `run(args)`.
 
 | File | Lines | Purpose |
 |------|------:|---------|
-| `crack_pack_server.py` | 5359 | **Web server**: all HTTP routes, API handlers, SSE endpoints |
+| `crack_pack_server.py` | 5354 | **Web server**: all HTTP routes, API handlers, SSE endpoints |
 | `data_cmd.py` | 922 | MTGJSON + price data import/export commands |
+| `demo_data.py` | 413 | Load demo collection for testing (cards, decks, binders, views) |
 | `ingest_ocr.py` | 393 | CLI image-based card ingestion via EasyOCR + Claude |
 | `ingest_corners.py` | 320 | CLI corner-photo card ingestion via Claude Vision |
-| `demo_data.py` | 413 | Load demo collection for testing (cards, decks, binders, views) |
 | `sample_ingest.py` | 289 |  |
 | `ingest_ids.py` | 246 | Manual card entry by rarity/collector-number/set |
 
@@ -75,10 +75,10 @@ Repository classes in `models.py`: `CardRepository`, `SetRepository`, `PrintingR
 | File | Lines | Purpose |
 |------|------:|---------|
 | `order_parser.py` | 724 | Parse TCGPlayer HTML/text and Card Kingdom text into `ParsedOrder` |
-| `agent.py` | 552 | Agentic OCR: Claude tool-use loop with `query_local_db` and `analyze_image` tools |
-| `claude.py` | 504 | Claude Vision API: corner reading, card identification |
+| `agent.py` | 555 | Agentic OCR: Claude tool-use loop with `query_local_db` and `analyze_image` tools |
+| `claude.py` | 507 | Claude Vision API: corner reading, card identification |
 | `pack_generator.py` | 329 | MTGJSON-based booster pack simulation from SQLite |
-| `order_resolver.py` | 316 | Resolve parsed orders to local DB cards, treatment-aware matching |
+| `order_resolver.py` | 318 | Resolve parsed orders to local DB cards, treatment-aware matching |
 | `bulk_import.py` | 264 | `ScryfallBulkClient` class (bulk cache only), `cache_card_data()`, `ensure_set_populated()` |
 
 ### `mtg_collector/static/` — Web UI (single-file HTML pages)
@@ -87,21 +87,21 @@ Repository classes in `models.py`: `CardRepository`, `SetRepository`, `PrintingR
 |------|------:|---------|
 | `collection.html` | 3835 | **Collection browser**: filters, sorting, card grid, inline editing. Canonical card display. |
 | `sealed.html` | 2116 |  |
-| `recent.html` | 1380 | Recently ingested images gallery |
+| `recent.html` | 1370 | Recently ingested images gallery |
 | `correct.html` | 1048 | Fix misidentified cards in ingest pipeline |
 | `crack_pack.html` | 1040 | Booster pack simulator with rarity borders and badge system |
 | `explore_sheets.html` | 824 | Browse MTGJSON booster sheet layouts |
-| `ingest_ids.html` | 680 | Manual card entry web UI |
+| `decks.html` | 748 | Deck list/detail/edit with card management |
+| `ingest_ids.html` | 708 | Manual card entry web UI |
 | `disambiguate.html` | 634 | Resolve ambiguous card matches |
 | `edit_order.html` | 631 |  |
 | `ingest_corners.html` | 561 | Corner photo ingest web UI |
-| `ingest_order.html` | 495 | Order ingestion web UI |
-| `decks.html` | 748 | Deck list/detail/edit with card management |
+| `ingest_order.html` | 542 | Order ingestion web UI |
 | `import_csv.html` | 517 | CSV import web UI (with deck/binder assignment) |
 | `binders.html` | 471 | Binder list/detail/edit with card management |
 | `process.html` | 406 | OCR processing + Claude identification |
 | `upload.html` | 395 | Photo upload for image ingest |
-| `index.html` | 309 | Homepage / navigation |
+| `index.html` | 311 | Homepage / navigation |
 
 ### `mtg_collector/importers/` and `exporters/`
 
@@ -120,13 +120,12 @@ Repository classes in `models.py`: `CardRepository`, `SetRepository`, `PrintingR
 |------|------:|---------|
 | `test_sealed_products.py` | 1346 |  |
 | `test_order_parser.py` | 785 | Order parsing (TCGPlayer HTML/text, Card Kingdom) |
-| `test_import.py` | 620 | CSV import (Moxfield, Archidekt, Deckbox, decklist) |
 | `test_price_import.py` | 530 | MTGJSON price import pipeline |
 | `test_mtgjson_import.py` | 515 | MTGJSON AllPrintings import |
 | `test_import.py` | 484 | CSV import (Moxfield, Archidekt, Deckbox, decklist) |
+| `test_decks_binders.py` | 401 |  |
 | `test_ingest_ids.py` | 392 | Manual card entry + `resolve_and_add_ids()` |
 | `test_order_resolver.py` | 302 | Order resolution to local DB cards |
-| `test_decks_binders.py` | — | Deck/binder/view repository CRUD and card assignment |
 
 ### UI scenario tests (`tests/ui/`)
 
@@ -136,9 +135,10 @@ Claude Vision agent loop that drives a headless browser through UX flows. Each s
 |------|---------|
 | `test_sealed_products.py` | 1346 |  |
 | `test_order_parser.py` | 785 |  |
-| `test_import.py` | 620 |  |
 | `test_price_import.py` | 530 |  |
 | `test_mtgjson_import.py` | 515 |  |
+| `test_import.py` | 484 |  |
+| `test_decks_binders.py` | 401 |  |
 | `test_ingest_ids.py` | 392 |  |
 | `test_order_resolver.py` | 302 |  |
 

--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -1900,15 +1900,14 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         self._send_json(counts)
 
     def _api_ingest2_recent(self, params):
-        """Return images from last N hours with computed status info.
+        """Return all non-INGESTED images with computed status info.
 
         Optional ?id=X filters to a single image (for per-image polling).
         """
-        hours = float(params.get("hours", ["2"])[0])
         image_id = params.get("id", [None])[0]
         conn = self._ingest2_db()
-        where = "WHERE created_at >= strftime('%Y-%m-%dT%H:%M:%S', 'now', ?) AND status != 'INGESTED'"
-        args = [f"-{int(hours * 3600)} seconds"]
+        where = "WHERE status != 'INGESTED'"
+        args = []
         if image_id is not None:
             where += " AND id = ?"
             args.append(int(image_id))
@@ -2040,14 +2039,12 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         self._send_json(result)
 
     def _api_ingest2_usage_stats(self, params):
-        """Aggregate API token usage and estimated cost over a time window."""
-        hours = float(params.get("hours", ["24"])[0])
+        """Aggregate API token usage and estimated cost for non-INGESTED images."""
         conn = self._ingest2_db()
         rows = conn.execute(
             """SELECT api_usage FROM ingest_images
                WHERE api_usage IS NOT NULL
-               AND created_at >= strftime('%Y-%m-%dT%H:%M:%S', 'now', ?)""",
-            (f"-{int(hours * 3600)} seconds",),
+               AND status != 'INGESTED'""",
         ).fetchall()
         conn.close()
 
@@ -2972,15 +2969,12 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         if data is None:
             return
 
-        hours = float(data.get("hours", 24))
         assign_target = data.get("assign_target", "")
         conn = self._ingest2_db()
         rows = conn.execute(
             """SELECT id, md5, stored_name, disambiguated, claude_result
                FROM ingest_images
-               WHERE status = 'DONE'
-               AND created_at >= strftime('%Y-%m-%dT%H:%M:%S', 'now', ?)""",
-            (f"-{int(hours * 3600)} seconds",),
+               WHERE status = 'DONE'""",
         ).fetchall()
 
         printing_repo = PrintingRepository(conn)

--- a/mtg_collector/static/recent.html
+++ b/mtg_collector/static/recent.html
@@ -34,22 +34,6 @@ header a:hover { color: #e94560; }
   flex-wrap: wrap;
 }
 .controls label { font-size: 0.8rem; color: #888; }
-.pill-row { display: flex; gap: 0; }
-.pill-row .pill {
-  padding: 5px 12px;
-  border: 1px solid #0f3460;
-  background: #16213e;
-  color: #888;
-  font-size: 0.8rem;
-  font-weight: 600;
-  cursor: pointer;
-  user-select: none;
-}
-.pill-row .pill:first-child { border-radius: 6px 0 0 6px; }
-.pill-row .pill:last-child { border-radius: 0 6px 6px 0; }
-.pill-row .pill + .pill { border-left: none; }
-.pill-row .pill.active { background: #e94560; border-color: #e94560; color: #fff; }
-.pill-row .pill:hover:not(.active) { border-color: #e94560; color: #e0e0e0; }
 
 .col-controls {
   display: flex;
@@ -519,14 +503,6 @@ header a:hover { color: #e94560; }
 </header>
 
 <div class="controls">
-  <label>Time window:</label>
-  <div class="pill-row" id="time-pills">
-    <div class="pill" data-hours="0.5">30m</div>
-    <div class="pill active" data-hours="2">2h</div>
-    <div class="pill" data-hours="4">4h</div>
-    <div class="pill" data-hours="12">12h</div>
-    <div class="pill" data-hours="24">24h</div>
-  </div>
   <label>Columns:</label>
   <div class="col-controls">
     <button class="col-btn" id="col-minus">&minus;</button>
@@ -550,7 +526,6 @@ header a:hover { color: #e94560; }
 </div>
 
 <script>
-let currentHours = 2;
 const activePolls = new Map(); // image_id (number) → intervalId
 let discoveryTimer = null;
 
@@ -575,18 +550,6 @@ document.getElementById('col-plus').addEventListener('click', () => {
 });
 
 applyGridCols();
-
-// ── Time pills ───────────────────────────────────────────────────────────────
-
-document.querySelectorAll('#time-pills .pill').forEach(pill => {
-  pill.addEventListener('click', () => {
-    document.querySelectorAll('#time-pills .pill').forEach(p => p.classList.remove('active'));
-    pill.classList.add('active');
-    currentHours = parseFloat(pill.dataset.hours);
-    loadRecent();
-    loadUsageStats();
-  });
-});
 
 // ── Rendering helpers ────────────────────────────────────────────────────────
 
@@ -938,7 +901,7 @@ async function accRefresh(imgId) {
     renderAccordionContent(imgId, detail);
   }
   // Also refresh the grid card
-  const resp = await fetch(`/api/ingest2/recent?hours=${currentHours}&id=${imgId}`);
+  const resp = await fetch(`/api/ingest2/recent?id=${imgId}`);
   const images = await resp.json();
   if (images.length) {
     const card = document.querySelector(`#grid .img-card[data-id="${imgId}"]`);
@@ -949,7 +912,7 @@ async function accRefresh(imgId) {
 
 function updateSummaryFromGrid() {
   // Re-fetch summary from server to stay accurate
-  fetch(`/api/ingest2/recent?hours=${currentHours}`)
+  fetch('/api/ingest2/recent')
     .then(r => r.json())
     .then(images => updateSummary(images));
 }
@@ -1168,10 +1131,10 @@ function updateSummary(images) {
   batchBtn.style.display = counts.done > 0 ? 'inline-block' : 'none';
 }
 
-// ── Full render (initial load + time-pill changes) ───────────────────────────
+// ── Full render (initial load) ────────────────────────────────────────────────
 
 async function loadRecent() {
-  const resp = await fetch(`/api/ingest2/recent?hours=${currentHours}`);
+  const resp = await fetch('/api/ingest2/recent');
   const images = await resp.json();
 
   const grid = document.getElementById('grid');
@@ -1243,7 +1206,7 @@ function syncPolls(images) {
 }
 
 async function pollOneImage(id) {
-  const resp = await fetch(`/api/ingest2/recent?hours=${currentHours}&id=${id}`);
+  const resp = await fetch(`/api/ingest2/recent?id=${id}`);
   const images = await resp.json();
   if (images.length === 0) {
     clearInterval(activePolls.get(id));
@@ -1262,7 +1225,7 @@ async function pollOneImage(id) {
 // ── Discovery poll (slow — finds new images uploaded while page is open) ─────
 
 async function discoverNewImages() {
-  const resp = await fetch(`/api/ingest2/recent?hours=${currentHours}`);
+  const resp = await fetch('/api/ingest2/recent');
   const images = await resp.json();
   const grid = document.getElementById('grid');
   let foundNew = false;
@@ -1290,7 +1253,7 @@ function fmtTokens(n) {
 }
 
 async function loadUsageStats() {
-  const resp = await fetch(`/api/ingest2/usage-stats?hours=${currentHours}`);
+  const resp = await fetch('/api/ingest2/usage-stats');
   const data = await resp.json();
   const box = document.getElementById('usage-box');
   const u = data.usage;
@@ -1337,7 +1300,7 @@ async function batchIngest() {
   const msg = document.getElementById('batch-msg');
   btn.disabled = true;
   const assignSel = document.getElementById('assign-target');
-  const body = { hours: currentHours };
+  const body = {};
   if (assignSel && assignSel.value) body.assign_target = assignSel.value;
   const resp = await fetch('/api/ingest2/batch-ingest', {
     method: 'POST',
@@ -1384,7 +1347,7 @@ document.getElementById('grid').addEventListener('click', async (e) => {
   });
 
   // Refresh the single card
-  const resp = await fetch(`/api/ingest2/recent?hours=${currentHours}&id=${imgId}`);
+  const resp = await fetch(`/api/ingest2/recent?id=${imgId}`);
   const images = await resp.json();
   if (images.length && card) updateCardEl(card, images[0]);
 


### PR DESCRIPTION
## Summary
- Remove the time-window pill row (30m/2h/4h/12h/24h) from the recents page
- All non-INGESTED images are now shown regardless of when they were created
- Strip `hours` param from 3 backend endpoints and 8 frontend fetch calls

## Test plan
- [ ] Open `/recent` — no time-window pills visible
- [ ] All non-INGESTED images appear in the grid
- [ ] Batch ingest still works (with assign-target dropdown)
- [ ] Per-image polling and discovery poll still function
- [ ] Usage stats box still displays

🤖 Generated with [Claude Code](https://claude.com/claude-code)