### PR TITLE
Fix Recents page showing already-ingested old images

### DIFF
--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -1944,7 +1944,8 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         """
         image_id = params.get("id", [None])[0]
         conn = self._ingest2_db()
-        where = "WHERE status != 'INGESTED'"
+        where = ("WHERE (status NOT IN ('INGESTED', 'DONE')"
+                 " OR (status = 'DONE' AND md5 NOT IN (SELECT DISTINCT image_md5 FROM ingest_lineage)))")
         args = []
         if image_id is not None:
             where += " AND id = ?"
@@ -3015,7 +3016,8 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         rows = conn.execute(
             """SELECT id, md5, stored_name, disambiguated, claude_result
                FROM ingest_images
-               WHERE status = 'DONE'""",
+               WHERE status = 'DONE'
+               AND md5 NOT IN (SELECT DISTINCT image_md5 FROM ingest_lineage)""",
         ).fetchall()
 
         printing_repo = PrintingRepository(conn)


### PR DESCRIPTION
## Summary
- Recents page was showing ~2,900 old images (Feb 14-19) that were already ingested into the collection under the pre-`INGESTED` auto-ingest code but never transitioned from `DONE` to `INGESTED`
- Exclude `DONE` images that already have `ingest_lineage` entries from both the `/api/ingest2/recent` query and the `/api/ingest2/batch-ingest` query
- Only genuinely un-ingested `DONE` images now appear on Recents and get processed by batch-ingest

## Root cause
Two changes combined: commit `7866726` (Feb 23) introduced the `INGESTED` status without backfilling old `DONE` images, then commit `d0d8135` (Feb 28) removed the time-window filter, exposing the full backlog.

## Test plan
- [ ] Verify Recents page no longer shows old already-ingested images
- [ ] Verify legitimately un-ingested DONE images still appear
- [ ] Verify batch-ingest only processes images without existing lineage entries
- [ ] Verify per-image polling (`?id=X`) still works with the updated WHERE clause

🤖 Generated with [Claude Code](https://claude.com/claude-code)