### PR TITLE
Fix AllPrintings.json staleness causing unmapped price UUIDs

### DIFF
--- a/mtg_collector/cli/data_cmd.py
+++ b/mtg_collector/cli/data_cmd.py
@@ -21,6 +21,7 @@ def _download(url: str, dest: Path):
 
 MTGJSON_URL = "https://mtgjson.com/api/v5/AllPrintings.json.gz"
 MTGJSON_PRICES_URL = "https://mtgjson.com/api/v5/AllPricesToday.json.gz"
+MTGJSON_META_URL = "https://mtgjson.com/api/v5/Meta.json"
 
 
 def get_allprintings_path() -> Path:
@@ -165,6 +166,16 @@ def fetch_allprintings(force: bool = False):
         from mtg_collector.db.connection import get_db_path
         db_path = get_db_path()
         import_mtgjson(db_path)
+        # Store the MTGJSON version we just imported
+        version = _fetch_mtgjson_version()
+        if version:
+            conn = sqlite3.connect(db_path)
+            conn.execute(
+                "INSERT OR REPLACE INTO settings (key, value) VALUES ('mtgjson_version', ?)",
+                (version,),
+            )
+            conn.commit()
+            conn.close()
     except Exception as e:
         print(f"Warning: auto-import failed: {e}", file=sys.stderr)
 
@@ -352,8 +363,52 @@ def import_mtgjson(db_path: str):
     print(f"  Elapsed: {elapsed:.1f}s")
 
 
+def _fetch_mtgjson_version() -> str | None:
+    """Fetch the current MTGJSON build version from Meta.json."""
+    try:
+        req = urllib.request.Request(MTGJSON_META_URL, headers={"User-Agent": _USER_AGENT})
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            meta = json.loads(resp.read())
+        return meta.get("data", {}).get("version")
+    except Exception as e:
+        print(f"Warning: could not fetch MTGJSON meta: {e}", file=sys.stderr)
+        return None
+
+
+def _ensure_allprintings_fresh():
+    """Re-download AllPrintings.json if MTGJSON has published a newer build."""
+    path = get_allprintings_path()
+    if not path.exists():
+        print("AllPrintings.json not found — downloading ...")
+        fetch_allprintings(force=True)
+        return
+
+    remote_version = _fetch_mtgjson_version()
+    if not remote_version:
+        return
+
+    try:
+        from mtg_collector.db.connection import get_db_path
+        conn = sqlite3.connect(get_db_path())
+        row = conn.execute(
+            "SELECT value FROM settings WHERE key = 'mtgjson_version'"
+        ).fetchone()
+        conn.close()
+    except Exception:
+        return
+
+    local_version = row[0] if row else None
+    if local_version == remote_version:
+        return
+
+    print(f"MTGJSON updated: {local_version or 'unknown'} → {remote_version} — refreshing AllPrintings.json ...")
+    fetch_allprintings(force=True)
+
+
 def _fetch_prices(force: bool = False):
     """Download AllPricesToday.json from MTGJSON, then auto-import into SQLite."""
+    _ensure_allprintings_fresh()
+
     dest = get_allpricestoday_path()
     dest.parent.mkdir(parents=True, exist_ok=True)
 
@@ -388,15 +443,22 @@ def _fetch_prices(force: bool = False):
 
 
 def _ensure_uuid_map(conn: sqlite3.Connection):
-    """Build mtgjson_uuid_map from AllPrintings.json if empty."""
+    """Build mtgjson_uuid_map from AllPrintings.json if empty or stale."""
     count = conn.execute("SELECT COUNT(*) FROM mtgjson_uuid_map").fetchone()[0]
-    if count > 0:
-        return
 
     path = get_allprintings_path()
     if not path.exists():
-        print(f"AllPrintings.json not found at {path} — cannot build UUID map")
+        if count == 0:
+            print(f"AllPrintings.json not found at {path} — cannot build UUID map")
         return
+
+    file_mtime = str(path.stat().st_mtime)
+    stored_mtime = conn.execute(
+        "SELECT value FROM settings WHERE key = 'uuid_map_source_mtime'"
+    ).fetchone()
+
+    if count > 0 and stored_mtime and stored_mtime[0] == file_mtime:
+        return  # Map is current
 
     print("Building UUID map from AllPrintings.json ...")
     with open(path) as f:
@@ -413,6 +475,10 @@ def _ensure_uuid_map(conn: sqlite3.Connection):
     conn.executemany(
         "INSERT OR IGNORE INTO mtgjson_uuid_map (uuid, set_code, collector_number) VALUES (?, ?, ?)",
         rows,
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO settings (key, value) VALUES ('uuid_map_source_mtime', ?)",
+        (file_mtime,),
     )
     conn.commit()
     print(f"  UUID map populated: {len(rows)} entries")

--- a/tests/test_price_import.py
+++ b/tests/test_price_import.py
@@ -5,8 +5,10 @@ To run: uv run pytest tests/test_price_import.py -v
 """
 
 import json
+import os
 import sqlite3
 import tempfile
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -374,6 +376,141 @@ class TestPriceFetchLog:
         dates = json.loads(log["dates_imported"])
         assert "2024-01-15" in dates
         conn2.close()
+
+
+class TestUuidMapStaleness:
+    def test_rebuilds_when_mtime_changes(self, test_db, mock_allprintings):
+        """_ensure_uuid_map rebuilds when AllPrintings.json mtime changes."""
+        from mtg_collector.cli.data_cmd import _ensure_uuid_map
+
+        _, conn = test_db
+        with patch("mtg_collector.cli.data_cmd.get_allprintings_path", return_value=mock_allprintings):
+            _ensure_uuid_map(conn)
+
+        count1 = conn.execute("SELECT COUNT(*) FROM mtgjson_uuid_map").fetchone()[0]
+        assert count1 == 5
+
+        # Append a new card to the file and update its mtime
+        data = json.loads(mock_allprintings.read_text())
+        data["data"]["NEO"]["cards"].append({"uuid": "uuid-004", "number": "4"})
+        mock_allprintings.write_text(json.dumps(data))
+        # Force a different mtime (file write should change it, but be explicit)
+        os.utime(mock_allprintings, (time.time() + 100, time.time() + 100))
+
+        with patch("mtg_collector.cli.data_cmd.get_allprintings_path", return_value=mock_allprintings):
+            _ensure_uuid_map(conn)
+
+        count2 = conn.execute("SELECT COUNT(*) FROM mtgjson_uuid_map").fetchone()[0]
+        assert count2 == 6  # New card picked up via INSERT OR IGNORE
+
+    def test_skips_when_mtime_matches(self, test_db, mock_allprintings):
+        """_ensure_uuid_map skips rebuild when mtime matches stored value."""
+        from mtg_collector.cli.data_cmd import _ensure_uuid_map
+
+        _, conn = test_db
+        with patch("mtg_collector.cli.data_cmd.get_allprintings_path", return_value=mock_allprintings):
+            _ensure_uuid_map(conn)
+
+        # Manually delete rows to verify it doesn't rebuild
+        conn.execute("DELETE FROM mtgjson_uuid_map WHERE uuid = 'uuid-001'")
+        conn.commit()
+
+        with patch("mtg_collector.cli.data_cmd.get_allprintings_path", return_value=mock_allprintings):
+            _ensure_uuid_map(conn)
+
+        # Should still be 4 because mtime matched — no rebuild
+        count = conn.execute("SELECT COUNT(*) FROM mtgjson_uuid_map").fetchone()[0]
+        assert count == 4
+
+    def test_rebuilds_when_no_stored_mtime(self, test_db, mock_allprintings):
+        """_ensure_uuid_map rebuilds when no stored mtime (legacy DB)."""
+        from mtg_collector.cli.data_cmd import _ensure_uuid_map
+
+        _, conn = test_db
+        # Pre-populate uuid_map without setting mtime (simulates pre-fix state)
+        conn.executemany(
+            "INSERT INTO mtgjson_uuid_map (uuid, set_code, collector_number) VALUES (?, ?, ?)",
+            [("uuid-001", "neo", "1")],
+        )
+        conn.commit()
+
+        with patch("mtg_collector.cli.data_cmd.get_allprintings_path", return_value=mock_allprintings):
+            _ensure_uuid_map(conn)
+
+        # Should rebuild and pick up all 5 entries
+        count = conn.execute("SELECT COUNT(*) FROM mtgjson_uuid_map").fetchone()[0]
+        assert count == 5
+
+
+class TestEnsureAllprintingsFresh:
+    def test_skips_when_version_matches(self, test_db, mock_allprintings):
+        """_ensure_allprintings_fresh does nothing when local version matches remote."""
+        from mtg_collector.cli.data_cmd import _ensure_allprintings_fresh
+
+        db_path, conn = test_db
+        conn.execute(
+            "INSERT OR REPLACE INTO settings (key, value) VALUES ('mtgjson_version', '5.3.0+20260302')"
+        )
+        conn.commit()
+
+        with patch("mtg_collector.cli.data_cmd.get_allprintings_path", return_value=mock_allprintings):
+            with patch("mtg_collector.db.connection.get_db_path", return_value=db_path):
+                with patch("mtg_collector.cli.data_cmd._fetch_mtgjson_version", return_value="5.3.0+20260302"):
+                    with patch("mtg_collector.cli.data_cmd.fetch_allprintings") as mock_fetch:
+                        _ensure_allprintings_fresh()
+                        mock_fetch.assert_not_called()
+
+    def test_triggers_when_version_differs(self, test_db, mock_allprintings):
+        """_ensure_allprintings_fresh re-downloads when remote version is newer."""
+        from mtg_collector.cli.data_cmd import _ensure_allprintings_fresh
+
+        db_path, conn = test_db
+        conn.execute(
+            "INSERT OR REPLACE INTO settings (key, value) VALUES ('mtgjson_version', '5.3.0+20260216')"
+        )
+        conn.commit()
+
+        with patch("mtg_collector.cli.data_cmd.get_allprintings_path", return_value=mock_allprintings):
+            with patch("mtg_collector.db.connection.get_db_path", return_value=db_path):
+                with patch("mtg_collector.cli.data_cmd._fetch_mtgjson_version", return_value="5.3.0+20260302"):
+                    with patch("mtg_collector.cli.data_cmd.fetch_allprintings") as mock_fetch:
+                        _ensure_allprintings_fresh()
+                        mock_fetch.assert_called_once_with(force=True)
+
+    def test_triggers_when_no_stored_version(self, test_db, mock_allprintings):
+        """_ensure_allprintings_fresh re-downloads when no local version stored (legacy DB)."""
+        from mtg_collector.cli.data_cmd import _ensure_allprintings_fresh
+
+        db_path, conn = test_db
+
+        with patch("mtg_collector.cli.data_cmd.get_allprintings_path", return_value=mock_allprintings):
+            with patch("mtg_collector.db.connection.get_db_path", return_value=db_path):
+                with patch("mtg_collector.cli.data_cmd._fetch_mtgjson_version", return_value="5.3.0+20260302"):
+                    with patch("mtg_collector.cli.data_cmd.fetch_allprintings") as mock_fetch:
+                        _ensure_allprintings_fresh()
+                        mock_fetch.assert_called_once_with(force=True)
+
+    def test_triggers_when_file_missing(self, tmp_path):
+        """_ensure_allprintings_fresh downloads when file doesn't exist."""
+        from mtg_collector.cli.data_cmd import _ensure_allprintings_fresh
+
+        missing = tmp_path / "AllPrintings.json"
+        with patch("mtg_collector.cli.data_cmd.get_allprintings_path", return_value=missing):
+            with patch("mtg_collector.cli.data_cmd.fetch_allprintings") as mock_fetch:
+                _ensure_allprintings_fresh()
+                mock_fetch.assert_called_once_with(force=True)
+
+    def test_skips_when_meta_fetch_fails(self, test_db, mock_allprintings):
+        """_ensure_allprintings_fresh does nothing when Meta.json fetch fails."""
+        from mtg_collector.cli.data_cmd import _ensure_allprintings_fresh
+
+        db_path, _ = test_db
+
+        with patch("mtg_collector.cli.data_cmd.get_allprintings_path", return_value=mock_allprintings):
+            with patch("mtg_collector.cli.data_cmd._fetch_mtgjson_version", return_value=None):
+                with patch("mtg_collector.cli.data_cmd.fetch_allprintings") as mock_fetch:
+                    _ensure_allprintings_fresh()
+                    mock_fetch.assert_not_called()
 
 
 class TestMigrationV14ToV15:


### PR DESCRIPTION
## Summary

- **`_ensure_uuid_map()` never rebuilt** — bailed when table was non-empty, so even re-downloading AllPrintings.json wouldn't fix the map. Now tracks file mtime in the `settings` table and does `INSERT OR IGNORE` when the file changes.
- **No auto-refresh of AllPrintings.json** — only prices were fetched nightly. Now `_fetch_prices()` checks MTGJSON's `Meta.json` (~100 bytes) for the build version and only re-downloads the full AllPrintings when a newer build is available. No timer changes needed.

## Test plan

- [x] `uv run pytest tests/test_price_import.py -v` — 19 tests pass (8 new)
- [x] `uv run ruff check mtg_collector/cli/data_cmd.py` — clean
- [ ] Deploy to test container, run `mtg data fetch-prices --force`, verify AllPrintings.json gets refreshed and TMT cards get mapped

🤖 Generated with [Claude Code](https://claude.com/claude-code)