### PR TITLE
Fix macOS container builds

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,43 @@
+# Virtual environment (built inside container, not copied from host)
+.venv/
+
+# Git
+.git/
+
+# Screenshots (taken from host against container URL)
+screenshots/
+
+# Python artifacts
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+build/
+dist/
+
+# Dev/IDE
+.idea/
+.vscode/
+*.swp
+.ruff_cache/
+.pytest_cache/
+
+# CI, docs, plans
+.github/
+.claude/
+docs/
+plans/
+architecture/
+
+# Environment files (injected via --env-file at runtime)
+.env
+.env.*
+
+# Deployment scripts (not needed inside container)
+deploy/
+
+# Makefile
+Makefile
+
+# Output files
+moxfield_collection.csv

--- a/deploy/mac-deploy.sh
+++ b/deploy/mac-deploy.sh
@@ -34,6 +34,20 @@ if [ ! -f "$ENV_FILE" ]; then
     exit 1
 fi
 
+# --- Prerequisites ---
+
+if ! podman machine inspect --format '{{.State}}' 2>/dev/null | grep -q "running"; then
+    echo "ERROR: Podman machine is not running."
+    echo "  Start it with:  podman machine start"
+    exit 1
+fi
+
+MACHINE_MEM=$(podman machine inspect --format '{{.Resources.Memory}}' 2>/dev/null || echo 0)
+if [ "$MACHINE_MEM" -gt 0 ] && [ "$MACHINE_MEM" -lt 4096 ]; then
+    echo "WARNING: Podman machine has ${MACHINE_MEM}MB RAM — builds may fail."
+    echo "  Recreate with more:  podman machine stop && podman machine rm && podman machine init --memory 4096 --cpus 4 && podman machine start"
+fi
+
 echo "==> Building container image (mtgc:$INSTANCE)..."
 podman build -t "mtgc:${INSTANCE}" -f "$REPO_DIR/Containerfile" "$REPO_DIR"
 

--- a/deploy/mac-setup.sh
+++ b/deploy/mac-setup.sh
@@ -5,7 +5,7 @@
 #
 # Prerequisites:
 #   brew install podman
-#   podman machine init && podman machine start
+#   podman machine init --memory 4096 --cpus 4 && podman machine start
 #
 # Usage:
 #   bash deploy/mac-setup.sh <instance> [--init] [--test]
@@ -65,6 +65,21 @@ if ! command -v podman &>/dev/null; then
 fi
 
 echo "    podman: $(podman --version)"
+
+# Verify Podman machine is running (required on macOS)
+if ! podman machine inspect --format '{{.State}}' 2>/dev/null | grep -q "running"; then
+    echo "ERROR: Podman machine is not running."
+    echo "  Start it with:  podman machine start"
+    echo "  First time?:    podman machine init --memory 4096 --cpus 4 && podman machine start"
+    exit 1
+fi
+
+# Warn if Podman machine has low memory (< 4GB)
+MACHINE_MEM=$(podman machine inspect --format '{{.Resources.Memory}}' 2>/dev/null || echo 0)
+if [ "$MACHINE_MEM" -gt 0 ] && [ "$MACHINE_MEM" -lt 4096 ]; then
+    echo "WARNING: Podman machine has ${MACHINE_MEM}MB RAM — builds may fail."
+    echo "  Recreate with more:  podman machine stop && podman machine rm && podman machine init --memory 4096 --cpus 4 && podman machine start"
+fi
 
 # --- Env file ---
 


### PR DESCRIPTION
## Summary
- Add `.containerignore` to exclude `.venv/`, `screenshots/`, `.git/`, and other dev artifacts from the build context (~1.5GB → ~45MB)
- Add preflight checks to `mac-setup.sh` and `mac-deploy.sh`: verify the Podman machine is running before building, warn if it has < 4GB RAM
- Document recommended `podman machine init --memory 4096 --cpus 4` in prerequisites

## Test plan
- [ ] thaen runs `bash deploy/mac-setup.sh test --test` on his Intel Mac
- [ ] Verify build context transfer is fast (seconds, not minutes)
- [ ] Verify helpful error message when Podman machine is stopped
- [ ] Verify low-memory warning fires with default 2GB machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)