### PR TITLE
Fix matched card image not updating after accordion selection

### DIFF
--- a/mtg_collector/static/recent.html
+++ b/mtg_collector/static/recent.html
@@ -1056,7 +1056,21 @@ async function accRefresh(imgId) {
   const images = await resp.json();
   if (images.length) {
     const card = document.querySelector(`#grid .img-card[data-id="${imgId}"]`);
-    if (card) updateCardEl(card, images[0]);
+    if (card) {
+      updateCardEl(card, images[0]);
+      // Update scryfall thumbnail (table mode matched card image)
+      const thumb = card.querySelector('.scryfall-thumb');
+      if (thumb) {
+        const sid = (detail.disambiguated || [])[0];
+        if (sid && sid !== 'skipped' && sid !== 'already_ingested') {
+          const candidates = (detail.scryfall_matches || [])[0] || [];
+          const match = candidates.find(c => c.printing_id === sid);
+          if (match && match.image_uri) thumb.src = match.image_uri.replace('/small/', '/normal/');
+        } else {
+          thumb.removeAttribute('src');
+        }
+      }
+    }
   }
   updateSummaryFromGrid();
 }


### PR DESCRIPTION
## Summary
- When selecting a candidate card in the Recents accordion, `accRefresh()` updated overlays and metadata via `updateCardEl()` but never refreshed the `.scryfall-thumb` image in table mode
- Now updates the scryfall thumbnail using the already-loaded detail data (disambiguated printing_id + scryfall_matches) after each confirm/correct action

## Test plan
- [ ] Open Recents page in table view mode
- [ ] Click a card to open the accordion
- [ ] Select a different candidate in the accordion
- [ ] Verify the matched card thumbnail in the table row updates to reflect the new selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)