### PR TITLE
Fix import set_code case sensitivity breaking flavor_name resolution

### DIFF
--- a/mtg_collector/importers/base.py
+++ b/mtg_collector/importers/base.py
@@ -147,6 +147,10 @@ class BaseImporter(ABC):
         collector_number: Optional[str],
     ) -> Optional[str]:
         """Resolve a card using the local database. Returns printing_id or None."""
+        # Normalize set_code to lowercase (DB stores lowercase, imports may have uppercase)
+        if set_code:
+            set_code = set_code.lower()
+
         # Normalize DFC names: Moxfield exports "Front / Back", Scryfall stores "Front // Back"
         if " / " in name:
             name = name.replace(" / ", " // ")


### PR DESCRIPTION
## Summary

- Deck list parsers pass uppercase set codes (e.g. `TMC`) but the DB stores them lowercase (`tmc`)
- `get_by_set_cn()` and `get_by_flavor_name()` both do exact SQL matches on `set_code`, so Strategy 1 (set+CN lookup) and Strategy 3 (flavor name fallback) silently fail
- This caused the 5 flavor-named TMNT cards (Aggro Amalgam, Heralds of the Shredder, etc.) to fail import even after PR #158's fix was deployed
- Fix: normalize `set_code` to lowercase at the top of `_resolve_card()` before any lookups

## Test plan

- [x] All 249 existing tests pass (64 import-specific)
- [ ] Import "Turtle Power" TMC precon deck list — all cards should resolve including flavor-named ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)