### PR TITLE
Add price floor setting for collection totals

### DIFF
--- a/mtg_collector/db/schema.py
+++ b/mtg_collector/db/schema.py
@@ -656,6 +656,7 @@ def _seed_default_settings(conn: sqlite3.Connection):
     for key, value in [
         ("image_display", "crop"),
         ("price_sources", "tcg,ck"),
+        ("price_floor", "0"),
     ]:
         conn.execute(
             "INSERT OR IGNORE INTO settings (key, value) VALUES (?, ?)",

--- a/mtg_collector/services/order_parser.py
+++ b/mtg_collector/services/order_parser.py
@@ -558,7 +558,7 @@ def _is_ck_table_format(text: str) -> bool:
     if "\t" in lines[0] and "description" in first and "qty" in first:
         return True
     # Fallback: multiple lines with 4+ tab-separated columns
-    tab_lines = [l for l in lines if l.count("\t") >= 3]
+    tab_lines = [line for line in lines if line.count("\t") >= 3]
     return len(tab_lines) >= 2
 
 

--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -1330,6 +1330,14 @@ tr.ordered td:first-child { border-left: 3px solid #f0a030; }
             <div class="pill" data-value="contain">Contain</div>
           </div>
         </div>
+        <div class="more-menu-section">
+          <span class="more-menu-label">Price Floor</span>
+          <div style="display:flex;align-items:center;gap:6px">
+            <span style="color:#888;font-size:0.85rem">$</span>
+            <input type="number" id="price-floor-input" step="0.01" min="0" placeholder="0"
+              style="width:70px;padding:4px 6px;background:#16213e;border:1px solid #0f3460;color:#e0e0e0;border-radius:4px;font-size:0.85rem">
+          </div>
+        </div>
       </div>
     </div>
     <div class="col-controls" id="grid-size-wrap" style="display:none"><button class="col-btn" id="col-minus">&minus;</button><div class="col-count" id="col-count"></div><button class="col-btn" id="col-plus">+</button></div>
@@ -1749,6 +1757,16 @@ document.querySelectorAll('#image-display-pills .pill').forEach(pill => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ image_display: pill.dataset.value }),
     });
+  });
+});
+
+document.getElementById('price-floor-input').addEventListener('change', async (e) => {
+  _settings.price_floor = e.target.value || '0';
+  updateStatusText();
+  await fetch('/api/settings', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ price_floor: _settings.price_floor }),
   });
 });
 
@@ -3218,15 +3236,22 @@ function updateStatusText() {
   const sources = (_settings.price_sources || 'tcg,ck').split(',');
   const priceField = sources[0] === 'ck' ? 'ck_price' : 'tcg_price';
   const priceLabel = sources[0] === 'ck' ? 'CK' : 'TCG';
+  const floor = parseFloat(_settings.price_floor) || 0;
   if (includeUnowned) {
     const ownedCards = allCards.filter(c => c.owned);
     const missingCards = allCards.filter(c => !c.owned);
-    const ownedValue = ownedCards.reduce((s, c) => s + (parseFloat(c[priceField]) || 0) * c.qty, 0);
+    const ownedValue = ownedCards.reduce((s, c) => {
+      const p = parseFloat(c[priceField]) || 0;
+      return s + (floor > 0 && p < floor ? 0 : p * c.qty);
+    }, 0);
     const modeLabel = includeUnowned === 'full' ? 'full' : 'base';
     statusEl.textContent = `${ownedCards.length} owned, ${missingCards.length} missing (${modeLabel}) \u2014 ${priceLabel} $${ownedValue.toFixed(2)}`;
   } else {
     const totalQty = allCards.reduce((s, c) => s + c.qty, 0);
-    const totalValue = allCards.reduce((s, c) => s + (parseFloat(c[priceField]) || 0) * c.qty, 0);
+    const totalValue = allCards.reduce((s, c) => {
+      const p = parseFloat(c[priceField]) || 0;
+      return s + (floor > 0 && p < floor ? 0 : p * c.qty);
+    }, 0);
     statusEl.textContent = `${allCards.length} entries, ${totalQty} cards \u2014 ${priceLabel} $${totalValue.toFixed(2)}`;
   }
 }
@@ -3752,6 +3777,9 @@ function applySettings() {
   document.querySelectorAll('#image-display-pills .pill').forEach(p => {
     p.classList.toggle('active', p.dataset.value === _settings.image_display);
   });
+  // Sync price floor input
+  const floorInput = document.getElementById('price-floor-input');
+  if (floorInput) floorInput.value = _settings.price_floor || '';
 }
 
 // --- Wishlist state ---


### PR DESCRIPTION
## Summary

- Adds a `price_floor` setting (default `0`) that excludes cards priced below the threshold from collection market value totals
- Number input in the More menu (after Image Display) persists via `/api/settings`
- Fixes pre-existing ruff lint error in `order_parser.py` (`l` → `line`)

## Test plan

- [ ] Verify setting appears in More menu on collection page
- [ ] Set floor to `1.00`, confirm total drops (cheap cards excluded)
- [ ] Set floor back to `0`, confirm total returns to original
- [ ] Reload page, confirm floor value persists
- [ ] `uv run ruff check mtg_collector/` passes
- [ ] `uv run pytest tests/ -k "not ui"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)