### PR TITLE
Fix backfill gaps and add non-English card backfill

### DIFF
--- a/mtg_collector/cli/cache_cmd.py
+++ b/mtg_collector/cli/cache_cmd.py
@@ -164,7 +164,7 @@ def cache_all(db_path: str):
         sc = row["set_code"]
         local = row["local_count"]
         expected = expected_counts.get(sc, 0)
-        if expected > 0 and local < expected and sc not in all_set_codes:
+        if expected > 0 and local < expected:
             sets_needing_backfill.append((sc, local, expected))
 
     if sets_needing_backfill:
@@ -190,7 +190,55 @@ def cache_all(db_path: str):
     if backfill_count:
         print(f"  Backfilled {backfill_count} cards via per-set API")
 
-    # Step 7: Clean up temp file
+    # Step 7: Non-English backfill.
+    # Some physical printings only exist in non-English on Scryfall (e.g.
+    # NEO Ukiyo-e Japanese basics, WAR Japanese alt-art planeswalkers).
+    # After the English backfill, re-check gaps and fetch all languages
+    # for sets that are still under-populated. Only insert cards for
+    # collector numbers not already present locally.
+    cursor = conn.execute(
+        "SELECT s.set_code, COUNT(p.printing_id) as local_count"
+        " FROM sets s"
+        " LEFT JOIN printings p ON s.set_code = p.set_code"
+        " WHERE s.digital = 0"
+        " GROUP BY s.set_code"
+    )
+    still_gapped = []
+    for row in cursor.fetchall():
+        sc = row["set_code"]
+        local = row["local_count"]
+        expected = expected_counts.get(sc, 0)
+        if expected > 0 and local < expected:
+            still_gapped.append((sc, local, expected))
+
+    non_en_count = 0
+    if still_gapped:
+        print(f"  Non-English backfill: {len(still_gapped)} sets still have gaps...")
+        for sc, local, expected in still_gapped:
+            cards = api.get_set_cards_all_langs(sc)
+            if not cards:
+                continue
+            set_added = 0
+            for card_data in cards:
+                if "oracle_id" not in card_data:
+                    continue
+                cn = card_data["collector_number"]
+                if printing_repo.get_by_set_cn(sc, cn):
+                    continue  # Already have this collector number
+                card = api.to_card_model(card_data)
+                card_repo.upsert(card)
+                printing = api.to_printing_model(card_data)
+                printing_repo.upsert(printing)
+                set_added += 1
+            conn.commit()
+            non_en_count += set_added
+            if set_added:
+                print(f"    {sc.upper()}: +{set_added} non-English cards ({local} → {local + set_added})")
+
+    if non_en_count:
+        print(f"  Added {non_en_count} non-English-only cards")
+
+    # Step 8: Clean up temp file
     tmp_path.unlink(missing_ok=True)
 
     # Summary

--- a/mtg_collector/services/bulk_import.py
+++ b/mtg_collector/services/bulk_import.py
@@ -93,6 +93,41 @@ class ScryfallBulkClient:
         self._set_cache[set_code] = cards
         return cards
 
+    def get_set_cards_all_langs(self, set_code: str) -> List[Dict]:
+        """Fetch all cards in a set from Scryfall across all languages."""
+        set_code = set_code.lower()
+        cache_key = f"{set_code}:all"
+        if not hasattr(self, "_set_cache"):
+            self._set_cache = {}
+        if cache_key in self._set_cache:
+            return self._set_cache[cache_key]
+
+        cards = []
+        url = f"{self.BASE_URL}/cards/search"
+        params = {"q": f"set:{set_code}", "unique": "prints", "order": "collector_number"}
+
+        while url:
+            try:
+                response = self._request_with_retry("GET", url, params=params)
+                response.raise_for_status()
+                data = response.json()
+
+                if data.get("object") == "list":
+                    cards.extend(data.get("data", []))
+
+                if data.get("has_more"):
+                    url = data.get("next_page")
+                    params = {}
+                else:
+                    url = None
+
+            except requests.exceptions.RequestException as e:
+                print(f"    Error fetching set {set_code} (all langs): {e}")
+                break
+
+        self._set_cache[cache_key] = cards
+        return cards
+
     def get_card_by_id(self, scryfall_id: str) -> Optional[Dict]:
         """Get a specific card by Scryfall ID (for cache refresh)."""
         url = f"{self.BASE_URL}/cards/{scryfall_id}"


### PR DESCRIPTION
## Summary

- **Remove overly-restrictive backfill guard** — `sc not in all_set_codes` caused sets with partial bulk data coverage to be skipped entirely. Now any set where `local < expected` gets backfilled.
- **Add non-English backfill pass** — after the English backfill, re-check for still-gapped sets and fetch all languages from Scryfall. Only insert cards for collector numbers not already present locally (avoids duplicates via `UNIQUE(set_code, collector_number)`).
- **New `get_set_cards_all_langs()` method** on `ScryfallBulkClient` — queries Scryfall without `lang:en` filter for the non-English pass.

Recovers ~2,500 previously missing cards including NEO Ukiyo-e Japanese basics (#293-302), WAR Japanese alt-art planeswalkers, STA Japanese Mystical Archive, and entirely non-English sets like Foreign Black Border, Renaissance, and Salvat 2005.

## Test plan

- [x] `uv run pytest` — 250 passed, 82 skipped
- [x] `uv run ruff check` — clean
- [x] Ran `mtg cache all` locally — confirmed gap reduction from 2,580 → 88 missing cards
- [x] Verified NEO Ukiyo-e basics (#293-302) present in local DB
- [ ] Run `mtg cache all` on prod after merge to populate missing cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)