### PR TITLE
Fix batch ingest ignoring confirmed finish

### DIFF
--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -3020,7 +3020,7 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         assign_target = data.get("assign_target", "")
         conn = self._ingest2_db()
         rows = conn.execute(
-            """SELECT id, md5, stored_name, disambiguated, claude_result
+            """SELECT id, md5, stored_name, disambiguated, claude_result, confirmed_finishes
                FROM ingest_images
                WHERE status = 'DONE'
                AND md5 NOT IN (SELECT DISTINCT image_md5 FROM ingest_lineage)""",
@@ -3049,8 +3049,13 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                 printing = printing_repo.get(sid)
                 if not printing:
                     continue
-                finishes = json.loads(printing.raw_json).get("finishes", ["nonfoil"]) if printing.raw_json else ["nonfoil"]
-                finish = finishes[0] if finishes else "nonfoil"
+                confirmed = json.loads(img["confirmed_finishes"]) if img.get("confirmed_finishes") else []
+                finish = None
+                if card_idx < len(confirmed) and confirmed[card_idx]:
+                    finish = confirmed[card_idx]
+                if not finish:
+                    finishes = json.loads(printing.raw_json).get("finishes", ["nonfoil"]) if printing.raw_json else ["nonfoil"]
+                    finish = finishes[0] if finishes else "nonfoil"
                 entry = CollectionEntry(
                     id=None,
                     printing_id=sid,


### PR DESCRIPTION
## Summary

- Batch ingest (`_api_ingest2_batch_ingest`) ignored the user's confirmed finish selection, always defaulting to `finishes[0]` from Scryfall printing data (typically `"nonfoil"`)
- Now fetches `confirmed_finishes` from the `ingest_images` row and uses it when present, falling back to Scryfall data only when no confirmed finish exists

## Test plan

- [ ] Confirm a card with finish "foil", batch ingest, verify collection entry has `finish = 'foil'`
- [ ] Confirm a card without setting finish, batch ingest, verify fallback to `finishes[0]` from Scryfall data

🤖 Generated with [Claude Code](https://claude.com/claude-code)