### PR TITLE
Add shareable card list URLs for cross-instance sharing

### DIFF
--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -1798,6 +1798,17 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         filter_wanted = params.get("filter_wanted", [""])[0] == "true"
         _unowned_raw = params.get("include_unowned", [""])[0]
         include_unowned = _unowned_raw if _unowned_raw in ("base", "full") else ""
+        # Explicit card list: ?cards=set:cn,set:cn,... — forces include_unowned=base
+        cards_param = params.get("cards", [""])[0]
+        card_pairs = []
+        if cards_param:
+            for entry in cards_param.split(","):
+                entry = entry.strip()
+                if ":" in entry:
+                    sc, cn = entry.split(":", 1)
+                    card_pairs.append((sc.lower(), cn))
+            if card_pairs:
+                include_unowned = include_unowned or "base"
         filter_deck_id = params.get("deck_id", [""])[0]
         filter_binder_id = params.get("binder_id", [""])[0]
         filter_unassigned = params.get("unassigned", [""])[0] == "1"
@@ -1821,8 +1832,16 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                 where_clauses.append("c.status = ?")
                 sql_params.append(filter_status)
 
+        # Explicit card list filter
+        if card_pairs:
+            pair_clauses = []
+            for sc, cn in card_pairs:
+                pair_clauses.append("(p.set_code = ? AND p.collector_number = ?)")
+                sql_params.extend([sc, cn])
+            where_clauses.append(f"({' OR '.join(pair_clauses)})")
+
         # Exclude non-collectible cards (digital-only, meld backs)
-        if include_unowned:
+        if include_unowned and not card_pairs:
             where_clauses.append("json_extract(p.raw_json, '$.digital') = 0")
             where_clauses.append(
                 "NOT (json_extract(p.raw_json, '$.layout') = 'meld'"

--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -3034,6 +3034,10 @@ function updateUnownedBtn() {
 // --- Fetch ---
 function getFetchParams() {
   const params = new URLSearchParams();
+  if (_sharedCards) {
+    params.set('cards', _sharedCards);
+    return params.toString();
+  }
   const q = searchInput.value.trim();
   if (q) params.set('q', q);
   const oq = oracleSearchInput.value.trim();
@@ -4087,6 +4091,8 @@ async function assignSelectedToBinder() {
 function serializeFiltersToURL() {
   const params = new URLSearchParams();
 
+  if (_sharedCards) { params.set('cards', _sharedCards); params.set('view', 'grid'); }
+
   const q = searchInput.value.trim();
   if (q) params.set('q', q);
 
@@ -4134,10 +4140,20 @@ function serializeFiltersToURL() {
 }
 
 let _pendingContainerValue = '';
+let _sharedCards = '';  // ?cards=set:cn,set:cn,... for shareable links
 
 function restoreFiltersFromURL() {
   const params = new URLSearchParams(window.location.search);
   if (!params.toString()) return;
+
+  // Shared card list — takes precedence, forces grid view
+  const cards = params.get('cards');
+  if (cards) {
+    _sharedCards = cards;
+    includeUnowned = 'base';
+    currentView = 'grid';
+    updateViewButtons();
+  }
 
   // Search
   const q = params.get('q');

--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -3062,6 +3062,7 @@ function getFetchParams() {
 }
 
 function hasAnyFilter() {
+  if (_sharedCards) return true;
   if (searchInput.value.trim()) return true;
   if (oracleSearchInput.value.trim()) return true;
   if (selectedSets.size) return true;

--- a/mtg_collector/static/deck-builder.css
+++ b/mtg_collector/static/deck-builder.css
@@ -591,4 +591,6 @@
   #type-groups { column-count: 1; }
   .zone-tabs { flex-wrap: wrap; }
   .zone-tabs .tab { padding: 8px 16px; font-size: 0.85rem; }
+  .deck-header .header-actions { flex-wrap: wrap; margin-left: 0; width: 100%; }
+  .deck-header .header-actions button { font-size: 0.78rem; padding: 5px 10px; }
 }

--- a/mtg_collector/static/deck-builder.js
+++ b/mtg_collector/static/deck-builder.js
@@ -179,6 +179,7 @@
             <div class="header-actions">
               <button class="edit-btn" id="edit-deck-btn">Edit</button>
               <button class="add-btn" id="add-card-btn">+ Add Card</button>
+              <button class="edit-btn" id="btn-share-deck">Share</button>
               <button class="edit-btn" id="btn-import-expected">Import Expected</button>
               ${deck.state !== 'constructed' ? '<button class="add-btn" id="btn-materialize">Materialize</button>' : ''}
               <button class="delete-btn" id="delete-deck-btn">Delete</button>
@@ -457,6 +458,18 @@
 
     // Edit deck
     document.getElementById('edit-deck-btn').addEventListener('click', () => showEditModal(deck));
+
+    // Share deck as collection URL
+    document.getElementById('btn-share-deck').addEventListener('click', () => {
+      const allCards = window._deckCards || [];
+      const pairs = allCards.map(c => c.set_code + ':' + c.collector_number);
+      const url = window.location.origin + '/collection?cards=' + pairs.join(',') + '&view=grid';
+      navigator.clipboard.writeText(url).then(() => {
+        const btn = document.getElementById('btn-share-deck');
+        btn.textContent = 'Copied!';
+        setTimeout(() => { btn.textContent = 'Share'; }, 2000);
+      });
+    });
 
     // Import expected list
     document.getElementById('btn-import-expected').addEventListener('click', showExpectedModal);

--- a/tests/ui/hints/collection_shared_card_list.yaml
+++ b/tests/ui/hints/collection_shared_card_list.yaml
@@ -1,0 +1,17 @@
+start_page: /collection?cards=fdn:188,otj:196&view=grid
+involves:
+  - "Card grid (.card-grid) showing card images"
+  - "Status bar (#status) showing owned/missing counts"
+  - "Sheet card elements (.sheet-card) with optional .unowned class"
+fixture_data:
+  card1_set_cn: "fdn:188"
+  card1_name: "Abrade"
+  card1_owned: false
+  card2_set_cn: "otj:196"
+  card2_name: "Bonny Pall, Clearcutter"
+  card2_owned: true
+notes: >
+  Navigate directly to the URL with cards param. Wait for the grid to render.
+  The status bar should show "1 owned, 1 missing (base)". Verify at least
+  2 .sheet-card elements are present. One card (Abrade) is unowned so its
+  element should have the .unowned class.

--- a/tests/ui/hints/collection_shared_card_list_empty.yaml
+++ b/tests/ui/hints/collection_shared_card_list_empty.yaml
@@ -1,0 +1,11 @@
+start_page: /collection?cards=zzz:999&view=grid
+involves:
+  - "Card grid (.card-grid) empty"
+  - "Status bar (#status) showing 0 results"
+fixture_data:
+  nonexistent_card: "zzz:999"
+notes: >
+  Navigate directly to the URL with a nonexistent set:cn pair.
+  Wait for the page to load. The status bar should show
+  "0 owned, 0 missing (base)". The grid should have no .sheet-card
+  elements.

--- a/tests/ui/hints/deck_share_button_copies_url.yaml
+++ b/tests/ui/hints/deck_share_button_copies_url.yaml
@@ -1,0 +1,11 @@
+start_page: /decks/2
+involves:
+  - "Share button (#btn-share-deck) in deck header actions"
+  - "Button text changes to 'Copied!' after click"
+fixture_data:
+  deck_id: "2"
+  deck_name: "Eldrazi Ramp"
+notes: >
+  Navigate to deck 2 (Eldrazi Ramp). Wait for deck to load. Click the
+  "Share" button. Wait for the button text to change to "Copied!".
+  Verify the button text is "Copied!".

--- a/tests/ui/implementations/collection_shared_card_list.py
+++ b/tests/ui/implementations/collection_shared_card_list.py
@@ -1,0 +1,23 @@
+"""
+Hand-written implementation for collection_shared_card_list.
+
+Verifies that a shared card list URL renders specific cards in grid view.
+"""
+
+
+def steps(harness):
+    # start_page from hints navigates to /collection?cards=fdn:188,otj:196&view=grid
+
+    # Wait for the grid to render with card images
+    harness.wait_for_visible(".sheet-card", timeout=10_000)
+
+    # Verify status bar shows owned/missing counts
+    harness.wait_for_text("1 owned, 1 missing", timeout=10_000)
+
+    # Verify both cards are rendered
+    harness.assert_element_count(".sheet-card", 2)
+
+    # Verify unowned card has the dimmed style
+    harness.assert_visible(".sheet-card.unowned")
+
+    harness.screenshot("final_state")

--- a/tests/ui/implementations/collection_shared_card_list_empty.py
+++ b/tests/ui/implementations/collection_shared_card_list_empty.py
@@ -1,0 +1,17 @@
+"""
+Hand-written implementation for collection_shared_card_list_empty.
+
+Verifies that a shared card list URL with nonexistent cards shows empty results.
+"""
+
+
+def steps(harness):
+    # start_page from hints navigates to /collection?cards=zzz:999&view=grid
+
+    # Wait for the page to finish loading
+    harness.wait_for_text("0 owned", timeout=10_000)
+
+    # Verify no cards are rendered in the grid
+    harness.assert_element_count(".sheet-card", 0)
+
+    harness.screenshot("final_state")

--- a/tests/ui/implementations/deck_share_button_copies_url.py
+++ b/tests/ui/implementations/deck_share_button_copies_url.py
@@ -1,0 +1,24 @@
+"""
+Hand-written implementation for deck_share_button_copies_url.
+
+Clicks the Share button on a deck page and verifies the button feedback.
+"""
+
+
+def steps(harness):
+    # start_page from hints navigates to /decks/2
+
+    # Wait for deck to load
+    harness.wait_for_text("Eldrazi Ramp")
+
+    # Grant clipboard permissions for headless browser
+    harness.page.context.grant_permissions(["clipboard-read", "clipboard-write"])
+
+    # Click the Share button
+    harness.click_by_selector("#btn-share-deck")
+
+    # Verify button text changes to "Copied!"
+    harness.wait_for_text("Copied!", timeout=5_000)
+    harness.assert_text_present("Copied!")
+
+    harness.screenshot("final_state")

--- a/tests/ui/intents/collection_shared_card_list.yaml
+++ b/tests/ui/intents/collection_shared_card_list.yaml
@@ -1,0 +1,11 @@
+# Scenario: View a shared card list via URL
+#
+# Related:
+#   issues: []
+#   pull_requests: [238]
+
+description: >
+  When I navigate to /collection?cards=fdn:188,otj:196&view=grid, I see
+  those two specific cards rendered in the grid view. The status bar shows
+  owned and missing counts. Cards I own appear normally while cards I don't
+  own appear dimmed (unowned style).

--- a/tests/ui/intents/collection_shared_card_list_empty.yaml
+++ b/tests/ui/intents/collection_shared_card_list_empty.yaml
@@ -1,0 +1,10 @@
+# Scenario: Shared card list with nonexistent cards shows empty results
+#
+# Related:
+#   issues: []
+#   pull_requests: [238]
+
+description: >
+  When I navigate to /collection?cards=zzz:999&view=grid with a
+  nonexistent set code and collector number, the page loads normally
+  but shows zero cards and a status indicating 0 results.

--- a/tests/ui/intents/deck_share_button_copies_url.yaml
+++ b/tests/ui/intents/deck_share_button_copies_url.yaml
@@ -1,0 +1,11 @@
+# Scenario: Share button on deck page copies a card list URL
+#
+# Related:
+#   issues: []
+#   pull_requests: [238]
+
+description: >
+  When I view a deck and click the "Share" button, the button text briefly
+  changes to "Copied!" indicating the URL was copied to the clipboard.
+  The Share button is visible in the deck header actions alongside Edit
+  and other action buttons.


### PR DESCRIPTION
## Summary
- Collection page accepts `?cards=set:cn,set:cn,...` URL parameter to display specific printings in grid view with owned/unowned status
- Works across instances since set codes + collector numbers are universal (Scryfall data)
- Deck builder gets a "Share" button that copies a collection URL with all deck cards
- Unowned cards appear dimmed, owned cards appear normally — instant visibility into what you have vs. don't

Example URL: `/collection?cards=ltc:4,ltc:210,ltr:264&view=grid`

## Test plan
- [x] 3 UI scenario tests: shared card list renders, empty results, deck share button — all passing
- [x] API verified: `?cards=fdn:188,otj:196` returns correct cards with owned status

🤖 Generated with [Claude Code](https://claude.com/claude-code)