### PR TITLE
Add Scryfall-style search query engine

### DIFF
--- a/mtg_collector/cli/cache_cmd.py
+++ b/mtg_collector/cli/cache_cmd.py
@@ -5,6 +5,7 @@ import sys
 
 from mtg_collector.db import get_connection, init_db
 from mtg_collector.db.models import CardRepository, PrintingRepository, SetRepository
+from mtg_collector.db.schema import rebuild_fts
 from mtg_collector.services.bulk_import import resolve_reversible_oracle_id
 from mtg_collector.services.scryfall import ScryfallAPI
 from mtg_collector.utils import get_mtgc_home
@@ -244,7 +245,11 @@ def cache_all(db_path: str):
     if non_en_count:
         print(f"  Added {non_en_count} non-English-only cards")
 
-    # Step 8: Clean up temp file
+    # Step 8: Rebuild full-text search index
+    print("Rebuilding full-text search index...")
+    rebuild_fts(conn)
+
+    # Step 9: Clean up temp file
     tmp_path.unlink(missing_ok=True)
 
     # Summary

--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -1042,6 +1042,8 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             self._api_collection_copies(params)
         elif path == "/api/collection":
             self._api_collection(params)
+        elif path == "/api/search":
+            self._api_search(params)
         elif path == "/api/wishlist":
             self._api_wishlist_list(params)
         elif path == "/api/cards/by-name":
@@ -1833,6 +1835,111 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         conn.close()
 
         self._send_json(result)
+
+    def _api_search(self, params: dict):
+        """Scryfall-style search endpoint."""
+        import time as _time
+
+        from mtg_collector.search import SearchError, compile_query, execute_search, parse_query
+
+        q = params.get("q", [""])[0]
+        if not q:
+            self._send_json([])
+            return
+
+        include_unowned = params.get("include_unowned", [""])[0]
+        status = params.get("status", ["owned"])[0]
+
+        timings = {}
+
+        # Parse
+        t0 = _time.monotonic()
+        try:
+            ast = parse_query(q)
+        except SearchError as e:
+            self._send_json({"error": str(e), "position": e.position}, 400)
+            return
+        timings["parse_ms"] = round((_time.monotonic() - t0) * 1000, 1)
+
+        # Compile
+        t0 = _time.monotonic()
+        compiled = compile_query(ast)
+        timings["compile_ms"] = round((_time.monotonic() - t0) * 1000, 1)
+
+        # Execute
+        mode = "all" if include_unowned else "collection"
+        conn = self._get_conn()
+        rows, query_timings = execute_search(conn, compiled, mode=mode, status=status)
+        timings.update(query_timings)
+
+        # Format results
+        results = []
+        for row in rows:
+            keys = row.keys()
+            card = {
+                "oracle_id": row["oracle_id"],
+                "name": row["name"],
+                "type_line": row["type_line"],
+                "mana_cost": row["mana_cost"],
+                "cmc": row["cmc"],
+                "colors": row["colors"],
+                "color_identity": row["color_identity"],
+                "set_code": row["set_code"],
+                "set_name": row["set_name"],
+                "collector_number": row["collector_number"],
+                "rarity": row["rarity"],
+                "printing_id": row["printing_id"],
+                "image_uri": row["image_uri"],
+                "artist": row["artist"],
+                "frame_effects": row["frame_effects"],
+                "border_color": row["border_color"],
+                "full_art": bool(row["full_art"]) if row["full_art"] else False,
+                "promo": bool(row["promo"]) if row["promo"] else False,
+                "promo_types": row["promo_types"],
+                "finishes": row["finishes"],
+                "layout": row["layout"] or "normal",
+                "finish": row["finish"],
+                "condition": row["condition"],
+                "status": row["status"],
+                "qty": row["qty"],
+                "acquired_at": row["acquired_at"] if "acquired_at" in keys else None,
+                "owned": row["collection_id"] is not None if include_unowned else True,
+            }
+            if row["flavor_name"]:
+                card["oracle_name"] = row["name"]
+                card["name"] = row["flavor_name"]
+            # Optional fields
+            if "collection_id" in keys and row["collection_id"]:
+                card["collection_id"] = row["collection_id"]
+            if "order_id" in keys and row["order_id"]:
+                card["order_id"] = row["order_id"]
+            if "binder_id" in keys and row["binder_id"]:
+                card["binder_id"] = row["binder_id"]
+
+            results.append(card)
+
+        # Attach prices
+        _bulk_attach_prices(conn, results)
+        conn.close()
+
+        timings["total_ms"] = round(
+            timings.get("parse_ms", 0) + timings.get("compile_ms", 0) + timings.get("query_ms", 0), 1
+        )
+        timings["row_count"] = len(results)
+
+        # Send response with timing headers
+        body = json.dumps(results).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        for key, val in timings.items():
+            self.send_header(f"X-Search-{key.replace('_', '-').title()}", str(val))
+        accept_enc = self.headers.get("Accept-Encoding", "")
+        if "gzip" in accept_enc and len(body) > 1024:
+            body = gzip.compress(body)
+            self.send_header("Content-Encoding", "gzip")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
 
     def _api_collection(self, params: dict):
         """Return aggregated collection data with optional search/sort/filter."""

--- a/mtg_collector/db/models.py
+++ b/mtg_collector/db/models.py
@@ -1,5 +1,6 @@
 """Database models and repositories."""
 
+import json
 import sqlite3
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
@@ -18,6 +19,8 @@ class Card:
     oracle_text: Optional[str] = None
     colors: List[str] = field(default_factory=list)
     color_identity: List[str] = field(default_factory=list)
+    keywords: List[str] = field(default_factory=list)
+    legalities: Optional[Dict] = None
 
 
 @dataclass
@@ -48,6 +51,18 @@ class Printing:
     artist: Optional[str] = None
     image_uri: Optional[str] = None
     raw_json: Optional[str] = None  # Full card data as JSON string (cached from bulk import)
+    power: Optional[str] = None
+    toughness: Optional[str] = None
+    loyalty: Optional[str] = None
+    layout: Optional[str] = None
+    flavor_text: Optional[str] = None
+    flavor_name: Optional[str] = None
+    watermark: Optional[str] = None
+    digital: bool = False
+    reserved: bool = False
+    reprint: bool = False
+    produced_mana: List[str] = field(default_factory=list)
+    games: List[str] = field(default_factory=list)
 
     def get_card_data(self) -> Optional[Dict]:
         """Parse and return the full card data as a dict."""
@@ -235,11 +250,15 @@ class CardRepository:
 
     def upsert(self, card: Card) -> None:
         """Insert or update a card."""
+        legalities_json = None
+        if card.legalities is not None:
+            legalities_json = json.dumps(card.legalities) if isinstance(card.legalities, dict) else card.legalities
         self.conn.execute(
             """
             INSERT INTO cards
-            (oracle_id, name, type_line, mana_cost, cmc, oracle_text, colors, color_identity)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            (oracle_id, name, type_line, mana_cost, cmc, oracle_text, colors, color_identity,
+             keywords, legalities)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(oracle_id) DO UPDATE SET
                 name = excluded.name,
                 type_line = excluded.type_line,
@@ -247,7 +266,9 @@ class CardRepository:
                 cmc = excluded.cmc,
                 oracle_text = excluded.oracle_text,
                 colors = excluded.colors,
-                color_identity = excluded.color_identity
+                color_identity = excluded.color_identity,
+                keywords = excluded.keywords,
+                legalities = excluded.legalities
             """,
             (
                 card.oracle_id,
@@ -258,7 +279,28 @@ class CardRepository:
                 card.oracle_text,
                 to_json_array(card.colors),
                 to_json_array(card.color_identity),
+                to_json_array(card.keywords),
+                legalities_json,
             ),
+        )
+
+    def _row_to_card(self, row) -> Card:
+        """Convert a database row to a Card object."""
+        legalities = None
+        leg_raw = row["legalities"] if "legalities" in row.keys() else None
+        if leg_raw:
+            legalities = json.loads(leg_raw) if isinstance(leg_raw, str) else leg_raw
+        return Card(
+            oracle_id=row["oracle_id"],
+            name=row["name"],
+            type_line=row["type_line"],
+            mana_cost=row["mana_cost"],
+            cmc=row["cmc"],
+            oracle_text=row["oracle_text"],
+            colors=parse_json_array(row["colors"]),
+            color_identity=parse_json_array(row["color_identity"]),
+            keywords=parse_json_array(row["keywords"] if "keywords" in row.keys() else None),
+            legalities=legalities,
         )
 
     def get(self, oracle_id: str) -> Optional[Card]:
@@ -269,17 +311,7 @@ class CardRepository:
         row = cursor.fetchone()
         if row is None:
             return None
-
-        return Card(
-            oracle_id=row["oracle_id"],
-            name=row["name"],
-            type_line=row["type_line"],
-            mana_cost=row["mana_cost"],
-            cmc=row["cmc"],
-            oracle_text=row["oracle_text"],
-            colors=parse_json_array(row["colors"]),
-            color_identity=parse_json_array(row["color_identity"]),
-        )
+        return self._row_to_card(row)
 
     def get_by_name(self, name: str) -> Optional[Card]:
         """Get a card by exact name."""
@@ -289,17 +321,7 @@ class CardRepository:
         row = cursor.fetchone()
         if row is None:
             return None
-
-        return Card(
-            oracle_id=row["oracle_id"],
-            name=row["name"],
-            type_line=row["type_line"],
-            mana_cost=row["mana_cost"],
-            cmc=row["cmc"],
-            oracle_text=row["oracle_text"],
-            colors=parse_json_array(row["colors"]),
-            color_identity=parse_json_array(row["color_identity"]),
-        )
+        return self._row_to_card(row)
 
     def search_by_name(self, name: str) -> Optional[Card]:
         """Search for a card by name (case-insensitive, handles DFCs).
@@ -366,18 +388,6 @@ class CardRepository:
             results.append(self._row_to_card(row))
 
         return results
-
-    def _row_to_card(self, row) -> Card:
-        return Card(
-            oracle_id=row["oracle_id"],
-            name=row["name"],
-            type_line=row["type_line"],
-            mana_cost=row["mana_cost"],
-            cmc=row["cmc"],
-            oracle_text=row["oracle_text"],
-            colors=parse_json_array(row["colors"]),
-            color_identity=parse_json_array(row["color_identity"]),
-        )
 
 
 class SetRepository:
@@ -520,8 +530,11 @@ class PrintingRepository:
             INSERT INTO printings
             (printing_id, oracle_id, set_code, collector_number, rarity,
              frame_effects, border_color, full_art, promo, promo_types,
-             finishes, artist, image_uri, raw_json)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             finishes, artist, image_uri, raw_json,
+             power, toughness, loyalty, layout, flavor_text, flavor_name,
+             watermark, digital, reserved, reprint, produced_mana, games)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(printing_id) DO UPDATE SET
                 oracle_id = excluded.oracle_id,
                 set_code = excluded.set_code,
@@ -535,7 +548,19 @@ class PrintingRepository:
                 finishes = excluded.finishes,
                 artist = excluded.artist,
                 image_uri = excluded.image_uri,
-                raw_json = excluded.raw_json
+                raw_json = excluded.raw_json,
+                power = excluded.power,
+                toughness = excluded.toughness,
+                loyalty = excluded.loyalty,
+                layout = excluded.layout,
+                flavor_text = excluded.flavor_text,
+                flavor_name = excluded.flavor_name,
+                watermark = excluded.watermark,
+                digital = excluded.digital,
+                reserved = excluded.reserved,
+                reprint = excluded.reprint,
+                produced_mana = excluded.produced_mana,
+                games = excluded.games
             """,
             (
                 p.printing_id,
@@ -552,6 +577,18 @@ class PrintingRepository:
                 p.artist,
                 p.image_uri,
                 p.raw_json,
+                p.power,
+                p.toughness,
+                p.loyalty,
+                p.layout,
+                p.flavor_text,
+                p.flavor_name,
+                p.watermark,
+                1 if p.digital else 0,
+                1 if p.reserved else 0,
+                1 if p.reprint else 0,
+                to_json_array(p.produced_mana),
+                to_json_array(p.games),
             ),
         )
 
@@ -612,12 +649,10 @@ class PrintingRepository:
         return cursor.fetchone() is not None
 
     def _row_to_printing(self, row: sqlite3.Row) -> Printing:
-        # Handle raw_json which might not exist in older databases
-        raw_json = None
-        try:
-            raw_json = row["raw_json"]
-        except (IndexError, KeyError):
-            pass
+        keys = row.keys()
+
+        def _get(key, default=None):
+            return row[key] if key in keys else default
 
         return Printing(
             printing_id=row["printing_id"],
@@ -633,7 +668,19 @@ class PrintingRepository:
             finishes=parse_json_array(row["finishes"]),
             artist=row["artist"],
             image_uri=row["image_uri"],
-            raw_json=raw_json,
+            raw_json=_get("raw_json"),
+            power=_get("power"),
+            toughness=_get("toughness"),
+            loyalty=_get("loyalty"),
+            layout=_get("layout"),
+            flavor_text=_get("flavor_text"),
+            flavor_name=_get("flavor_name"),
+            watermark=_get("watermark"),
+            digital=bool(_get("digital", 0)),
+            reserved=bool(_get("reserved", 0)),
+            reprint=bool(_get("reprint", 0)),
+            produced_mana=parse_json_array(_get("produced_mana")),
+            games=parse_json_array(_get("games")),
         )
 
 

--- a/mtg_collector/db/schema.py
+++ b/mtg_collector/db/schema.py
@@ -2,7 +2,7 @@
 
 import sqlite3
 
-SCHEMA_VERSION = 41
+SCHEMA_VERSION = 42
 
 # Tables whose data can be served from an ATTACHed shared DB via temp views.
 SHARED_TABLES = [
@@ -23,7 +23,9 @@ CREATE TABLE IF NOT EXISTS cards (
     cmc REAL,
     oracle_text TEXT,
     colors TEXT,           -- JSON array: ["R", "G"]
-    color_identity TEXT    -- JSON array
+    color_identity TEXT,   -- JSON array
+    keywords TEXT,         -- JSON array: ["Flying", "Trample"]
+    legalities TEXT        -- JSON object: {"standard": "legal", ...}
 );
 
 -- Sets (cached from Scryfall)
@@ -52,6 +54,18 @@ CREATE TABLE IF NOT EXISTS printings (
     artist TEXT,
     image_uri TEXT,
     raw_json TEXT,         -- Full Scryfall API response as JSON (for semantic search, etc.)
+    power TEXT,
+    toughness TEXT,
+    loyalty TEXT,
+    layout TEXT,
+    flavor_text TEXT,
+    flavor_name TEXT,
+    watermark TEXT,
+    digital INTEGER DEFAULT 0,
+    reserved INTEGER DEFAULT 0,
+    reprint INTEGER DEFAULT 0,
+    produced_mana TEXT,    -- JSON array
+    games TEXT,            -- JSON array: ["paper", "mtgo", "arena"]
     UNIQUE(set_code, collector_number)
 );
 
@@ -419,6 +433,13 @@ CREATE INDEX IF NOT EXISTS idx_printings_oracle ON printings(oracle_id);
 CREATE INDEX IF NOT EXISTS idx_printings_set ON printings(set_code);
 CREATE INDEX IF NOT EXISTS idx_cards_name ON cards(name);
 
+-- Full-text search on cards (external content mode — no data duplication)
+CREATE VIRTUAL TABLE IF NOT EXISTS cards_fts USING fts5(
+    name, type_line, oracle_text,
+    content='cards', content_rowid='rowid',
+    tokenize='unicode61 remove_diacritics 2'
+);
+
 -- Sealed product reference data (imported from MTGJSON AllPrintings.json)
 CREATE TABLE IF NOT EXISTS sealed_products (
     uuid TEXT PRIMARY KEY,
@@ -710,6 +731,8 @@ def init_db(conn: sqlite3.Connection, force: bool = False) -> bool:
             _migrate_v39_to_v40(conn)
         if current < 41:
             _migrate_v40_to_v41(conn)
+        if current < 42:
+            _migrate_v41_to_v42(conn)
 
     # Record schema version
     conn.execute(
@@ -2526,9 +2549,132 @@ def _migrate_v40_to_v41(conn: sqlite3.Connection):
     conn.execute("DELETE FROM deck_cards WHERE collection_id IS NULL")
 
 
+def _migrate_v41_to_v42(conn: sqlite3.Connection):
+    """Add search-related columns to cards/printings and create FTS5 table."""
+    # --- cards table: add keywords and legalities ---
+    existing = {r[1] for r in conn.execute("PRAGMA table_info(cards)").fetchall()}
+    if "keywords" not in existing:
+        conn.execute("ALTER TABLE cards ADD COLUMN keywords TEXT")
+    if "legalities" not in existing:
+        conn.execute("ALTER TABLE cards ADD COLUMN legalities TEXT")
+
+    # --- printings table: add extracted fields ---
+    existing = {r[1] for r in conn.execute("PRAGMA table_info(printings)").fetchall()}
+    new_cols = [
+        ("power", "TEXT"),
+        ("toughness", "TEXT"),
+        ("loyalty", "TEXT"),
+        ("layout", "TEXT"),
+        ("flavor_text", "TEXT"),
+        ("flavor_name", "TEXT"),
+        ("watermark", "TEXT"),
+        ("digital", "INTEGER DEFAULT 0"),
+        ("reserved", "INTEGER DEFAULT 0"),
+        ("reprint", "INTEGER DEFAULT 0"),
+        ("produced_mana", "TEXT"),
+        ("games", "TEXT"),
+    ]
+    for col_name, col_type in new_cols:
+        if col_name not in existing:
+            conn.execute(f"ALTER TABLE printings ADD COLUMN {col_name} {col_type}")
+
+    # --- Backfill from raw_json (only if the column exists) ---
+    printing_cols = {r[1] for r in conn.execute("PRAGMA table_info(printings)").fetchall()}
+    if "raw_json" in printing_cols:
+        conn.execute("""
+            UPDATE printings SET
+                power = COALESCE(
+                    json_extract(raw_json, '$.power'),
+                    json_extract(raw_json, '$.card_faces[0].power')
+                ),
+                toughness = COALESCE(
+                    json_extract(raw_json, '$.toughness'),
+                    json_extract(raw_json, '$.card_faces[0].toughness')
+                ),
+                loyalty = COALESCE(
+                    json_extract(raw_json, '$.loyalty'),
+                    json_extract(raw_json, '$.card_faces[0].loyalty')
+                ),
+                layout = json_extract(raw_json, '$.layout'),
+                flavor_text = COALESCE(
+                    json_extract(raw_json, '$.flavor_text'),
+                    json_extract(raw_json, '$.card_faces[0].flavor_text')
+                ),
+                flavor_name = json_extract(raw_json, '$.flavor_name'),
+                watermark = COALESCE(
+                    json_extract(raw_json, '$.watermark'),
+                    json_extract(raw_json, '$.card_faces[0].watermark')
+                ),
+                digital = COALESCE(json_extract(raw_json, '$.digital'), 0),
+                reserved = COALESCE(json_extract(raw_json, '$.reserved'), 0),
+                reprint = COALESCE(json_extract(raw_json, '$.reprint'), 0),
+                produced_mana = json_extract(raw_json, '$.produced_mana'),
+                games = json_extract(raw_json, '$.games')
+            WHERE raw_json IS NOT NULL
+        """)
+
+        # --- Backfill cards.legalities from first printing per oracle_id ---
+        conn.execute("""
+            UPDATE cards SET legalities = (
+                SELECT json_extract(p.raw_json, '$.legalities')
+                FROM printings p
+                WHERE p.oracle_id = cards.oracle_id AND p.raw_json IS NOT NULL
+                LIMIT 1
+            )
+            WHERE legalities IS NULL
+        """)
+
+        # --- Backfill cards.keywords from first printing per oracle_id ---
+        conn.execute("""
+            UPDATE cards SET keywords = (
+                SELECT json_extract(p.raw_json, '$.keywords')
+                FROM printings p
+                WHERE p.oracle_id = cards.oracle_id AND p.raw_json IS NOT NULL
+                LIMIT 1
+            )
+            WHERE keywords IS NULL
+        """)
+
+    # --- Create FTS5 virtual table ---
+    # Only create if cards table has required columns (may not in minimal test DBs)
+    card_cols = {r[1] for r in conn.execute("PRAGMA table_info(cards)").fetchall()}
+    if "oracle_text" in card_cols:
+        conn.execute("DROP TABLE IF EXISTS cards_fts")
+        conn.execute("""
+            CREATE VIRTUAL TABLE cards_fts USING fts5(
+                name, type_line, oracle_text,
+                content='cards', content_rowid='rowid',
+                tokenize='unicode61 remove_diacritics 2'
+            )
+        """)
+        conn.execute("INSERT INTO cards_fts(cards_fts) VALUES('rebuild')")
+
+
+def rebuild_fts(conn):
+    """Rebuild the cards_fts full-text search index.
+
+    Call after bulk imports (cache all) to sync FTS with cards table.
+    """
+    # Ensure FTS table exists
+    existing = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='cards_fts'"
+    ).fetchone()
+    if not existing:
+        conn.execute("""
+            CREATE VIRTUAL TABLE cards_fts USING fts5(
+                name, type_line, oracle_text,
+                content='cards', content_rowid='rowid',
+                tokenize='unicode61 remove_diacritics 2'
+            )
+        """)
+    conn.execute("INSERT INTO cards_fts(cards_fts) VALUES('rebuild')")
+    conn.commit()
+
+
 def drop_all_tables(conn: sqlite3.Connection):
     """Drop all tables (for testing/reset)."""
     conn.executescript("""
+        DROP TABLE IF EXISTS cards_fts;
         DROP VIEW IF EXISTS latest_sealed_prices;
         DROP VIEW IF EXISTS sealed_collection_view;
         DROP VIEW IF EXISTS collection_view;

--- a/mtg_collector/search/__init__.py
+++ b/mtg_collector/search/__init__.py
@@ -1,0 +1,37 @@
+"""Scryfall-style search query parser for the MTG collection app.
+
+Public API:
+    parse_query(q: str) -> ASTNode  -- Parse a query string into an AST
+    SearchError                     -- Raised on invalid queries
+
+AST node types:
+    AndNode, OrNode, NotNode, ComparisonNode, NameSearchNode, ExactNameNode
+"""
+
+from .ast_nodes import (
+    AndNode,
+    ASTNode,
+    ComparisonNode,
+    ExactNameNode,
+    NameSearchNode,
+    NotNode,
+    OrNode,
+)
+from .compiler import CompiledQuery, compile_query, execute_search, explain
+from .grammar import SearchError, parse_query
+
+__all__ = [
+    "parse_query",
+    "compile_query",
+    "execute_search",
+    "explain",
+    "SearchError",
+    "CompiledQuery",
+    "ASTNode",
+    "AndNode",
+    "OrNode",
+    "NotNode",
+    "ComparisonNode",
+    "NameSearchNode",
+    "ExactNameNode",
+]

--- a/mtg_collector/search/ast_nodes.py
+++ b/mtg_collector/search/ast_nodes.py
@@ -1,0 +1,53 @@
+"""AST node definitions for the search query parser."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Union
+
+
+@dataclass
+class AndNode:
+    """Implicit AND of multiple criteria."""
+
+    children: list  # list of ASTNode
+
+
+@dataclass
+class OrNode:
+    """Explicit OR between clauses."""
+
+    children: list  # list of ASTNode
+
+
+@dataclass
+class NotNode:
+    """Negation (- prefix)."""
+
+    child: object  # ASTNode
+
+
+@dataclass
+class ComparisonNode:
+    """A keyword:operator:value triple like c:r, mv>=3, t:creature."""
+
+    keyword: str  # canonical keyword name (after alias resolution)
+    operator: str  # ':', '=', '!=', '<', '>', '<=', '>='
+    value: str  # the value string (quotes stripped)
+
+
+@dataclass
+class NameSearchNode:
+    """Bare word(s) for implicit name search."""
+
+    term: str
+
+
+@dataclass
+class ExactNameNode:
+    """!"Lightning Bolt" exact name match."""
+
+    name: str
+
+
+ASTNode = Union[AndNode, OrNode, NotNode, ComparisonNode, NameSearchNode, ExactNameNode]

--- a/mtg_collector/search/compiler.py
+++ b/mtg_collector/search/compiler.py
@@ -1,0 +1,719 @@
+"""SQL compiler: walks AST nodes and produces parameterized SQL WHERE clauses."""
+
+import sys
+import time
+
+from .ast_nodes import (
+    AndNode,
+    ASTNode,
+    ComparisonNode,
+    ExactNameNode,
+    NameSearchNode,
+    NotNode,
+    OrNode,
+)
+from .keywords import COLOR_MAP, RARITY_ALIASES, RARITY_ORDER
+
+ALL_COLORS = {"W", "U", "B", "R", "G"}
+
+
+class CompiledQuery:
+    """Result of compiling an AST into SQL."""
+
+    __slots__ = ("where_sql", "params", "needs_fts", "order_by", "order_dir")
+
+    def __init__(self):
+        self.where_sql: str = "1=1"
+        self.params: list = []
+        self.needs_fts: bool = False
+        self.order_by: str | None = None
+        self.order_dir: str = "asc"
+
+
+class CompileError(Exception):
+    """Raised when the AST cannot be compiled to SQL."""
+
+
+def compile_query(ast: ASTNode) -> CompiledQuery:
+    """Compile an AST into a CompiledQuery with WHERE clause and params."""
+    result = CompiledQuery()
+    # Extract display modifiers before compiling
+    ast = _extract_modifiers(ast, result)
+    if ast is None:
+        # Only modifiers, no search criteria
+        return result
+    sql, params = _compile_node(ast, result)
+    result.where_sql = sql
+    result.params = params
+    return result
+
+
+def explain(conn, compiled: CompiledQuery, mode: str = "collection") -> list[str]:
+    """Run EXPLAIN QUERY PLAN on a compiled query. Returns plan lines."""
+    full_sql = _build_full_sql(compiled, mode)
+    rows = conn.execute(f"EXPLAIN QUERY PLAN {full_sql}", compiled.params).fetchall()
+    return [row[3] if len(row) > 3 else str(row) for row in rows]
+
+
+def execute_search(conn, compiled: CompiledQuery, mode: str = "collection",
+                   status: str = "owned") -> tuple[list, dict]:
+    """Execute a compiled search query and return (rows, timing_dict).
+
+    mode: 'collection' (owned cards) or 'all' (all printings)
+    status: 'owned' (default), 'all', or specific status
+    """
+    timings = {}
+
+    t0 = time.monotonic()
+    full_sql = _build_full_sql(compiled, mode, status)
+    timings["compile_sql_ms"] = round((time.monotonic() - t0) * 1000, 1)
+
+    t0 = time.monotonic()
+    rows = conn.execute(full_sql, compiled.params).fetchall()
+    timings["query_ms"] = round((time.monotonic() - t0) * 1000, 1)
+    timings["row_count"] = len(rows)
+
+    # Log slow queries
+    total_ms = timings["query_ms"]
+    if total_ms > 200:
+        plan = explain(conn, compiled, mode)
+        print(
+            f"[SLOW QUERY] {total_ms:.0f}ms, {len(rows)} rows\n"
+            f"  SQL: {full_sql[:200]}...\n"
+            f"  PLAN: {'; '.join(plan[:5])}",
+            file=sys.stderr,
+        )
+
+    return rows, timings
+
+
+# ---------------------------------------------------------------------------
+# Internal compilation
+# ---------------------------------------------------------------------------
+
+
+def _compile_node(node: ASTNode, ctx: CompiledQuery) -> tuple[str, list]:
+    """Recursively compile an AST node into (sql_fragment, params)."""
+    if isinstance(node, AndNode):
+        parts = [_compile_node(c, ctx) for c in node.children]
+        sql = " AND ".join(f"({p[0]})" for p in parts)
+        params = [v for p in parts for v in p[1]]
+        return sql, params
+
+    if isinstance(node, OrNode):
+        parts = [_compile_node(c, ctx) for c in node.children]
+        sql = " OR ".join(f"({p[0]})" for p in parts)
+        params = [v for p in parts for v in p[1]]
+        return sql, params
+
+    if isinstance(node, NotNode):
+        inner_sql, inner_params = _compile_node(node.child, ctx)
+        return f"NOT ({inner_sql})", inner_params
+
+    if isinstance(node, NameSearchNode):
+        return _compile_name_search(node.term, ctx)
+
+    if isinstance(node, ExactNameNode):
+        # Match the card identity (oracle_id), not just any printing with that name.
+        # This returns all printings of that specific card across sets.
+        return (
+            "card.oracle_id = (SELECT oracle_id FROM cards WHERE name = ? COLLATE NOCASE LIMIT 1)",
+            [node.name],
+        )
+
+    if isinstance(node, ComparisonNode):
+        return _compile_comparison(node, ctx)
+
+    raise CompileError(f"Unknown AST node type: {type(node)}")
+
+
+def _compile_name_search(term: str, ctx: CompiledQuery) -> tuple[str, list]:
+    """Compile a bare word name search.
+
+    Matches Scryfall's behavior: bare words match card name and flavor_name
+    only. Type line requires t:, oracle text requires o:.
+    """
+    return (
+        "(card.name LIKE ? COLLATE NOCASE"
+        " OR p.flavor_name LIKE ? COLLATE NOCASE)",
+        [f"%{term}%", f"%{term}%"],
+    )
+
+
+def _compile_comparison(node: ComparisonNode, ctx: CompiledQuery) -> tuple[str, list]:
+    """Compile a keyword comparison into SQL."""
+    kw = node.keyword
+    op = node.operator
+    val = node.value
+
+    # --- Color / Color Identity ---
+    if kw in ("color", "color_identity"):
+        return _compile_color(kw, op, val)
+
+    # --- Type ---
+    if kw == "type":
+        return _compile_text_like("card.type_line", op, val)
+
+    # --- Oracle text ---
+    if kw == "oracle":
+        return _compile_text_like("card.oracle_text", op, val)
+
+    # --- Full oracle text (same as oracle for our purposes) ---
+    if kw == "fulloracle":
+        return _compile_text_like("card.oracle_text", op, val)
+
+    # --- Mana value / CMC ---
+    if kw == "mana_value":
+        return _compile_numeric("card.cmc", op, val)
+
+    # --- Power ---
+    if kw == "power":
+        return _compile_stat("p.power", op, val)
+
+    # --- Toughness ---
+    if kw == "toughness":
+        return _compile_stat("p.toughness", op, val)
+
+    # --- Loyalty ---
+    if kw == "loyalty":
+        return _compile_stat("p.loyalty", op, val)
+
+    # --- Power + Toughness ---
+    if kw == "powtou":
+        return _compile_numeric(
+            "(CAST(p.power AS REAL) + CAST(p.toughness AS REAL))", op, val,
+            extra_where="p.power IS NOT NULL AND p.toughness IS NOT NULL "
+                        "AND p.power != '*' AND p.toughness != '*'"
+        )
+
+    # --- Rarity ---
+    if kw == "rarity":
+        return _compile_rarity(op, val)
+
+    # --- Set ---
+    if kw == "set":
+        if op in (":", "="):
+            return "p.set_code = ? COLLATE NOCASE", [val]
+        if op == "!=":
+            return "p.set_code != ? COLLATE NOCASE", [val]
+        return "1=1", []  # < > on sets doesn't make sense
+
+    # --- Set type ---
+    if kw == "set_type":
+        if op in (":", "="):
+            return "s.set_type = ? COLLATE NOCASE", [val]
+        return "1=1", []
+
+    # --- Artist ---
+    if kw == "artist":
+        return _compile_text_like("p.artist", op, val)
+
+    # --- Flavor text ---
+    if kw == "flavor":
+        return _compile_text_like("p.flavor_text", op, val)
+
+    # --- Watermark ---
+    if kw == "watermark":
+        if op in (":", "="):
+            return "p.watermark = ? COLLATE NOCASE", [val]
+        return "1=1", []
+
+    # --- Keywords (abilities) ---
+    if kw == "keyword":
+        return _compile_json_array_contains("card.keywords", val)
+
+    # --- Mana cost ---
+    if kw == "mana":
+        return _compile_text_like("card.mana_cost", op, val)
+
+    # --- Format legality ---
+    if kw == "format":
+        fmt = val.lower()
+        return "json_extract(card.legalities, '$.' || ?) = 'legal'", [fmt]
+
+    if kw == "banned":
+        fmt = val.lower()
+        return "json_extract(card.legalities, '$.' || ?) = 'banned'", [fmt]
+
+    if kw == "restricted":
+        fmt = val.lower()
+        return "json_extract(card.legalities, '$.' || ?) = 'restricted'", [fmt]
+
+    # --- is: flags ---
+    if kw == "is_flag":
+        return _compile_is_flag(val)
+
+    # --- not: flags (negate is:) ---
+    if kw == "not_flag":
+        sql, params = _compile_is_flag(val)
+        return f"NOT ({sql})", params
+
+    # --- has: flags ---
+    if kw == "has_flag":
+        return _compile_has_flag(val)
+
+    # --- Collector number ---
+    if kw == "collector_number":
+        return _compile_numeric("CAST(p.collector_number AS INTEGER)", op, val)
+
+    # --- Year ---
+    if kw == "year":
+        return _compile_numeric(
+            "CAST(SUBSTR(s.released_at, 1, 4) AS INTEGER)", op, val
+        )
+
+    # --- Layout ---
+    if kw == "layout":
+        if op in (":", "="):
+            return "p.layout = ? COLLATE NOCASE", [val]
+        return "1=1", []
+
+    # --- Produces mana ---
+    if kw == "produces":
+        colors = _resolve_color_value(val)
+        if colors == "C":
+            return _compile_json_array_contains("p.produced_mana", "C")
+        conditions = []
+        params = []
+        for c in colors:
+            conditions.append("p.produced_mana LIKE ?")
+            params.append(f'%"{c}"%')
+        if conditions:
+            return f"({' AND '.join(conditions)})", params
+        return "1=1", []
+
+    # Fallback: unsupported keyword, match nothing
+    return "1=0 /* unsupported keyword */", []
+
+
+# ---------------------------------------------------------------------------
+# Color compilation
+# ---------------------------------------------------------------------------
+
+
+def _resolve_color_value(val: str) -> str:
+    """Resolve a color value to color letters. E.g., 'rg' -> 'RG', 'azorius' -> 'WU'."""
+    lower = val.lower()
+    if lower in COLOR_MAP:
+        return COLOR_MAP[lower]
+    # Try treating each char as a color
+    result = ""
+    for ch in lower:
+        if ch in COLOR_MAP:
+            result += COLOR_MAP[ch]
+    return result if result else val.upper()
+
+
+def _compile_color(kw: str, op: str, val: str) -> tuple[str, list]:
+    """Compile color/color_identity comparisons."""
+    col = "card.colors" if kw == "color" else "card.color_identity"
+    lower_val = val.lower()
+
+    # Numeric color count: c=2, c>=3, etc.
+    if val.isdigit():
+        return _compile_numeric(f"json_array_length({col})", op, val)
+
+    # Multicolor check
+    if lower_val in ("m", "multicolor"):
+        if op in (":", "="):
+            return f"json_array_length({col}) >= 2", []
+        if op == "!=":
+            return f"json_array_length({col}) < 2", []
+        return "1=1", []
+
+    # Colorless check
+    colors = _resolve_color_value(val)
+    if colors == "C":
+        if op in (":", "="):
+            return f"({col} IS NULL OR {col} = '[]')", []
+        if op == "!=":
+            return f"({col} IS NOT NULL AND {col} != '[]')", []
+        return "1=1", []
+
+    # Multi-color value
+    color_set = set(colors)
+
+    if op in (":", ">="):
+        # Superset: card has ALL of these colors (and possibly more)
+        conditions = []
+        params = []
+        for c in color_set:
+            conditions.append(f"{col} LIKE ?")
+            params.append(f'%"{c}"%')
+        return f"({' AND '.join(conditions)})", params
+
+    if op == "=":
+        # Exact: card has exactly these colors
+        conditions = []
+        params = []
+        for c in color_set:
+            conditions.append(f"{col} LIKE ?")
+            params.append(f'%"{c}"%')
+        conditions.append(f"json_array_length({col}) = {len(color_set)}")
+        return f"({' AND '.join(conditions)})", params
+
+    if op == "<=":
+        # Subset: card only has colors from this set (no others)
+        excluded = ALL_COLORS - color_set
+        conditions = []
+        params = []
+        for c in excluded:
+            conditions.append(f"{col} NOT LIKE ?")
+            params.append(f'%"{c}"%')
+        return f"({' AND '.join(conditions)})", params
+
+    if op == "<":
+        # Strict subset: card has fewer colors, all within this set
+        excluded = ALL_COLORS - color_set
+        conditions = []
+        params = []
+        for c in excluded:
+            conditions.append(f"{col} NOT LIKE ?")
+            params.append(f'%"{c}"%')
+        conditions.append(f"json_array_length({col}) < {len(color_set)}")
+        return f"({' AND '.join(conditions)})", params
+
+    if op == ">":
+        # Strict superset: has all these colors AND more
+        conditions = []
+        params = []
+        for c in color_set:
+            conditions.append(f"{col} LIKE ?")
+            params.append(f'%"{c}"%')
+        conditions.append(f"json_array_length({col}) > {len(color_set)}")
+        return f"({' AND '.join(conditions)})", params
+
+    if op == "!=":
+        # Not this exact color set
+        inner_conditions = []
+        inner_params = []
+        for c in color_set:
+            inner_conditions.append(f"{col} LIKE ?")
+            inner_params.append(f'%"{c}"%')
+        inner_conditions.append(f"json_array_length({col}) = {len(color_set)}")
+        return f"NOT ({' AND '.join(inner_conditions)})", inner_params
+
+    return "1=1", []
+
+
+# ---------------------------------------------------------------------------
+# Text compilation
+# ---------------------------------------------------------------------------
+
+
+def _compile_text_like(column: str, op: str, val: str) -> tuple[str, list]:
+    """Compile a text field comparison using LIKE."""
+    if op in (":", ">=", "<=", ">", "<"):
+        # Contains match
+        return f"{column} LIKE ? COLLATE NOCASE", [f"%{val}%"]
+    if op == "=":
+        return f"{column} = ? COLLATE NOCASE", [val]
+    if op == "!=":
+        return f"({column} IS NULL OR {column} != ? COLLATE NOCASE)", [val]
+    return "1=1", []
+
+
+# ---------------------------------------------------------------------------
+# Numeric compilation
+# ---------------------------------------------------------------------------
+
+_SQL_OPS = {":", "=", "!=", "<", ">", "<=", ">="}
+_SAFE_OPS = {"=": "=", "!=": "!=", "<": "<", ">": ">", "<=": "<=", ">=": ">=", ":": "="}
+
+
+def _compile_numeric(expr: str, op: str, val: str,
+                     extra_where: str | None = None) -> tuple[str, list]:
+    """Compile a numeric comparison."""
+    sql_op = _SAFE_OPS.get(op, "=")
+    try:
+        num = float(val)
+    except ValueError:
+        return "1=0 /* invalid number */", []
+    parts = [f"{expr} {sql_op} ?"]
+    params: list = [num]
+    if extra_where:
+        parts.insert(0, extra_where)
+    return f"({' AND '.join(parts)})", params
+
+
+def _compile_stat(column: str, op: str, val: str) -> tuple[str, list]:
+    """Compile power/toughness/loyalty with * handling."""
+    if val == "*":
+        if op in (":", "="):
+            return f"{column} = '*'", []
+        if op == "!=":
+            return f"{column} != '*'", []
+        return "1=1", []
+    return _compile_numeric(
+        f"CAST({column} AS REAL)", op, val,
+        extra_where=f"{column} IS NOT NULL AND {column} != '*'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rarity compilation
+# ---------------------------------------------------------------------------
+
+
+def _compile_rarity(op: str, val: str) -> tuple[str, list]:
+    """Compile rarity comparisons with ordinal support."""
+    lower_val = val.lower()
+
+    if op in (":", "="):
+        rarity_name = RARITY_ALIASES.get(lower_val, lower_val)
+        return "p.rarity = ?", [rarity_name]
+
+    if op == "!=":
+        rarity_name = RARITY_ALIASES.get(lower_val, lower_val)
+        return "p.rarity != ?", [rarity_name]
+
+    # Ordinal comparisons
+    ordinal = RARITY_ORDER.get(lower_val)
+    if ordinal is None:
+        return "1=0 /* unknown rarity */", []
+
+    rarity_expr = (
+        "CASE p.rarity "
+        "WHEN 'common' THEN 0 "
+        "WHEN 'uncommon' THEN 1 "
+        "WHEN 'rare' THEN 2 "
+        "WHEN 'mythic' THEN 3 "
+        "WHEN 'special' THEN 4 "
+        "WHEN 'bonus' THEN 5 "
+        "ELSE -1 END"
+    )
+    sql_op = _SAFE_OPS.get(op, "=")
+    return f"({rarity_expr}) {sql_op} ?", [ordinal]
+
+
+# ---------------------------------------------------------------------------
+# JSON array helpers
+# ---------------------------------------------------------------------------
+
+
+def _compile_json_array_contains(column: str, val: str) -> tuple[str, list]:
+    """Check if a JSON array column contains a value (case-insensitive)."""
+    return f"{column} LIKE ? COLLATE NOCASE", [f'%"{val}"%']
+
+
+# ---------------------------------------------------------------------------
+# is: / has: flags
+# ---------------------------------------------------------------------------
+
+_IS_FLAG_MAP = {
+    # Printing properties
+    "foil": "p.finishes LIKE '%foil%'",
+    "nonfoil": "p.finishes LIKE '%nonfoil%'",
+    "etched": "p.finishes LIKE '%etched%'",
+    "fullart": "p.full_art = 1",
+    "full": "p.full_art = 1",
+    "promo": "p.promo = 1",
+    "reprint": "p.reprint = 1",
+    "firstprint": "p.reprint = 0",
+    "reserved": "p.reserved = 1",
+    "digital": "p.digital = 1",
+    # Border
+    "borderless": "p.border_color = 'borderless'",
+    # Frame effects
+    "showcase": "p.frame_effects LIKE '%showcase%'",
+    "extendedart": "p.frame_effects LIKE '%extendedart%'",
+    "colorshifted": "p.frame_effects LIKE '%colorshifted%'",
+    "companion": "p.frame_effects LIKE '%companion%'",
+    "devoid": "p.frame_effects LIKE '%devoid%'",
+    "snow": "p.frame_effects LIKE '%snow%'",
+    "lesson": "p.frame_effects LIKE '%lesson%'",
+    "miracle": "p.frame_effects LIKE '%miracle%'",
+    # Layout flags
+    "split": "p.layout = 'split'",
+    "flip": "p.layout = 'flip'",
+    "transform": "p.layout IN ('transform', 'double_faced_token')",
+    "tdfc": "p.layout IN ('transform', 'double_faced_token')",
+    "mdfc": "p.layout = 'modal_dfc'",
+    "meld": "p.layout = 'meld'",
+    "dfc": "p.layout IN ('transform', 'modal_dfc', 'double_faced_token', 'art_series', 'reversible_card')",
+    "leveler": "p.layout = 'leveler'",
+    "adventure": "p.layout = 'adventure'",
+    "saga": "card.type_line LIKE '%Saga%'",
+    "class": "p.layout = 'class'",
+    "case": "p.layout = 'case'",
+    "battle": "p.layout = 'battle'",
+    "mutate": "p.layout = 'mutate'",
+    "prototype": "p.layout = 'prototype'",
+    # Game availability
+    "paper": "p.games LIKE '%paper%'",
+    "mtgo": "p.games LIKE '%mtgo%'",
+    "arena": "p.games LIKE '%arena%'",
+    # Card type flags
+    "spell": "card.type_line NOT LIKE '%Land%'",
+    "permanent": "card.type_line NOT LIKE '%Instant%' AND card.type_line NOT LIKE '%Sorcery%'",
+    "historic": "(card.type_line LIKE '%Legendary%' OR card.type_line LIKE '%Artifact%' OR card.type_line LIKE '%Saga%')",
+    "vanilla": "(card.type_line LIKE '%Creature%' AND (card.oracle_text IS NULL OR card.oracle_text = ''))",
+    "commander": "(card.type_line LIKE '%Legendary%' AND card.type_line LIKE '%Creature%')",
+    "land": "card.type_line LIKE '%Land%'",
+    "creature": "card.type_line LIKE '%Creature%'",
+    # Security stamp
+    "acorn": "p.frame_effects LIKE '%acorn%' OR json_extract(p.raw_json, '$.security_stamp') = 'acorn'",
+}
+
+_HAS_FLAG_MAP = {
+    "watermark": "p.watermark IS NOT NULL AND p.watermark != ''",
+    "flavor": "p.flavor_text IS NOT NULL AND p.flavor_text != ''",
+    "power": "p.power IS NOT NULL",
+    "toughness": "p.toughness IS NOT NULL",
+    "loyalty": "p.loyalty IS NOT NULL",
+    "pt": "p.power IS NOT NULL AND p.toughness IS NOT NULL",
+    "indicator": "json_extract(p.raw_json, '$.color_indicator') IS NOT NULL",
+}
+
+
+def _compile_is_flag(val: str) -> tuple[str, list]:
+    """Compile is:X flags."""
+    lower = val.lower()
+    sql = _IS_FLAG_MAP.get(lower)
+    if sql:
+        return sql, []
+    return "1=0 /* unknown is: flag */", []
+
+
+def _compile_has_flag(val: str) -> tuple[str, list]:
+    """Compile has:X flags."""
+    lower = val.lower()
+    sql = _HAS_FLAG_MAP.get(lower)
+    if sql:
+        return sql, []
+    return "1=0 /* unknown has: flag */", []
+
+
+# ---------------------------------------------------------------------------
+# Display modifier extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_modifiers(ast: ASTNode, ctx: CompiledQuery) -> ASTNode | None:
+    """Extract order:/direction: modifiers from the AST (mutates ctx).
+
+    Returns the AST with modifiers removed, or None if nothing remains.
+    """
+    if isinstance(ast, ComparisonNode):
+        if ast.keyword == "order":
+            ctx.order_by = ast.value.lower()
+            return None
+        if ast.keyword == "direction":
+            ctx.order_dir = ast.value.lower()
+            return None
+        return ast
+
+    if isinstance(ast, AndNode):
+        remaining = []
+        for child in ast.children:
+            result = _extract_modifiers(child, ctx)
+            if result is not None:
+                remaining.append(result)
+        if not remaining:
+            return None
+        if len(remaining) == 1:
+            return remaining[0]
+        return AndNode(children=remaining)
+
+    return ast
+
+
+# ---------------------------------------------------------------------------
+# Full SQL generation
+# ---------------------------------------------------------------------------
+
+_SORT_MAP = {
+    "name": "card.name",
+    "cmc": "card.cmc",
+    "mv": "card.cmc",
+    "rarity": (
+        "CASE p.rarity "
+        "WHEN 'common' THEN 0 WHEN 'uncommon' THEN 1 "
+        "WHEN 'rare' THEN 2 WHEN 'mythic' THEN 3 ELSE 4 END"
+    ),
+    "set": "p.set_code",
+    "color": "card.color_identity",
+    "power": "CAST(p.power AS REAL)",
+    "toughness": "CAST(p.toughness AS REAL)",
+    "artist": "p.artist",
+    "collector_number": "CAST(p.collector_number AS INTEGER)",
+}
+
+
+def _build_full_sql(compiled: CompiledQuery, mode: str = "collection",
+                    status: str = "owned") -> str:
+    """Build the complete SQL statement from a compiled query."""
+    fts_join = ""
+    if compiled.needs_fts:
+        fts_join = "JOIN cards_fts ON cards_fts.rowid = card.rowid"
+
+    order_col = _SORT_MAP.get(compiled.order_by, "card.name") if compiled.order_by else "card.name"
+    direction = "DESC" if compiled.order_dir == "desc" else "ASC"
+    order_clause = f"ORDER BY {order_col} {direction}"
+
+    if mode == "collection":
+        status_clause = "c.status IN ('owned', 'ordered')"
+        if status == "all":
+            status_clause = "1=1"
+        elif status != "owned":
+            status_clause = f"c.status = '{status}'"
+
+        return f"""
+            SELECT
+                card.name, card.oracle_id, card.type_line, card.mana_cost,
+                card.cmc, card.oracle_text, card.colors, card.color_identity,
+                card.keywords AS card_keywords, card.legalities,
+                p.printing_id, p.set_code, p.collector_number, p.rarity,
+                p.frame_effects, p.border_color, p.full_art, p.promo,
+                p.promo_types, p.finishes, p.artist, p.image_uri,
+                p.power, p.toughness, p.loyalty, p.layout,
+                p.flavor_text, p.flavor_name, p.watermark,
+                p.digital, p.reserved, p.reprint, p.games,
+                s.set_name, s.set_type, s.released_at,
+                c.id AS collection_id, c.finish, c.condition, c.language,
+                c.purchase_price, c.acquired_at, c.source, c.status,
+                c.notes, c.tags, c.tradelist, c.sale_price,
+                c.binder_id, c.batch_id, c.order_id,
+                COUNT(DISTINCT c.id) AS qty
+            FROM collection c
+            JOIN printings p ON c.printing_id = p.printing_id
+            JOIN cards card ON p.oracle_id = card.oracle_id
+            JOIN sets s ON p.set_code = s.set_code
+            {fts_join}
+            WHERE {status_clause}
+              AND ({compiled.where_sql})
+            GROUP BY p.printing_id, c.finish, c.condition, c.status
+            {order_clause}
+        """
+    else:
+        # All cards mode
+        return f"""
+            SELECT
+                card.name, card.oracle_id, card.type_line, card.mana_cost,
+                card.cmc, card.oracle_text, card.colors, card.color_identity,
+                card.keywords AS card_keywords, card.legalities,
+                p.printing_id, p.set_code, p.collector_number, p.rarity,
+                p.frame_effects, p.border_color, p.full_art, p.promo,
+                p.promo_types, p.finishes, p.artist, p.image_uri,
+                p.power, p.toughness, p.loyalty, p.layout,
+                p.flavor_text, p.flavor_name, p.watermark,
+                p.digital, p.reserved, p.reprint, p.games,
+                s.set_name, s.set_type, s.released_at,
+                NULL AS collection_id, NULL AS finish, NULL AS condition,
+                NULL AS language, NULL AS purchase_price, NULL AS acquired_at,
+                NULL AS source, NULL AS status, NULL AS notes, NULL AS tags,
+                NULL AS tradelist, NULL AS sale_price,
+                NULL AS binder_id, NULL AS batch_id, NULL AS order_id,
+                0 AS qty
+            FROM printings p
+            JOIN cards card ON p.oracle_id = card.oracle_id
+            JOIN sets s ON p.set_code = s.set_code
+            {fts_join}
+            WHERE p.digital = 0
+              AND p.layout NOT IN ('token', 'art_series', 'planar', 'emblem',
+                                   'vanguard', 'scheme', 'double_faced_token')
+              AND s.set_type NOT IN ('funny', 'memorabilia')
+              AND ({compiled.where_sql})
+            GROUP BY p.printing_id
+            {order_clause}
+        """

--- a/mtg_collector/search/grammar.py
+++ b/mtg_collector/search/grammar.py
@@ -1,0 +1,162 @@
+"""Tokenizer and parser for Scryfall-style search queries.
+
+Uses a hand-rolled regex tokenizer + recursive descent parser (in transformer.py)
+because the grammar has context-sensitive aspects that make a pure CFG awkward:
+- keyword detection depends on adjacency to operators (no space before : or =)
+- `or` is a keyword between clauses but a bare word otherwise
+- `-` prefix for negation must not conflict with hyphens in card names
+"""
+
+from __future__ import annotations
+
+import re
+
+# Pre-compiled regex for tokenization.
+# Order matters: more specific patterns must come before more general ones.
+# The NEGATE pattern handles `-` prefix before keyword/word patterns.
+_TOKEN_PATTERNS = [
+    ("LPAREN", re.compile(r"\(")),
+    ("RPAREN", re.compile(r"\)")),
+    ("EXACT_NAME", re.compile(r'!"([^"]*)"')),
+    ("EXACT_NAME_UNQUOTED", re.compile(r"!(\S+)")),
+    # Negated keyword with comparison op: -word(!=|<=|>=|<|>|=)
+    ("NEG_KEYWORD_COMPARE", re.compile(r"-([a-zA-Z][a-zA-Z0-9_]*)(!=|<=|>=|<|>|=)")),
+    # Negated keyword with colon: -word:
+    ("NEG_KEYWORD_COLON", re.compile(r"-([a-zA-Z][a-zA-Z0-9_]*):")),
+    # keyword with comparison op: word(!=|<=|>=|<|>|=)
+    ("KEYWORD_COMPARE", re.compile(r"([a-zA-Z][a-zA-Z0-9_]*)(!=|<=|>=|<|>|=)")),
+    # keyword with colon: word:
+    ("KEYWORD_COLON", re.compile(r"([a-zA-Z][a-zA-Z0-9_]*):")),
+    ("QUOTED_STRING", re.compile(r'"([^"]*)"')),
+    # Negation prefix followed by a parenthesized group or word
+    ("NEGATE", re.compile(r"-(?=[\(\"]|[a-zA-Z])")),
+    # bare word: everything else up to whitespace or parens
+    ("WORD", re.compile(r"[^\s\(\)]+")),
+]
+
+
+class SearchError(Exception):
+    """Error during search query parsing."""
+
+    def __init__(self, message: str, position: int = -1):
+        super().__init__(message)
+        self.position = position
+
+
+def tokenize(query: str) -> list[tuple[str, str, str, int]]:
+    """Tokenize a search query into (type, key_or_word, operator, value, position) tuples.
+
+    Returns list of tuples: (token_type, raw_text, extra_data, position)
+    """
+    tokens = []
+    pos = 0
+    length = len(query)
+
+    while pos < length:
+        # Skip whitespace
+        if query[pos].isspace():
+            pos += 1
+            continue
+
+        matched = False
+        for name, pattern in _TOKEN_PATTERNS:
+            m = pattern.match(query, pos)
+            if m:
+                if name == "LPAREN":
+                    tokens.append(("LPAREN", "(", "", pos))
+                elif name == "RPAREN":
+                    tokens.append(("RPAREN", ")", "", pos))
+                elif name == "EXACT_NAME":
+                    tokens.append(("EXACT_NAME", m.group(1), "", pos))
+                elif name == "EXACT_NAME_UNQUOTED":
+                    tokens.append(("EXACT_NAME", m.group(1), "", pos))
+                elif name in ("NEG_KEYWORD_COMPARE", "NEG_KEYWORD_COLON"):
+                    # Negated keyword: emit NEGATE + KEYWORD_EXPR + VALUE
+                    tokens.append(("NEGATE", "-", "", pos))
+                    keyword = m.group(1)
+                    op = m.group(2) if name == "NEG_KEYWORD_COMPARE" else ":"
+                    val_pos = m.end()
+                    val, val_end = _read_value(query, val_pos)
+                    tokens.append(("KEYWORD_EXPR", keyword, op, pos + 1))
+                    tokens.append(("VALUE", val, "", val_pos))
+                    pos = val_end
+                    matched = True
+                    break
+                elif name == "KEYWORD_COMPARE":
+                    keyword = m.group(1)
+                    op = m.group(2)
+                    # Now read the value
+                    val_pos = m.end()
+                    val, val_end = _read_value(query, val_pos)
+                    tokens.append(("KEYWORD_EXPR", keyword, op, pos))
+                    tokens.append(("VALUE", val, "", val_pos))
+                    pos = val_end
+                    matched = True
+                    break
+                elif name == "KEYWORD_COLON":
+                    keyword = m.group(1)
+                    # Now read the value
+                    val_pos = m.end()
+                    val, val_end = _read_value(query, val_pos)
+                    tokens.append(("KEYWORD_EXPR", keyword, ":", pos))
+                    tokens.append(("VALUE", val, "", val_pos))
+                    pos = val_end
+                    matched = True
+                    break
+                elif name == "NEGATE":
+                    tokens.append(("NEGATE", "-", "", pos))
+                elif name == "QUOTED_STRING":
+                    # Bare quoted string (not after keyword) -- treat as name search
+                    tokens.append(("WORD", m.group(1), "", pos))
+                elif name == "WORD":
+                    tokens.append(("WORD", m.group(0), "", pos))
+
+                pos = m.end()
+                matched = True
+                break
+
+        if not matched:
+            raise SearchError(f"Unexpected character '{query[pos]}'", position=pos)
+
+    return tokens
+
+
+def _read_value(query: str, pos: int) -> tuple[str, int]:
+    """Read a value starting at pos. Handles quoted strings and unquoted tokens."""
+    if pos >= len(query):
+        return ("", pos)
+
+    if query[pos] == '"':
+        # Quoted value
+        end = query.find('"', pos + 1)
+        if end == -1:
+            raise SearchError("Unterminated quoted string", position=pos)
+        return (query[pos + 1 : end], end + 1)
+    else:
+        # Unquoted value: read until whitespace or ) or end
+        end = pos
+        while end < len(query) and query[end] not in (" ", "\t", "\n", "\r", ")"):
+            end += 1
+        return (query[pos:end], end)
+
+
+def parse_query(query: str):
+    """Parse a Scryfall-style search query string into an AST.
+
+    Returns an ASTNode.
+    """
+    from .transformer import build_ast
+
+    query = query.strip()
+    if not query:
+        raise SearchError("Empty search query")
+
+    try:
+        tokens = tokenize(query)
+    except SearchError:
+        raise
+
+    try:
+        return build_ast(tokens)
+    except SearchError:
+        raise

--- a/mtg_collector/search/keywords.py
+++ b/mtg_collector/search/keywords.py
@@ -1,0 +1,162 @@
+"""Keyword alias registry, color maps, rarity ordering for the search engine."""
+
+# Maps all Scryfall keyword prefixes to canonical internal names
+KEYWORD_ALIASES = {
+    # Colors
+    "c": "color",
+    "color": "color",
+    "colours": "color",
+    "id": "color_identity",
+    "identity": "color_identity",
+    "ci": "color_identity",
+    # Types
+    "t": "type",
+    "type": "type",
+    # Text
+    "o": "oracle",
+    "oracle": "oracle",
+    "fo": "fulloracle",
+    "fulloracle": "fulloracle",
+    # Mana
+    "m": "mana",
+    "mana": "mana",
+    "mv": "mana_value",
+    "manavalue": "mana_value",
+    "cmc": "mana_value",
+    # Stats
+    "pow": "power",
+    "power": "power",
+    "tou": "toughness",
+    "tough": "toughness",
+    "toughness": "toughness",
+    "pt": "powtou",
+    "powtou": "powtou",
+    "loy": "loyalty",
+    "loyalty": "loyalty",
+    # Rarity
+    "r": "rarity",
+    "rarity": "rarity",
+    # Set/edition
+    "s": "set",
+    "set": "set",
+    "e": "set",
+    "edition": "set",
+    "b": "block",
+    "block": "block",
+    "st": "set_type",
+    "cn": "collector_number",
+    "number": "collector_number",
+    # People/text
+    "a": "artist",
+    "artist": "artist",
+    "ft": "flavor",
+    "flavor": "flavor",
+    "wm": "watermark",
+    "watermark": "watermark",
+    # Keywords/abilities
+    "kw": "keyword",
+    "keyword": "keyword",
+    # Format legality
+    "f": "format",
+    "format": "format",
+    "banned": "banned",
+    "restricted": "restricted",
+    # Flags
+    "is": "is_flag",
+    "not": "not_flag",
+    "has": "has_flag",
+    # Mana production
+    "produces": "produces",
+    # Dates
+    "year": "year",
+    "date": "date",
+    # Display modifiers (extracted, not compiled to SQL)
+    "order": "order",
+    "direction": "direction",
+    "unique": "unique",
+}
+
+# Color values: single chars, full names, guild/shard/wedge names -> color letter strings
+COLOR_MAP = {
+    # Single chars
+    "w": "W",
+    "u": "U",
+    "b": "B",
+    "r": "R",
+    "g": "G",
+    "c": "C",
+    "m": "M",
+    # Full names
+    "white": "W",
+    "blue": "U",
+    "black": "B",
+    "red": "R",
+    "green": "G",
+    "colorless": "C",
+    "multicolor": "M",
+    # Guilds (2-color)
+    "azorius": "WU",
+    "dimir": "UB",
+    "rakdos": "BR",
+    "gruul": "RG",
+    "selesnya": "WG",
+    "orzhov": "WB",
+    "izzet": "UR",
+    "golgari": "BG",
+    "boros": "WR",
+    "simic": "UG",
+    # Shards (3-color)
+    "bant": "WUG",
+    "esper": "WUB",
+    "grixis": "UBR",
+    "jund": "BRG",
+    "naya": "WRG",
+    # Wedges (3-color)
+    "abzan": "WBG",
+    "jeskai": "WUR",
+    "sultai": "UBG",
+    "mardu": "WBR",
+    "temur": "URG",
+    # Colleges
+    "silverquill": "WB",
+    "prismari": "UR",
+    "witherbloom": "BG",
+    "lorehold": "WR",
+    "quandrix": "UG",
+    # 4-color
+    "chaos": "UBRG",
+    "aggression": "WBRG",
+    "altruism": "WURG",
+    "growth": "WUBG",
+    "artifice": "WUBR",
+}
+
+# Rarity ordering for comparison operators
+RARITY_ORDER = {
+    "common": 0,
+    "c": 0,
+    "uncommon": 1,
+    "u": 1,
+    "rare": 2,
+    "r": 2,
+    "mythic": 3,
+    "m": 3,
+    "special": 4,
+    "s": 4,
+    "bonus": 5,
+}
+
+# Rarity aliases for = matching
+RARITY_ALIASES = {
+    "c": "common",
+    "u": "uncommon",
+    "r": "rare",
+    "m": "mythic",
+    "s": "special",
+    "common": "common",
+    "uncommon": "uncommon",
+    "rare": "rare",
+    "mythic": "mythic",
+    "special": "special",
+    "bonus": "bonus",
+}

--- a/mtg_collector/search/transformer.py
+++ b/mtg_collector/search/transformer.py
@@ -1,0 +1,139 @@
+"""Transforms tokenized search queries into AST nodes.
+
+Uses a recursive descent parser over the token stream to handle
+operator precedence: OR < AND (implicit) < NOT < atoms.
+"""
+
+from __future__ import annotations
+
+from .ast_nodes import (
+    AndNode,
+    ComparisonNode,
+    ExactNameNode,
+    NameSearchNode,
+    NotNode,
+    OrNode,
+)
+from .grammar import SearchError
+from .keywords import KEYWORD_ALIASES
+
+
+def build_ast(tokens: list[tuple[str, str, str, int]]):
+    """Build an AST from a token list using recursive descent parsing."""
+    parser = _Parser(tokens)
+    result = parser.parse_or()
+
+    if parser.pos < len(parser.tokens):
+        tok = parser.tokens[parser.pos]
+        raise SearchError(f"Unexpected token: {tok[1]}", position=tok[3])
+
+    return result
+
+
+class _Parser:
+    """Recursive descent parser over the token stream."""
+
+    def __init__(self, tokens: list[tuple[str, str, str, int]]):
+        self.tokens = tokens
+        self.pos = 0
+
+    def peek(self) -> tuple[str, str, str, int] | None:
+        if self.pos < len(self.tokens):
+            return self.tokens[self.pos]
+        return None
+
+    def advance(self) -> tuple[str, str, str, int]:
+        tok = self.tokens[self.pos]
+        self.pos += 1
+        return tok
+
+    def parse_or(self):
+        """Parse OR expressions (lowest precedence)."""
+        left = self.parse_and()
+
+        while self._is_or():
+            self.advance()  # consume 'or'
+            right = self.parse_and()
+            if isinstance(left, OrNode):
+                left.children.append(right)
+            else:
+                left = OrNode(children=[left, right])
+
+        return left
+
+    def _is_or(self) -> bool:
+        """Check if current token is the OR keyword."""
+        tok = self.peek()
+        return tok is not None and tok[0] == "WORD" and tok[1].lower() == "or"
+
+    def parse_and(self):
+        """Parse AND expressions (implicit, by adjacency)."""
+        children = [self.parse_atom()]
+
+        while self.peek() is not None and not self._is_or() and self.peek()[0] != "RPAREN":
+            children.append(self.parse_atom())
+
+        if len(children) == 1:
+            return children[0]
+        return AndNode(children=children)
+
+    def parse_atom(self):
+        """Parse a single atom: negation, grouped expr, exact name, keyword expr, or bare word."""
+        tok = self.peek()
+        if tok is None:
+            raise SearchError("Unexpected end of query")
+
+        # NEGATE token from tokenizer (handles -keyword:val, -(group), -word)
+        if tok[0] == "NEGATE":
+            self.advance()  # consume the -
+            child = self.parse_atom()
+            return NotNode(child=child)
+
+        # Grouped expression
+        if tok[0] == "LPAREN":
+            self.advance()  # consume (
+            inner = self.parse_or()
+            rparen = self.peek()
+            if rparen is None or rparen[0] != "RPAREN":
+                raise SearchError("Missing closing parenthesis", position=tok[3])
+            self.advance()  # consume )
+            return inner
+
+        # Exact name
+        if tok[0] == "EXACT_NAME":
+            self.advance()
+            return ExactNameNode(name=tok[1])
+
+        # Keyword expression
+        if tok[0] == "KEYWORD_EXPR":
+            self.advance()
+            keyword_raw = tok[1]
+            op = tok[2]
+            # Next token should be VALUE
+            val_tok = self.peek()
+            if val_tok is None or val_tok[0] != "VALUE":
+                raise SearchError(f"Expected value after {keyword_raw}{op}", position=tok[3])
+            self.advance()
+            keyword = _resolve_keyword(keyword_raw, tok[3])
+            return ComparisonNode(keyword=keyword, operator=op, value=val_tok[1])
+
+        # Bare word
+        if tok[0] == "WORD":
+            self.advance()
+            return NameSearchNode(term=tok[1])
+
+        # VALUE token appearing without a keyword -- treat as bare word
+        if tok[0] == "VALUE":
+            self.advance()
+            return NameSearchNode(term=tok[1])
+
+        raise SearchError(f"Unexpected token: {tok[1]}", position=tok[3])
+
+
+def _resolve_keyword(raw: str, position: int) -> str:
+    """Resolve a keyword alias to its canonical name. Raises SearchError if unknown."""
+    lower = raw.lower()
+    canonical = KEYWORD_ALIASES.get(lower)
+    if canonical is None:
+        raise SearchError(f"Unknown keyword: '{raw}'", position=position)
+    return canonical

--- a/mtg_collector/services/bulk_import.py
+++ b/mtg_collector/services/bulk_import.py
@@ -219,6 +219,8 @@ class ScryfallBulkClient:
             oracle_text=_field("oracle_text"),
             colors=_field("colors", []),
             color_identity=_field("color_identity", []),
+            keywords=data.get("keywords", []),
+            legalities=data.get("legalities"),
         )
 
     def to_set_model(self, data: Dict) -> Set:
@@ -247,6 +249,15 @@ class ScryfallBulkClient:
 
         raw_json = json.dumps(data)
 
+        faces = data.get("card_faces", [])
+        face0 = faces[0] if faces else {}
+
+        def _pfield(key, default=None):
+            val = data.get(key)
+            if val is not None:
+                return val
+            return face0.get(key, default)
+
         return Printing(
             printing_id=data["id"],
             oracle_id=data["oracle_id"],
@@ -262,6 +273,18 @@ class ScryfallBulkClient:
             artist=data.get("artist"),
             image_uri=image_uri,
             raw_json=raw_json,
+            power=_pfield("power"),
+            toughness=_pfield("toughness"),
+            loyalty=_pfield("loyalty"),
+            layout=data.get("layout"),
+            flavor_text=_pfield("flavor_text"),
+            flavor_name=data.get("flavor_name"),
+            watermark=_pfield("watermark"),
+            digital=data.get("digital", False),
+            reserved=data.get("reserved", False),
+            reprint=data.get("reprint", False),
+            produced_mana=data.get("produced_mana", []),
+            games=data.get("games", []),
         )
 
 

--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -96,7 +96,12 @@ button.secondary.active { background: #0f3460; border-color: #e94560; }
   position: relative;
 }
 
-#search-input { width: 220px; }
+#search-input { width: 320px; }
+#search-input.advanced-active { border-color: #7c3aed; box-shadow: 0 0 0 1px #7c3aed33; }
+#search-error { color: #e94560; font-size: 11px; position: absolute; top: 100%; left: 0; white-space: nowrap; z-index: 10; }
+.search-wrap { position: relative; display: inline-block; }
+.search-mode-badge { display: none; font-size: 9px; color: #7c3aed; position: absolute; top: -10px; right: 2px; pointer-events: none; }
+.search-mode-badge.visible { display: block; }
 #oracle-search-input { width: 220px; }
 
 /* Icon buttons in view toggle */
@@ -1236,6 +1241,7 @@ tr.ordered td:first-child { border-left: 3px solid #f0a030; }
 
 @media (max-width: 768px) {
   #search-input, #oracle-search-input { width: 100%; order: -1; }
+  .search-wrap { width: 100%; order: -1; }
   .controls { flex-wrap: wrap; }
   .sidebar { width: 280px; left: -300px; }
   .wishlist-panel { width: 280px; right: -300px; }
@@ -1248,7 +1254,11 @@ tr.ordered td:first-child { border-left: 3px solid #f0a030; }
 <header>
   <h1><a href="/" style="color:inherit;text-decoration:none">Collection</a></h1>
   <div class="controls">
-    <input type="text" id="search-input" placeholder="Search cards...">
+    <div class="search-wrap">
+      <input type="text" id="search-input" placeholder="Search cards... (e.g. c:r t:instant mv&lt;=2)">
+      <span class="search-mode-badge" id="search-mode-badge">scryfall syntax</span>
+      <div id="search-error"></div>
+    </div>
     <input type="text" id="oracle-search-input" placeholder="Oracle text...">
     <div class="view-toggle-group" id="view-toggle-group">
       <button class="secondary" id="view-table-btn" title="Table view"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><rect x="1" y="2" width="14" height="2" rx=".5"/><rect x="1" y="7" width="14" height="2" rx=".5"/><rect x="1" y="12" width="14" height="2" rx=".5"/></svg></button>
@@ -1548,6 +1558,24 @@ let lastSelectedIdx = null;
 let wishlistMap = {};  // wishlist_id → {id, oracle_id, printing_id, name, set_code, collector_number, ...}
 let wishlistByPrinting = {};  // printing_id → entry (only for printing-specific wants)
 let wishlistByOracle = {};  // oracle_id → entry (only for card-level wants where printing_id is null)
+const searchModeBadge = document.getElementById('search-mode-badge');
+const searchErrorEl = document.getElementById('search-error');
+
+// Detect Scryfall-style advanced query syntax
+function isAdvancedQuery(q) {
+  if (!q) return false;
+  // keyword:value patterns (c:r, t:instant, o:"text", etc.)
+  if (/[a-z]+[:=!<>]/.test(q)) return true;
+  // Exact name match: !"Lightning Bolt"
+  if (/^!"/.test(q)) return true;
+  // Explicit OR operator
+  if (/\bor\b/i.test(q)) return true;
+  // Parenthesized grouping
+  if (/[()]/.test(q)) return true;
+  // Leading negation: -word
+  if (/^-[a-z]/.test(q)) return true;
+  return false;
+}
 
 function _addWishlistEntry(e) {
   wishlistMap[e.id] = e;
@@ -3289,10 +3317,41 @@ function updateStatusText() {
 
 async function fetchCollection() {
   updateUnownedBtn();
-  const params = getFetchParams();
+  const q = searchInput.value.trim();
+  const advanced = isAdvancedQuery(q);
+
+  // Update visual indicators
+  searchInput.classList.toggle('advanced-active', advanced);
+  searchModeBadge.classList.toggle('visible', advanced);
+  searchErrorEl.textContent = '';
+
   statusEl.textContent = 'Loading...';
-  const res = await fetch(`/api/collection?${params}`);
-  allCardsUnfiltered = await res.json();
+
+  let res;
+  if (advanced && q) {
+    // Use Scryfall-style search endpoint
+    const params = new URLSearchParams();
+    params.set('q', q);
+    if (includeUnowned && hasAnyFilter()) params.set('include_unowned', includeUnowned);
+    const dispositionStatuses = ['sold', 'traded', 'gifted', 'lost'];
+    const hasDisposition = dispositionStatuses.some(s => document.getElementById('sf-' + s)?.checked);
+    if (hasDisposition) params.set('status', 'all');
+    res = await fetch(`/api/search?${params}`);
+    const data = await res.json();
+    if (!res.ok) {
+      searchErrorEl.textContent = data.error || 'Search error';
+      allCardsUnfiltered = [];
+    } else {
+      searchErrorEl.textContent = '';
+      allCardsUnfiltered = data;
+    }
+  } else {
+    // Use standard collection endpoint
+    const params = getFetchParams();
+    res = await fetch(`/api/collection?${params}`);
+    allCardsUnfiltered = await res.json();
+  }
+
   selectedCards.clear();
   lastSelectedIdx = null;
   updateSelectionBar();

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 dependencies = [
     "anthropic>=0.18.0",
     "beautifulsoup4>=4.12.0",
+    "lark>=1.1",
     "numpy<2",
     "onnxruntime>=1.18.0,<=1.23.0",
     "rapidocr>=3.3,<4",
@@ -69,6 +70,10 @@ ignore = ["E501"]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 addopts = "--ignore=tests/ui/"
+markers = [
+    "scryfall: tests requiring Scryfall API access (use --scryfall to enable)",
+    "generative: seed-based generative tests with reverse parser",
+]
 
 [dependency-groups]
 dev = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,157 @@
+"""Top-level conftest for search test infrastructure."""
+
+import shutil
+import sqlite3
+import tempfile
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--scryfall",
+        action="store_true",
+        default=False,
+        help="Enable Scryfall API tests (requires network)",
+    )
+    parser.addoption(
+        "--seeds",
+        action="store",
+        default="200",
+        help="Number of generative test seeds (default: 200)",
+    )
+    parser.addoption(
+        "--seed",
+        action="store",
+        default=None,
+        help="Run a single generative seed (for reproduction)",
+    )
+    parser.addoption(
+        "--search-db",
+        action="store",
+        default=None,
+        help="Path to DB for search tests (default: test fixture, or ~/.mtgc/collection.sqlite with --scryfall)",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if not config.getoption("--scryfall"):
+        skip = pytest.mark.skip(reason="need --scryfall option to run")
+        for item in items:
+            if "scryfall" in item.keywords:
+                item.add_marker(skip)
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "scryfall: tests requiring Scryfall API access")
+    config.addinivalue_line("markers", "generative: seed-based generative tests")
+
+
+def _resolve_search_db_path(request) -> str:
+    """Resolve which DB to use for search tests.
+
+    Priority:
+    1. --search-db explicit path
+    2. ~/.mtgc/collection.sqlite (if --scryfall and it exists — Scryfall
+       comparison only makes sense against the full DB)
+    3. tests/fixtures/test-data.sqlite (default for offline tests)
+    """
+    import pathlib
+
+    explicit = request.config.getoption("--search-db")
+    if explicit:
+        path = pathlib.Path(explicit)
+        if not path.exists():
+            pytest.skip(f"--search-db path not found: {explicit}")
+        return str(path)
+
+    if request.config.getoption("--scryfall"):
+        full_db = pathlib.Path.home() / ".mtgc" / "collection.sqlite"
+        if full_db.exists():
+            return str(full_db)
+
+    fixture = pathlib.Path(__file__).parent / "fixtures" / "test-data.sqlite"
+    if not fixture.exists():
+        pytest.skip("test-data.sqlite fixture not found")
+    return str(fixture)
+
+
+@pytest.fixture(scope="session")
+def search_db(request):
+    """Session-scoped migrated copy of the search DB.
+
+    With --scryfall: uses ~/.mtgc/collection.sqlite (full Scryfall corpus)
+    if available, since comparison only makes sense against the complete DB.
+    Without --scryfall: uses the 16-set test fixture for fast offline tests.
+    Explicit --search-db overrides both.
+    """
+    import pathlib
+
+    from mtg_collector.db.schema import init_db
+
+    source = _resolve_search_db_path(request)
+
+    # Copy to temp so we can migrate without touching the original
+    tmp = tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False)
+    tmp.close()
+    shutil.copy2(source, tmp.name)
+
+    conn = sqlite3.connect(tmp.name)
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+
+    yield conn
+
+    conn.close()
+    pathlib.Path(tmp.name).unlink(missing_ok=True)
+
+
+@pytest.fixture(scope="session")
+def known_printing_ids(search_db):
+    """All non-digital printing_ids in the search DB."""
+    rows = search_db.execute(
+        "SELECT printing_id FROM printings WHERE digital = 0"
+    ).fetchall()
+    return frozenset(row["printing_id"] for row in rows)
+
+
+@pytest.fixture(scope="session")
+def known_oracle_ids(search_db):
+    """All oracle_ids that have at least one non-digital printing in the search DB.
+
+    Used for Scryfall comparison — we deduplicate by oracle_id to match
+    Scryfall's default unique:cards behavior.
+    """
+    rows = search_db.execute(
+        "SELECT DISTINCT oracle_id FROM printings WHERE digital = 0"
+    ).fetchall()
+    return frozenset(row["oracle_id"] for row in rows)
+
+
+@pytest.fixture(scope="session")
+def scryfall_cache(request):
+    """SQLite cache for Scryfall API responses. Only created when --scryfall is used.
+
+    Automatically invalidated when query_generator.py changes (different
+    generator source → different seed-to-query mapping → stale cache).
+    """
+    import pathlib
+
+    from tests.search_helpers.scryfall_client import init_cache
+
+    cache_path = pathlib.Path(__file__).parent / ".scryfall_cache.sqlite"
+    conn = init_cache(cache_path)
+
+    yield conn
+
+    conn.close()
+
+
+@pytest.fixture
+def seed_range(request):
+    """Range of seeds for generative tests."""
+    single = request.config.getoption("--seed")
+    if single is not None:
+        return range(int(single), int(single) + 1)
+    count = int(request.config.getoption("--seeds"))
+    return range(count)

--- a/tests/fixtures/search_query_corpus.yaml
+++ b/tests/fixtures/search_query_corpus.yaml
@@ -1,0 +1,890 @@
+# Scryfall search query corpus for automated testing.
+# Sources: Scryfall docs, findingsimple/scryfall-local test suite, EDHREC guide.
+#
+# Fields:
+#   query: the search query string
+#   category: grouping for test organization
+#   should_parse: true if our parser should accept it
+#   compiler_supported: true if our SQL compiler handles it (subset of should_parse)
+
+# ============================================================================
+# Color queries
+# ============================================================================
+- query: "c:r"
+  category: color
+  should_parse: true
+  compiler_supported: true
+
+- query: "c:rg"
+  category: color
+  should_parse: true
+  compiler_supported: true
+
+- query: "c:blue"
+  category: color
+  should_parse: true
+  compiler_supported: true
+
+- query: "c:u"
+  category: color
+  should_parse: true
+  compiler_supported: true
+
+- query: "c:urg"
+  category: color
+  should_parse: true
+  compiler_supported: true
+
+- query: "c=rg"
+  category: color
+  should_parse: true
+  compiler_supported: true
+
+- query: "c>=uw"
+  category: color
+  should_parse: true
+  compiler_supported: true
+
+- query: "c<=w"
+  category: color
+  should_parse: true
+  compiler_supported: true
+
+- query: "c>2"
+  category: color
+  should_parse: true
+  compiler_supported: true
+
+- query: "c=2"
+  category: color
+  should_parse: true
+  compiler_supported: true
+
+- query: "c:c"
+  category: color
+  should_parse: true
+  compiler_supported: true
+
+- query: "c:m"
+  category: color
+  should_parse: true
+  compiler_supported: true
+
+- query: "c:azorius"
+  category: color
+  should_parse: true
+  compiler_supported: true
+
+- query: "c:esper"
+  category: color
+  should_parse: true
+  compiler_supported: true
+
+- query: "c:temur"
+  category: color
+  should_parse: true
+  compiler_supported: true
+
+- query: "color>=uw -c:red"
+  category: color
+  should_parse: true
+  compiler_supported: true
+
+- query: "c!=r"
+  category: color
+  should_parse: true
+  compiler_supported: true
+
+- query: "c:colorless"
+  category: color
+  should_parse: true
+  compiler_supported: true
+
+- query: "c:multicolor"
+  category: color
+  should_parse: true
+  compiler_supported: true
+
+# ============================================================================
+# Color identity queries
+# ============================================================================
+- query: "id:r"
+  category: color_identity
+  should_parse: true
+  compiler_supported: true
+
+- query: "id:wubrg"
+  category: color_identity
+  should_parse: true
+  compiler_supported: true
+
+- query: "id:esper"
+  category: color_identity
+  should_parse: true
+  compiler_supported: true
+
+- query: "identity:grixis"
+  category: color_identity
+  should_parse: true
+  compiler_supported: true
+
+- query: "ci:rg"
+  category: color_identity
+  should_parse: true
+  compiler_supported: true
+
+- query: "id<=rg"
+  category: color_identity
+  should_parse: true
+  compiler_supported: true
+
+- query: "id:colorless"
+  category: color_identity
+  should_parse: true
+  compiler_supported: true
+
+- query: "id<=esper t:instant"
+  category: color_identity
+  should_parse: true
+  compiler_supported: true
+
+- query: "id:c t:land"
+  category: color_identity
+  should_parse: true
+  compiler_supported: true
+
+# ============================================================================
+# Type queries
+# ============================================================================
+- query: "t:creature"
+  category: type
+  should_parse: true
+  compiler_supported: true
+
+- query: "t:instant"
+  category: type
+  should_parse: true
+  compiler_supported: true
+
+- query: "t:sorcery"
+  category: type
+  should_parse: true
+  compiler_supported: true
+
+- query: "t:land"
+  category: type
+  should_parse: true
+  compiler_supported: true
+
+- query: "t:enchantment"
+  category: type
+  should_parse: true
+  compiler_supported: true
+
+- query: "t:artifact"
+  category: type
+  should_parse: true
+  compiler_supported: true
+
+- query: "t:planeswalker"
+  category: type
+  should_parse: true
+  compiler_supported: true
+
+- query: "t:legendary"
+  category: type
+  should_parse: true
+  compiler_supported: true
+
+- query: "t:merfolk t:legend"
+  category: type
+  should_parse: true
+  compiler_supported: true
+
+- query: "t:goblin -t:creature"
+  category: type
+  should_parse: true
+  compiler_supported: true
+
+- query: "type:instant"
+  category: type
+  should_parse: true
+  compiler_supported: true
+
+# ============================================================================
+# Oracle text queries
+# ============================================================================
+- query: "o:flying"
+  category: oracle_text
+  should_parse: true
+  compiler_supported: true
+
+- query: "o:draw"
+  category: oracle_text
+  should_parse: true
+  compiler_supported: true
+
+- query: 'o:"enters tapped"'
+  category: oracle_text
+  should_parse: true
+  compiler_supported: true
+
+- query: 'o:"deals damage"'
+  category: oracle_text
+  should_parse: true
+  compiler_supported: true
+
+- query: "o:draw t:creature"
+  category: oracle_text
+  should_parse: true
+  compiler_supported: true
+
+- query: "oracle:draw"
+  category: oracle_text
+  should_parse: true
+  compiler_supported: true
+
+- query: "o:destroy"
+  category: oracle_text
+  should_parse: true
+  compiler_supported: true
+
+- query: "o:counter"
+  category: oracle_text
+  should_parse: true
+  compiler_supported: true
+
+- query: "o:exile"
+  category: oracle_text
+  should_parse: true
+  compiler_supported: true
+
+- query: "o:sacrifice"
+  category: oracle_text
+  should_parse: true
+  compiler_supported: true
+
+# ============================================================================
+# Numeric queries (mana value, power, toughness, loyalty)
+# ============================================================================
+- query: "mv>=3"
+  category: numeric
+  should_parse: true
+  compiler_supported: true
+
+- query: "mv<=2"
+  category: numeric
+  should_parse: true
+  compiler_supported: true
+
+- query: "mv=5"
+  category: numeric
+  should_parse: true
+  compiler_supported: true
+
+- query: "cmc=5"
+  category: numeric
+  should_parse: true
+  compiler_supported: true
+
+- query: "cmc<4"
+  category: numeric
+  should_parse: true
+  compiler_supported: true
+
+- query: "manavalue>=3"
+  category: numeric
+  should_parse: true
+  compiler_supported: true
+
+- query: "pow>=8"
+  category: numeric
+  should_parse: true
+  compiler_supported: true
+
+- query: "pow>5"
+  category: numeric
+  should_parse: true
+  compiler_supported: true
+
+- query: "pow:*"
+  category: numeric
+  should_parse: true
+  compiler_supported: true
+
+- query: "power<2"
+  category: numeric
+  should_parse: true
+  compiler_supported: true
+
+- query: "tou>=5"
+  category: numeric
+  should_parse: true
+  compiler_supported: true
+
+- query: "tou<=3"
+  category: numeric
+  should_parse: true
+  compiler_supported: true
+
+- query: "toughness<=3"
+  category: numeric
+  should_parse: true
+  compiler_supported: true
+
+- query: "loy>=4"
+  category: numeric
+  should_parse: true
+  compiler_supported: true
+
+- query: "loy:3"
+  category: numeric
+  should_parse: true
+  compiler_supported: true
+
+- query: "loyalty<5"
+  category: numeric
+  should_parse: true
+  compiler_supported: true
+
+- query: "c:u mv=5"
+  category: numeric
+  should_parse: true
+  compiler_supported: true
+
+- query: "t:planeswalker loy>=4"
+  category: numeric
+  should_parse: true
+  compiler_supported: true
+
+# ============================================================================
+# Rarity queries
+# ============================================================================
+- query: "r:rare"
+  category: rarity
+  should_parse: true
+  compiler_supported: true
+
+- query: "r:m"
+  category: rarity
+  should_parse: true
+  compiler_supported: true
+
+- query: "r:common"
+  category: rarity
+  should_parse: true
+  compiler_supported: true
+
+- query: "r:uncommon"
+  category: rarity
+  should_parse: true
+  compiler_supported: true
+
+- query: "r>=r"
+  category: rarity
+  should_parse: true
+  compiler_supported: true
+
+- query: "r!=c"
+  category: rarity
+  should_parse: true
+  compiler_supported: true
+
+- query: "rarity:rare"
+  category: rarity
+  should_parse: true
+  compiler_supported: true
+
+- query: "r:common t:artifact"
+  category: rarity
+  should_parse: true
+  compiler_supported: true
+
+# ============================================================================
+# Set queries
+# ============================================================================
+- query: "s:fdn"
+  category: set
+  should_parse: true
+  compiler_supported: true
+
+- query: "set:mh3"
+  category: set
+  should_parse: true
+  compiler_supported: true
+
+- query: "e:dsk"
+  category: set
+  should_parse: true
+  compiler_supported: true
+
+- query: "edition:lci"
+  category: set
+  should_parse: true
+  compiler_supported: true
+
+- query: "s:fdn t:creature"
+  category: set
+  should_parse: true
+  compiler_supported: true
+
+- query: "s:mh3 r:mythic"
+  category: set
+  should_parse: true
+  compiler_supported: true
+
+# ============================================================================
+# Format / legality queries
+# ============================================================================
+- query: "f:modern"
+  category: format
+  should_parse: true
+  compiler_supported: true
+
+- query: "f:standard"
+  category: format
+  should_parse: true
+  compiler_supported: true
+
+- query: "f:commander"
+  category: format
+  should_parse: true
+  compiler_supported: true
+
+- query: "format:legacy"
+  category: format
+  should_parse: true
+  compiler_supported: true
+
+- query: "f:pauper"
+  category: format
+  should_parse: true
+  compiler_supported: true
+
+- query: "f:pioneer"
+  category: format
+  should_parse: true
+  compiler_supported: true
+
+- query: "banned:legacy"
+  category: format
+  should_parse: true
+  compiler_supported: true
+
+- query: "restricted:vintage"
+  category: format
+  should_parse: true
+  compiler_supported: true
+
+- query: "c:g t:creature f:pauper"
+  category: format
+  should_parse: true
+  compiler_supported: true
+
+# ============================================================================
+# is: / has: flag queries
+# ============================================================================
+- query: "is:foil"
+  category: is_flag
+  should_parse: true
+  compiler_supported: true
+
+- query: "is:nonfoil"
+  category: is_flag
+  should_parse: true
+  compiler_supported: true
+
+- query: "is:fullart"
+  category: is_flag
+  should_parse: true
+  compiler_supported: true
+
+- query: "is:promo"
+  category: is_flag
+  should_parse: true
+  compiler_supported: true
+
+- query: "is:reserved"
+  category: is_flag
+  should_parse: true
+  compiler_supported: true
+
+- query: "is:reprint"
+  category: is_flag
+  should_parse: true
+  compiler_supported: true
+
+- query: "is:digital"
+  category: is_flag
+  should_parse: true
+  compiler_supported: true
+
+- query: "is:borderless"
+  category: is_flag
+  should_parse: true
+  compiler_supported: true
+
+- query: "is:showcase"
+  category: is_flag
+  should_parse: true
+  compiler_supported: true
+
+- query: "is:dfc"
+  category: is_flag
+  should_parse: true
+  compiler_supported: true
+
+- query: "is:split"
+  category: is_flag
+  should_parse: true
+  compiler_supported: true
+
+- query: "is:vanilla"
+  category: is_flag
+  should_parse: true
+  compiler_supported: true
+
+- query: "has:watermark"
+  category: has_flag
+  should_parse: true
+  compiler_supported: true
+
+- query: "has:flavor"
+  category: has_flag
+  should_parse: true
+  compiler_supported: true
+
+- query: "has:loyalty"
+  category: has_flag
+  should_parse: true
+  compiler_supported: true
+
+# ============================================================================
+# Artist / flavor queries
+# ============================================================================
+- query: "a:rush"
+  category: artist
+  should_parse: true
+  compiler_supported: true
+
+- query: 'a:"rebecca guay"'
+  category: artist
+  should_parse: true
+  compiler_supported: true
+
+- query: "artist:terese"
+  category: artist
+  should_parse: true
+  compiler_supported: true
+
+- query: "ft:mishra"
+  category: flavor
+  should_parse: true
+  compiler_supported: true
+
+- query: "ft:fire"
+  category: flavor
+  should_parse: true
+  compiler_supported: true
+
+# ============================================================================
+# Keyword ability queries
+# ============================================================================
+- query: "kw:flying"
+  category: keyword
+  should_parse: true
+  compiler_supported: true
+
+- query: "kw:deathtouch"
+  category: keyword
+  should_parse: true
+  compiler_supported: true
+
+- query: "keyword:vigilance"
+  category: keyword
+  should_parse: true
+  compiler_supported: true
+
+- query: "kw:flying -t:creature"
+  category: keyword
+  should_parse: true
+  compiler_supported: true
+
+- query: "kw:flying kw:vigilance"
+  category: keyword
+  should_parse: true
+  compiler_supported: true
+
+# ============================================================================
+# Name / exact name queries
+# ============================================================================
+- query: "bolt"
+  category: name
+  should_parse: true
+  compiler_supported: true
+
+- query: "lightning bolt"
+  category: name
+  should_parse: true
+  compiler_supported: true
+
+- query: '!"Lightning Bolt"'
+  category: name
+  should_parse: true
+  compiler_supported: true
+
+- query: "!bolt"
+  category: name
+  should_parse: true
+  compiler_supported: true
+
+- query: "dragon"
+  category: name
+  should_parse: true
+  compiler_supported: true
+
+- query: "serra angel"
+  category: name
+  should_parse: true
+  compiler_supported: true
+
+# ============================================================================
+# Boolean logic queries
+# ============================================================================
+- query: "c:r or c:g"
+  category: boolean
+  should_parse: true
+  compiler_supported: true
+
+- query: "c:r OR c:g"
+  category: boolean
+  should_parse: true
+  compiler_supported: true
+
+- query: "t:fish or t:bird"
+  category: boolean
+  should_parse: true
+  compiler_supported: true
+
+- query: "-c:r"
+  category: boolean
+  should_parse: true
+  compiler_supported: true
+
+- query: "-t:creature"
+  category: boolean
+  should_parse: true
+  compiler_supported: true
+
+- query: "-c:r t:creature"
+  category: boolean
+  should_parse: true
+  compiler_supported: true
+
+- query: "(c:r or c:g) t:creature"
+  category: boolean
+  should_parse: true
+  compiler_supported: true
+
+- query: "t:legendary (t:goblin or t:elf)"
+  category: boolean
+  should_parse: true
+  compiler_supported: true
+
+- query: "-(c:r or c:g)"
+  category: boolean
+  should_parse: true
+  compiler_supported: true
+
+- query: "(t:elf or t:goblin) c:green"
+  category: boolean
+  should_parse: true
+  compiler_supported: true
+
+- query: "c:green (t:elf or t:goblin) r:rare"
+  category: boolean
+  should_parse: true
+  compiler_supported: true
+
+- query: "t:instant or t:sorcery"
+  category: boolean
+  should_parse: true
+  compiler_supported: true
+
+# ============================================================================
+# Combined multi-keyword queries
+# ============================================================================
+- query: "c:r t:creature mv<=3"
+  category: combined
+  should_parse: true
+  compiler_supported: true
+
+- query: "c:r t:instant mv<=2"
+  category: combined
+  should_parse: true
+  compiler_supported: true
+
+- query: 'c:r t:instant mv<=2 o:"damage"'
+  category: combined
+  should_parse: true
+  compiler_supported: true
+
+- query: "(c:r or c:g) t:creature pow>=4"
+  category: combined
+  should_parse: true
+  compiler_supported: true
+
+- query: "c:blue t:instant cmc<=2"
+  category: combined
+  should_parse: true
+  compiler_supported: true
+
+- query: "c>=ur t:legendary"
+  category: combined
+  should_parse: true
+  compiler_supported: true
+
+- query: "s:fdn r:mythic t:creature"
+  category: combined
+  should_parse: true
+  compiler_supported: true
+
+- query: "f:modern c:r t:instant"
+  category: combined
+  should_parse: true
+  compiler_supported: true
+
+- query: "c:r t:creature f:pauper pow>=3"
+  category: combined
+  should_parse: true
+  compiler_supported: true
+
+- query: "c:r t:creature is:foil"
+  category: combined
+  should_parse: true
+  compiler_supported: true
+
+- query: "t:creature kw:flying c:w"
+  category: combined
+  should_parse: true
+  compiler_supported: true
+
+- query: "c:blue t:instant -cmc:0"
+  category: combined
+  should_parse: true
+  compiler_supported: true
+
+- query: "s:mh3 r:mythic c:r"
+  category: combined
+  should_parse: true
+  compiler_supported: true
+
+# ============================================================================
+# Mana cost queries
+# ============================================================================
+- query: "m:{R}"
+  category: mana
+  should_parse: true
+  compiler_supported: true
+
+- query: "m:{U}{U}"
+  category: mana
+  should_parse: true
+  compiler_supported: true
+
+- query: "mana:{W}{W}"
+  category: mana
+  should_parse: true
+  compiler_supported: true
+
+# ============================================================================
+# Layout queries
+# ============================================================================
+- query: "is:mdfc"
+  category: layout
+  should_parse: true
+  compiler_supported: true
+
+- query: "is:adventure"
+  category: layout
+  should_parse: true
+  compiler_supported: true
+
+- query: "is:transform"
+  category: layout
+  should_parse: true
+  compiler_supported: true
+
+# ============================================================================
+# Year / collector number
+# ============================================================================
+- query: "year>=2020"
+  category: year
+  should_parse: true
+  compiler_supported: true
+
+- query: "year<=2023"
+  category: year
+  should_parse: true
+  compiler_supported: true
+
+- query: "cn>100"
+  category: collector_number
+  should_parse: true
+  compiler_supported: true
+
+# ============================================================================
+# Unsupported (parses but compiler doesn't fully handle)
+# ============================================================================
+- query: "b:zendikar"
+  category: unsupported
+  should_parse: true
+  compiler_supported: false
+
+- query: "is:fetchland"
+  category: unsupported
+  should_parse: true
+  compiler_supported: false
+
+- query: "is:shockland"
+  category: unsupported
+  should_parse: true
+  compiler_supported: false
+
+- query: "is:dual"
+  category: unsupported
+  should_parse: true
+  compiler_supported: false
+
+- query: "is:manland"
+  category: unsupported
+  should_parse: true
+  compiler_supported: false
+
+- query: "is:bear"
+  category: unsupported
+  should_parse: true
+  compiler_supported: false
+
+# ============================================================================
+# Error cases (should NOT parse)
+# ============================================================================
+- query: ""
+  category: error
+  should_parse: false
+  compiler_supported: false
+
+- query: "   "
+  category: error
+  should_parse: false
+  compiler_supported: false
+
+- query: "xyz:value"
+  category: error
+  should_parse: false
+  compiler_supported: false
+
+- query: "zzz:abc"
+  category: error
+  should_parse: false
+  compiler_supported: false

--- a/tests/search_helpers/__init__.py
+++ b/tests/search_helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Search test helpers: query generator, Scryfall client, result comparator."""

--- a/tests/search_helpers/query_generator.py
+++ b/tests/search_helpers/query_generator.py
@@ -1,0 +1,263 @@
+"""Reverse parser that generates syntactically valid Scryfall-style search queries.
+
+Inverts the grammar productions from mtg_collector/search/grammar.py to produce
+random but parseable queries for generative/fuzz testing.
+"""
+
+from __future__ import annotations
+
+import random
+
+from mtg_collector.search.compiler import _HAS_FLAG_MAP, _IS_FLAG_MAP
+from mtg_collector.search.keywords import COLOR_MAP, KEYWORD_ALIASES, RARITY_ALIASES
+
+# ---------------------------------------------------------------------------
+# Reverse alias lookup: canonical keyword -> list of aliases
+# ---------------------------------------------------------------------------
+
+_CANONICAL_TO_ALIASES: dict[str, list[str]] = {}
+for _alias, _canonical in KEYWORD_ALIASES.items():
+    _CANONICAL_TO_ALIASES.setdefault(_canonical, []).append(_alias)
+
+# ---------------------------------------------------------------------------
+# Canonical keywords to exclude in supported_only mode
+# ---------------------------------------------------------------------------
+
+_UNSUPPORTED = {"block", "date", "order", "direction", "unique"}
+
+# ---------------------------------------------------------------------------
+# Operator sets per keyword type
+# ---------------------------------------------------------------------------
+
+_NUMERIC_OPS = [":", "=", "!=", "<", ">", "<=", ">="]
+_TEXT_OPS = [":"]
+_ENUM_OPS = [":", "="]
+_COLOR_OPS = [":", "=", "!=", "<", ">", "<=", ">="]
+
+_KEYWORD_OPS: dict[str, list[str]] = {
+    "color": _COLOR_OPS,
+    "color_identity": _COLOR_OPS,
+    "type": _TEXT_OPS,
+    "oracle": _TEXT_OPS,
+    "fulloracle": _TEXT_OPS,
+    "mana": _TEXT_OPS,
+    "mana_value": _NUMERIC_OPS,
+    "power": _NUMERIC_OPS,
+    "toughness": _NUMERIC_OPS,
+    "powtou": _NUMERIC_OPS,
+    "loyalty": _NUMERIC_OPS,
+    "rarity": _COLOR_OPS,  # supports ordinal comparison
+    "set": _ENUM_OPS + ["!="],
+    "set_type": _ENUM_OPS,
+    "artist": _TEXT_OPS,
+    "flavor": _TEXT_OPS,
+    "watermark": _ENUM_OPS,
+    "keyword": _TEXT_OPS,
+    "format": _TEXT_OPS,
+    "banned": _TEXT_OPS,
+    "restricted": _TEXT_OPS,
+    "is_flag": _TEXT_OPS,
+    "not_flag": _TEXT_OPS,
+    "has_flag": _TEXT_OPS,
+    "collector_number": _NUMERIC_OPS,
+    "year": _NUMERIC_OPS,
+    "layout": _ENUM_OPS,
+    "produces": _TEXT_OPS,
+}
+
+# ---------------------------------------------------------------------------
+# Value pools
+# ---------------------------------------------------------------------------
+
+_VALUE_POOLS: dict[str, list[str]] = {
+    "color": list(COLOR_MAP.keys()),
+    "color_identity": list(COLOR_MAP.keys()),
+    "type": [
+        "creature", "instant", "sorcery", "land", "enchantment", "artifact",
+        "planeswalker", "legendary", "goblin", "elf", "merfolk", "dragon",
+        "human", "wizard", "angel", "demon", "elemental",
+    ],
+    "oracle": [
+        "draw", "damage", "destroy", "counter", "enters", "flying",
+        "trample", "exile", "sacrifice", "graveyard", "token",
+    ],
+    "fulloracle": ["draw", "damage", "destroy", "enters"],
+    "mana_value": [str(i) for i in range(16)],
+    "power": [str(i) for i in range(16)] + ["*"],
+    "toughness": [str(i) for i in range(16)] + ["*"],
+    "loyalty": [str(i) for i in range(8)],
+    "powtou": [str(i) for i in range(16)],
+    "rarity": list(RARITY_ALIASES.keys()),
+    "set": [
+        "fdn", "dsk", "blb", "otj", "mh3", "spg", "woe", "lci", "mkm",
+        "ecl", "fin", "tsp", "ddh", "tmp", "8ed", "roe",
+    ],
+    "set_type": ["expansion", "core", "masters", "draft_innovation", "commander",
+                 "eternal", "alchemy", "masterpiece", "duel_deck", "starter",
+                 "box", "promo", "arsenal", "from_the_vault", "spellbook"],
+    "artist": ["rush", "tedin", "nielsen", "guay", "post", "avon"],
+    "flavor": ["fire", "shadow", "death", "light", "dragon"],
+    "watermark": ["set", "planeswalker"],
+    "keyword": [
+        "flying", "trample", "deathtouch", "lifelink", "haste",
+        "vigilance", "first strike", "reach", "menace", "flash",
+    ],
+    "mana": ["{R}", "{G}", "{U}", "{B}", "{W}", "{1}", "{2}", "{3}"],
+    "format": [
+        "standard", "modern", "legacy", "vintage", "commander",
+        "pioneer", "pauper",
+    ],
+    "banned": ["modern", "legacy", "standard", "commander"],
+    "restricted": ["vintage"],
+    "is_flag": list(_IS_FLAG_MAP.keys()),
+    "not_flag": list(_IS_FLAG_MAP.keys()),
+    "has_flag": list(_HAS_FLAG_MAP.keys()),
+    "collector_number": [str(i) for i in range(1, 400)],
+    "year": ["2020", "2021", "2022", "2023", "2024", "2025"],
+    "layout": ["normal", "split", "flip", "transform", "modal_dfc", "adventure",
+               "meld", "leveler", "class", "case", "saga", "mutate", "prototype",
+               "battle", "augment", "host", "reversible_card", "prepare"],
+    "produces": ["w", "u", "b", "r", "g"],
+}
+
+_BARE_WORDS = [
+    "bolt", "lightning", "fire", "dragon", "sword", "angel",
+    "goblin", "forest", "island", "elf", "serra", "jace",
+]
+
+_EXACT_NAMES = [
+    "Lightning Bolt", "Sol Ring", "Counterspell", "Dark Ritual",
+    "Llanowar Elves", "Swords to Plowshares", "Birds of Paradise",
+]
+
+
+class QueryGenerator:
+    """Generates syntactically valid Scryfall-style search queries.
+
+    Inverts the grammar productions so every generated string is guaranteed
+    to parse successfully with ``parse_query``.
+    """
+
+    def __init__(
+        self,
+        rng: random.Random,
+        *,
+        supported_only: bool = True,
+        max_depth: int = 3,
+        max_and_terms: int = 4,
+        max_or_branches: int = 3,
+    ):
+        self.rng = rng
+        self.supported_only = supported_only
+        self.max_depth = max_depth
+        self.max_and_terms = max_and_terms
+        self.max_or_branches = max_or_branches
+        self._depth = 0
+
+        # Build the set of canonical keywords we can use.
+        # Only include keywords that actually appear in KEYWORD_ALIASES
+        # (the parser rejects unknown keywords).
+        _known_canonicals = set(KEYWORD_ALIASES.values())
+        self._keywords = sorted(
+            k for k in _KEYWORD_OPS
+            if k in _known_canonicals
+            and not (supported_only and k in _UNSUPPORTED)
+        )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def generate(self) -> str:
+        """Return a random, syntactically valid query string."""
+        self._depth = 0
+        return self._gen_query()
+
+    # ------------------------------------------------------------------
+    # Grammar productions
+    # ------------------------------------------------------------------
+
+    def _gen_query(self) -> str:
+        return self._gen_or_expr()
+
+    def _gen_or_expr(self) -> str:
+        count = self.rng.choices(
+            range(1, self.max_or_branches + 1),
+            weights=[70, 25, 5][: self.max_or_branches],
+            k=1,
+        )[0]
+        branches = [self._gen_and_expr() for _ in range(count)]
+        return " or ".join(branches)
+
+    def _gen_and_expr(self) -> str:
+        count = self.rng.choices(
+            range(1, self.max_and_terms + 1),
+            weights=[30, 40, 20, 10][: self.max_and_terms],
+            k=1,
+        )[0]
+        terms = [self._gen_atom() for _ in range(count)]
+        return " ".join(terms)
+
+    def _gen_atom(self) -> str:
+        roll = self.rng.random()
+        if roll < 0.75:
+            return self._gen_criterion()
+        if roll < 0.90:
+            # Negation: negate a criterion (not another atom) to avoid
+            # double-negation which is syntactically fine but odd.
+            return "-" + self._gen_criterion()
+        # Group
+        if self._depth < self.max_depth:
+            self._depth += 1
+            inner = self._gen_query()
+            self._depth -= 1
+            return "(" + inner + ")"
+        # Depth exceeded — fall back to criterion
+        return self._gen_criterion()
+
+    def _gen_criterion(self) -> str:
+        roll = self.rng.random()
+        if roll < 0.70:
+            return self._gen_keyword_expr()
+        if roll < 0.90:
+            return self._gen_bare_word()
+        return self._gen_exact_name()
+
+    # ------------------------------------------------------------------
+    # Leaf generators
+    # ------------------------------------------------------------------
+
+    def _gen_keyword_expr(self) -> str:
+        canonical = self.rng.choice(self._keywords)
+
+        # Pick an alias that maps to this canonical keyword
+        aliases = _CANONICAL_TO_ALIASES.get(canonical, [canonical])
+        alias = self.rng.choice(aliases)
+
+        # Pick a valid operator
+        ops = _KEYWORD_OPS.get(canonical, [":"])
+        op = self.rng.choice(ops)
+
+        # Pick a value from the pool
+        pool = _VALUE_POOLS.get(canonical, ["1"])
+        value = self.rng.choice(pool)
+
+        # Edge case: power/toughness '*' only valid with : or =
+        if canonical in ("power", "toughness") and value == "*":
+            if op not in (":", "="):
+                op = self.rng.choice([":", "="])
+
+        # Quote values that contain spaces
+        if " " in value:
+            formatted_value = f'"{value}"'
+        else:
+            formatted_value = value
+
+        return f"{alias}{op}{formatted_value}"
+
+    def _gen_bare_word(self) -> str:
+        return self.rng.choice(_BARE_WORDS)
+
+    def _gen_exact_name(self) -> str:
+        name = self.rng.choice(_EXACT_NAMES)
+        return f'!"{name}"'

--- a/tests/search_helpers/result_comparator.py
+++ b/tests/search_helpers/result_comparator.py
@@ -1,0 +1,77 @@
+"""Printing ID set comparison between local search and Scryfall results."""
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ComparisonResult:
+    """Result of comparing local vs Scryfall search results."""
+
+    query: str
+    seed: int
+    local_ids: frozenset = field(default_factory=frozenset)
+    scryfall_ids: frozenset = field(default_factory=frozenset)
+    local_only: frozenset = field(default_factory=frozenset)
+    scryfall_only: frozenset = field(default_factory=frozenset)
+    passed: bool = True
+    truncated: bool = False  # Scryfall returned fewer cards than total_cards
+
+    def summary(self) -> str:
+        parts = [f"seed={self.seed}, query={self.query!r}"]
+        if self.truncated:
+            parts.append("  (Scryfall results truncated — local_only not meaningful)")
+        if self.local_only and not self.truncated:
+            parts.append(f"  local_only ({len(self.local_only)}): too loose")
+        if self.scryfall_only:
+            parts.append(f"  scryfall_only ({len(self.scryfall_only)}): too strict")
+        return "\n".join(parts)
+
+
+def compare_results(
+    query: str,
+    seed: int,
+    local_rows: list,
+    scryfall_cards: list,
+    known_oracle_ids: frozenset,
+    scryfall_total: int = 0,
+) -> ComparisonResult:
+    """Compare local search results with Scryfall results.
+
+    Scryfall defaults to unique:cards (one result per oracle identity).
+    We return unique:prints (all printings). To compare fairly, we
+    deduplicate both sides by oracle_id and only compare cards that
+    exist in our local DB.
+    """
+    # Deduplicate to oracle_id (Scryfall's unique:cards default)
+    local_ids = frozenset(
+        row["oracle_id"] for row in local_rows if row["oracle_id"]
+    )
+    scryfall_ids = frozenset(
+        card["oracle_id"] for card in scryfall_cards
+        if "oracle_id" in card
+    )
+
+    # Intersect with known universe
+    local_in_known = local_ids & known_oracle_ids
+    scryfall_in_known = scryfall_ids & known_oracle_ids
+
+    local_only = local_in_known - scryfall_in_known
+    scryfall_only = scryfall_in_known - local_in_known
+
+    # If Scryfall truncated results, local_only is not meaningful
+    truncated = scryfall_total > len(scryfall_cards)
+    if truncated:
+        passed = len(scryfall_only) == 0
+    else:
+        passed = len(local_only) == 0 and len(scryfall_only) == 0
+
+    return ComparisonResult(
+        query=query,
+        seed=seed,
+        local_ids=local_in_known,
+        scryfall_ids=scryfall_in_known,
+        local_only=local_only,
+        scryfall_only=scryfall_only,
+        passed=passed,
+        truncated=truncated,
+    )

--- a/tests/search_helpers/scryfall_client.py
+++ b/tests/search_helpers/scryfall_client.py
@@ -1,0 +1,162 @@
+"""Rate-limited Scryfall search client with SQLite response caching.
+
+Cache is keyed by query string. A generator_hash in the meta table tracks
+whether the query_generator.py source has changed; if so, the entire cache
+is wiped on next run (since seed → query mapping changed).
+"""
+
+import hashlib
+import json
+import pathlib
+import sqlite3
+import time
+import urllib.parse
+
+import requests
+
+_BASE_URL = "https://api.scryfall.com/cards/search"
+_USER_AGENT = "MTGCollectionTool/2.0 SearchTests"
+_MIN_INTERVAL = 0.1  # 100ms between requests
+_MAX_PAGES = 3  # up to 525 cards
+
+_last_request_time = 0.0
+
+_GENERATOR_PATH = pathlib.Path(__file__).parent / "query_generator.py"
+
+
+def _rate_limit():
+    global _last_request_time
+    elapsed = time.monotonic() - _last_request_time
+    if elapsed < _MIN_INTERVAL:
+        time.sleep(_MIN_INTERVAL - elapsed)
+    _last_request_time = time.monotonic()
+
+
+def _cache_key(query: str) -> str:
+    return hashlib.sha256(query.strip().lower().encode()).hexdigest()
+
+
+def _generator_hash() -> str:
+    """Hash the query generator source to detect changes."""
+    if _GENERATOR_PATH.exists():
+        return hashlib.sha256(_GENERATOR_PATH.read_bytes()).hexdigest()[:16]
+    return "unknown"
+
+
+def init_cache(cache_path: str | pathlib.Path) -> sqlite3.Connection:
+    """Open or create the Scryfall cache DB, invalidating if generator changed."""
+    conn = sqlite3.connect(str(cache_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS query_cache (
+            query_hash TEXT PRIMARY KEY,
+            query_text TEXT NOT NULL,
+            response_json TEXT NOT NULL,
+            total_cards INTEGER,
+            status_code INTEGER NOT NULL DEFAULT 200,
+            fetched_at TEXT NOT NULL
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        )
+    """)
+    conn.commit()
+
+    # Check if generator changed
+    current_hash = _generator_hash()
+    row = conn.execute(
+        "SELECT value FROM meta WHERE key = 'generator_hash'"
+    ).fetchone()
+    stored_hash = row["value"] if row else None
+
+    if stored_hash != current_hash:
+        # Generator source changed — invalidate all cached results
+        count = conn.execute("SELECT COUNT(*) FROM query_cache").fetchone()[0]
+        if count > 0:
+            conn.execute("DELETE FROM query_cache")
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('generator_hash', ?)",
+            (current_hash,),
+        )
+        conn.commit()
+
+    return conn
+
+
+def scryfall_search(cache_conn: sqlite3.Connection, query: str) -> dict:
+    """Search Scryfall with caching.
+
+    Returns {"status_code": int, "cards": list[dict], "total_cards": int}.
+    """
+    key = _cache_key(query)
+
+    # Check cache
+    row = cache_conn.execute(
+        "SELECT response_json, status_code, total_cards FROM query_cache WHERE query_hash = ?",
+        (key,),
+    ).fetchone()
+    if row:
+        return {
+            "status_code": row["status_code"],
+            "cards": json.loads(row["response_json"]),
+            "total_cards": row["total_cards"] or 0,
+        }
+
+    # Fetch from Scryfall
+    cards = []
+    total_cards = 0
+    url = f"{_BASE_URL}?{urllib.parse.urlencode({'q': query})}"
+
+    _rate_limit()
+    first_resp = _request_with_retry(url)
+    status_code = first_resp.status_code
+
+    if status_code == 200:
+        data = first_resp.json()
+        total_cards = data.get("total_cards", 0)
+        cards.extend(data.get("data", []))
+
+        # Paginate
+        for _page in range(_MAX_PAGES - 1):
+            if not data.get("has_more"):
+                break
+            url = data.get("next_page")
+            if not url:
+                break
+            _rate_limit()
+            resp = _request_with_retry(url)
+            if resp.status_code != 200:
+                break
+            data = resp.json()
+            cards.extend(data.get("data", []))
+
+    # Cache result
+    from mtg_collector.utils import now_iso
+
+    cache_conn.execute(
+        """INSERT OR REPLACE INTO query_cache
+           (query_hash, query_text, response_json, total_cards, status_code, fetched_at)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (key, query, json.dumps(cards), total_cards, status_code, now_iso()),
+    )
+    cache_conn.commit()
+
+    return {"status_code": status_code, "cards": cards, "total_cards": total_cards}
+
+
+def _request_with_retry(url: str, max_retries: int = 3) -> requests.Response:
+    """HTTP GET with exponential backoff on 429."""
+    session = requests.Session()
+    session.headers["User-Agent"] = _USER_AGENT
+
+    for attempt in range(max_retries + 1):
+        resp = session.get(url)
+        if resp.status_code == 429:
+            wait = 0.5 * (2**attempt)
+            time.sleep(wait)
+            continue
+        return resp
+    return resp

--- a/tests/test_decks_binders.py
+++ b/tests/test_decks_binders.py
@@ -86,8 +86,8 @@ def seeded_db(db):
 # =============================================================================
 
 class TestMigration:
-    def test_fresh_install_has_v41(self, db):
-        assert get_current_version(db) == 41
+    def test_fresh_install_has_v42(self, db):
+        assert get_current_version(db) == 42
 
     def test_tables_exist(self, db):
         tables = [r[0] for r in db.execute(

--- a/tests/test_search_compiler.py
+++ b/tests/test_search_compiler.py
@@ -1,0 +1,269 @@
+"""Tests for the Scryfall search SQL compiler."""
+
+import sqlite3
+
+import pytest
+
+from mtg_collector.search import compile_query, parse_query
+from mtg_collector.search.compiler import CompiledQuery
+
+
+def _compile(q: str) -> CompiledQuery:
+    """Helper: parse and compile a query string."""
+    return compile_query(parse_query(q))
+
+
+class TestColorCompilation:
+    def test_color_contains(self):
+        c = _compile("c:r")
+        assert "colors LIKE" in c.where_sql
+        assert '%"R"%' in c.params
+
+    def test_color_exact(self):
+        c = _compile("c=rg")
+        assert "json_array_length" in c.where_sql
+        assert '%"R"%' in c.params
+        assert '%"G"%' in c.params
+
+    def test_color_superset(self):
+        c = _compile("c>=uw")
+        assert '%"W"%' in c.params
+        assert '%"U"%' in c.params
+
+    def test_color_subset(self):
+        c = _compile("c<=rg")
+        assert "NOT LIKE" in c.where_sql
+        # Params should include the excluded colors (W, U, B)
+        assert any('"W"' in str(p) or '"U"' in str(p) or '"B"' in str(p) for p in c.params)
+
+    def test_colorless(self):
+        c = _compile("c:c")
+        assert "IS NULL" in c.where_sql or "'[]'" in c.where_sql
+
+    def test_multicolor(self):
+        c = _compile("c:m")
+        assert "json_array_length" in c.where_sql
+
+    def test_guild_name(self):
+        c = _compile("c:azorius")
+        assert '%"W"%' in c.params
+        assert '%"U"%' in c.params
+
+    def test_color_identity(self):
+        c = _compile("id:rg")
+        assert "color_identity" in c.where_sql
+
+    def test_color_numeric(self):
+        c = _compile("c=2")
+        assert "json_array_length" in c.where_sql
+
+
+class TestNumericCompilation:
+    def test_cmc_gte(self):
+        c = _compile("mv>=3")
+        assert "card.cmc" in c.where_sql
+        assert 3.0 in c.params
+
+    def test_cmc_exact(self):
+        c = _compile("cmc=5")
+        assert 5.0 in c.params
+
+    def test_power_gt(self):
+        c = _compile("pow>5")
+        assert "power" in c.where_sql.lower()
+        assert 5.0 in c.params
+
+    def test_toughness_lte(self):
+        c = _compile("tou<=3")
+        assert "toughness" in c.where_sql.lower()
+
+    def test_power_star(self):
+        c = _compile("pow:*")
+        assert "'*'" in c.where_sql
+
+
+class TestTextCompilation:
+    def test_name_search(self):
+        c = _compile("bolt")
+        assert "card.name LIKE" in c.where_sql
+        assert "p.flavor_name LIKE" in c.where_sql
+        assert "type_line" not in c.where_sql  # type line requires t: prefix
+        assert "oracle_text" not in c.where_sql  # oracle text requires o: prefix
+        assert "%bolt%" in c.params
+
+    def test_oracle_text(self):
+        c = _compile('o:"enters tapped"')
+        assert "oracle_text" in c.where_sql.lower()
+        assert "%enters tapped%" in c.params
+
+    def test_type_like(self):
+        c = _compile("t:creature")
+        assert "type_line" in c.where_sql.lower()
+
+    def test_flavor_text(self):
+        c = _compile("ft:fire")
+        assert "flavor_text" in c.where_sql
+
+    def test_artist(self):
+        c = _compile("a:rush")
+        assert "artist" in c.where_sql.lower()
+
+    def test_exact_name(self):
+        c = _compile('!"Lightning Bolt"')
+        assert "oracle_id" in c.where_sql
+        assert "Lightning Bolt" in c.params
+
+
+class TestRarityCompilation:
+    def test_rarity_exact(self):
+        c = _compile("r:rare")
+        assert "p.rarity = ?" in c.where_sql
+        assert "rare" in c.params
+
+    def test_rarity_alias(self):
+        c = _compile("r:r")
+        assert "rare" in c.params
+
+    def test_rarity_gte(self):
+        c = _compile("r>=r")
+        assert "CASE" in c.where_sql
+        assert 2 in c.params  # rare = ordinal 2
+
+
+class TestFormatCompilation:
+    def test_format_legal(self):
+        c = _compile("f:standard")
+        assert "json_extract" in c.where_sql
+        assert "standard" in c.params
+
+    def test_banned(self):
+        c = _compile("banned:modern")
+        assert "banned" in c.where_sql
+        assert "modern" in c.params
+
+    def test_restricted(self):
+        c = _compile("restricted:vintage")
+        assert "restricted" in c.where_sql
+
+
+class TestSetCompilation:
+    def test_set_exact(self):
+        c = _compile("s:lea")
+        assert "set_code" in c.where_sql
+        assert "lea" in c.params
+
+
+class TestFlagCompilation:
+    def test_is_foil(self):
+        c = _compile("is:foil")
+        assert "finishes" in c.where_sql
+
+    def test_is_fullart(self):
+        c = _compile("is:fullart")
+        assert "full_art" in c.where_sql
+
+    def test_is_reserved(self):
+        c = _compile("is:reserved")
+        assert "reserved" in c.where_sql
+
+    def test_is_promo(self):
+        c = _compile("is:promo")
+        assert "promo" in c.where_sql
+
+
+class TestBooleanCompilation:
+    def test_and(self):
+        c = _compile("c:r t:creature")
+        assert " AND " in c.where_sql
+
+    def test_or(self):
+        c = _compile("c:r or c:g")
+        assert " OR " in c.where_sql
+
+    def test_not(self):
+        c = _compile("-c:r")
+        assert "NOT" in c.where_sql
+
+
+class TestDisplayModifiers:
+    def test_order_extracted(self):
+        c = _compile("c:r order:cmc")
+        assert c.order_by == "cmc"
+        # order: should not appear in WHERE
+        assert "order" not in c.where_sql.lower()
+
+    def test_direction_extracted(self):
+        c = _compile("c:r direction:desc")
+        assert c.order_dir == "desc"
+
+
+class TestKeywordAbilities:
+    def test_keyword_search(self):
+        c = _compile("kw:flying")
+        assert "keywords" in c.where_sql.lower()
+
+
+class TestSQLValidity:
+    """Test that compiled queries produce valid SQL by executing against an in-memory DB."""
+
+    @pytest.fixture
+    def db(self):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        from mtg_collector.db.schema import init_db
+        init_db(conn)
+        # Insert test data
+        conn.execute("""
+            INSERT INTO cards (oracle_id, name, type_line, mana_cost, cmc, oracle_text,
+                colors, color_identity, keywords, legalities)
+            VALUES ('t1', 'Test Card', 'Creature - Human', '{R}', 1.0, 'Test text.',
+                '["R"]', '["R"]', '["Haste"]',
+                '{"standard":"legal","modern":"legal"}')
+        """)
+        conn.execute("""
+            INSERT INTO sets (set_code, set_name, set_type, released_at, digital)
+            VALUES ('tst', 'Test Set', 'expansion', '2024-01-01', 0)
+        """)
+        conn.execute("""
+            INSERT INTO printings (printing_id, oracle_id, set_code, collector_number,
+                rarity, frame_effects, border_color, full_art, promo, promo_types,
+                finishes, artist, power, toughness, layout, digital, reserved, reprint, games)
+            VALUES ('p1', 't1', 'tst', '1', 'rare', '[]', 'black', 0, 0, '[]',
+                '["nonfoil"]', 'Test Artist', '2', '1', 'normal', 0, 0, 0, '["paper"]')
+        """)
+        conn.execute("""
+            INSERT INTO collection (printing_id, finish, condition, language, acquired_at, source, status)
+            VALUES ('p1', 'nonfoil', 'Near Mint', 'English', '2024-01-01', 'manual', 'owned')
+        """)
+        conn.execute("INSERT INTO cards_fts(cards_fts) VALUES('rebuild')")
+        conn.commit()
+        yield conn
+        conn.close()
+
+    @pytest.mark.parametrize("query", [
+        "test",
+        "c:r",
+        "c:r t:creature",
+        "mv<=1",
+        "r:rare",
+        "r>=r",
+        "f:modern",
+        "s:tst",
+        "a:artist",
+        "is:nonfoil",
+        "pow>=2",
+        "tou<=1",
+        "kw:haste",
+        "(c:r or c:g) t:creature",
+        "-c:b",
+        '!"Test Card"',
+        'o:"Test text"',
+        "c:r order:cmc direction:desc",
+    ])
+    def test_valid_sql(self, db, query):
+        """Every supported query should produce valid SQL that executes without error."""
+        from mtg_collector.search.compiler import execute_search
+        compiled = compile_query(parse_query(query))
+        rows, timings = execute_search(db, compiled, mode="collection")
+        assert isinstance(rows, list)
+        assert "query_ms" in timings

--- a/tests/test_search_corpus.py
+++ b/tests/test_search_corpus.py
@@ -1,0 +1,62 @@
+"""Tier 1: Parameterized tests against the curated query corpus."""
+
+import pathlib
+
+import pytest
+import yaml
+
+from mtg_collector.search import SearchError, compile_query, parse_query
+from mtg_collector.search.compiler import execute_search
+
+# Load corpus
+_CORPUS_PATH = pathlib.Path(__file__).parent / "fixtures" / "search_query_corpus.yaml"
+with open(_CORPUS_PATH) as f:
+    _CORPUS = yaml.safe_load(f)
+
+_SHOULD_PARSE = [e for e in _CORPUS if e["should_parse"]]
+_SHOULD_ERROR = [e for e in _CORPUS if not e["should_parse"]]
+_COMPILER_SUPPORTED = [e for e in _CORPUS if e["compiler_supported"]]
+
+
+def _qid(entry):
+    return entry["query"] or "<empty>"
+
+
+class TestCorpusParsing:
+    """All should_parse=true entries must parse without error."""
+
+    @pytest.mark.parametrize("entry", _SHOULD_PARSE, ids=[_qid(e) for e in _SHOULD_PARSE])
+    def test_parses_successfully(self, entry):
+        ast = parse_query(entry["query"])
+        assert ast is not None
+
+    @pytest.mark.parametrize("entry", _SHOULD_ERROR, ids=[_qid(e) for e in _SHOULD_ERROR])
+    def test_raises_search_error(self, entry):
+        with pytest.raises(SearchError):
+            parse_query(entry["query"])
+
+
+class TestCorpusCompilation:
+    """All compiler_supported=true entries must compile and execute."""
+
+    @pytest.mark.parametrize(
+        "entry", _COMPILER_SUPPORTED, ids=[_qid(e) for e in _COMPILER_SUPPORTED]
+    )
+    def test_compiles_to_sql(self, entry):
+        ast = parse_query(entry["query"])
+        compiled = compile_query(ast)
+        assert compiled.where_sql
+        # Should not contain unsupported fallback for supported queries
+        assert "1=0" not in compiled.where_sql, (
+            f"Unsupported keyword fallback in: {entry['query']}"
+        )
+
+    @pytest.mark.parametrize(
+        "entry", _COMPILER_SUPPORTED, ids=[_qid(e) for e in _COMPILER_SUPPORTED]
+    )
+    def test_executes_against_fixture(self, search_db, entry):
+        ast = parse_query(entry["query"])
+        compiled = compile_query(ast)
+        rows, timings = execute_search(search_db, compiled, mode="all")
+        assert isinstance(rows, list)
+        assert "query_ms" in timings

--- a/tests/test_search_generative.py
+++ b/tests/test_search_generative.py
@@ -1,0 +1,156 @@
+"""Tier 3: Generative testing with the reverse parser.
+
+Local tests (always run): verify generated queries parse, compile, and execute.
+Scryfall tests (--scryfall): compare results with Scryfall API (report mode).
+"""
+
+import json
+import pathlib
+import random
+
+import pytest
+
+from mtg_collector.search import SearchError, compile_query, parse_query
+from mtg_collector.search.compiler import execute_search
+
+
+@pytest.mark.generative
+class TestGenerativeLocal:
+    """Generate queries from seeds, verify they parse/compile/execute locally."""
+
+    def test_all_parse(self, seed_range):
+        """Every generated query must parse without error."""
+        from tests.search_helpers.query_generator import QueryGenerator
+
+        for seed in seed_range:
+            rng = random.Random(seed)
+            gen = QueryGenerator(rng, supported_only=True)
+            query = gen.generate()
+            try:
+                ast = parse_query(query)
+                assert ast is not None
+            except SearchError as e:
+                pytest.fail(f"Seed {seed} generated unparseable query: {query!r}\n  Error: {e}")
+
+    def test_all_compile(self, seed_range):
+        """Every generated query must compile to valid SQL (no unsupported fallback)."""
+        from tests.search_helpers.query_generator import QueryGenerator
+
+        for seed in seed_range:
+            rng = random.Random(seed)
+            gen = QueryGenerator(rng, supported_only=True)
+            query = gen.generate()
+            ast = parse_query(query)
+            compiled = compile_query(ast)
+            assert "1=0" not in compiled.where_sql, (
+                f"Seed {seed}: unsupported keyword in {query!r}"
+            )
+
+    def test_all_execute(self, search_db, seed_range):
+        """Every generated query must execute without SQL errors."""
+        from tests.search_helpers.query_generator import QueryGenerator
+
+        for seed in seed_range:
+            rng = random.Random(seed)
+            gen = QueryGenerator(rng, supported_only=True)
+            query = gen.generate()
+            ast = parse_query(query)
+            compiled = compile_query(ast)
+            try:
+                rows, _ = execute_search(search_db, compiled, mode="all")
+                assert isinstance(rows, list)
+            except Exception as e:
+                pytest.fail(f"Seed {seed}: SQL error for {query!r}\n  Error: {e}")
+
+
+@pytest.mark.generative
+@pytest.mark.scryfall
+class TestGenerativeScryfall:
+    """Compare generated query results with Scryfall API (report mode)."""
+
+    def test_results_report(self, search_db, known_oracle_ids,
+                            scryfall_cache, seed_range):
+        """Run generated queries against both local and Scryfall, write disagreement report."""
+        from tests.search_helpers.query_generator import QueryGenerator
+        from tests.search_helpers.result_comparator import compare_results
+        from tests.search_helpers.scryfall_client import scryfall_search
+
+        disagreements = []
+        skipped = 0
+        total = 0
+
+        for seed in seed_range:
+            total += 1
+            rng = random.Random(seed)
+            gen = QueryGenerator(rng, supported_only=True)
+            query = gen.generate()
+
+            # Local execution
+            ast = parse_query(query)
+            compiled = compile_query(ast)
+            try:
+                rows, _ = execute_search(search_db, compiled, mode="all")
+            except Exception:
+                skipped += 1
+                continue
+
+            # Scryfall execution
+            result = scryfall_search(scryfall_cache, query)
+            if result["status_code"] != 200:
+                skipped += 1
+                continue
+
+            # Compare
+            comparison = compare_results(
+                query, seed, rows, result["cards"], known_oracle_ids,
+                scryfall_total=result["total_cards"],
+            )
+            if not comparison.passed:
+                disagreements.append({
+                    "seed": seed,
+                    "query": query,
+                    "local_count": len(comparison.local_ids),
+                    "scryfall_count": len(comparison.scryfall_ids),
+                    "scryfall_total": result["total_cards"],
+                    "truncated": comparison.truncated,
+                    "local_only_count": len(comparison.local_only),
+                    "scryfall_only_count": len(comparison.scryfall_only),
+                    "local_only_sample": list(comparison.local_only)[:5],
+                    "scryfall_only_sample": list(comparison.scryfall_only)[:5],
+                })
+
+        # Classify disagreements
+        # "real" = local_only > 0 AND not truncated (we returned cards Scryfall didn't)
+        # "truncated" = Scryfall paginated, local_only not meaningful
+        # "coverage" = only scryfall_only > 0 (Scryfall matched printings not in our fixture)
+        real_bugs = [d for d in disagreements
+                     if d["local_only_count"] > 0 and not d.get("truncated")]
+        coverage_gaps = [d for d in disagreements
+                         if d["local_only_count"] == 0 and not d.get("truncated")]
+
+        # Write report (overwrite each run)
+        report_path = pathlib.Path(__file__).parent / ".scryfall_disagreements.json"
+        compared = total - skipped
+        report = {
+            "total_seeds": total,
+            "skipped": skipped,
+            "compared": compared,
+            "disagreements": len(disagreements),
+            "real_bugs": len(real_bugs),
+            "coverage_gaps": len(coverage_gaps),
+            "agreement_rate": (
+                f"{(compared - len(real_bugs)) / max(compared, 1) * 100:.1f}%"
+            ),
+            "details": disagreements[:50],
+        }
+        report_path.write_text(json.dumps(report, indent=2))
+
+        # Report mode: always pass, just log
+        print(f"\n  Scryfall comparison: {compared} compared, {skipped} skipped")
+        print(f"  Real bugs (local_only > 0): {len(real_bugs)}")
+        print(f"  Coverage gaps (scryfall-only, fixture missing printings): {len(coverage_gaps)}")
+        print(f"  Agreement rate (excluding coverage gaps): {report['agreement_rate']}")
+        print(f"  Report: {report_path}")
+        if real_bugs:
+            print(f"  First real bug: seed={real_bugs[0]['seed']}, "
+                  f"query={real_bugs[0]['query']!r}")

--- a/tests/test_search_parser.py
+++ b/tests/test_search_parser.py
@@ -1,0 +1,223 @@
+"""Tests for the Scryfall-style search query parser."""
+
+import pytest
+
+from mtg_collector.search import (
+    AndNode,
+    ComparisonNode,
+    ExactNameNode,
+    NameSearchNode,
+    NotNode,
+    OrNode,
+    SearchError,
+    parse_query,
+)
+
+
+class TestBareWords:
+    def test_single_word(self):
+        ast = parse_query("lightning")
+        assert isinstance(ast, NameSearchNode)
+        assert ast.term == "lightning"
+
+    def test_multiple_words_and(self):
+        ast = parse_query("lightning bolt")
+        assert isinstance(ast, AndNode)
+        assert len(ast.children) == 2
+        assert ast.children[0].term == "lightning"
+        assert ast.children[1].term == "bolt"
+
+
+class TestExactName:
+    def test_quoted_exact(self):
+        ast = parse_query('!"Lightning Bolt"')
+        assert isinstance(ast, ExactNameNode)
+        assert ast.name == "Lightning Bolt"
+
+    def test_unquoted_exact(self):
+        ast = parse_query("!bolt")
+        assert isinstance(ast, ExactNameNode)
+        assert ast.name == "bolt"
+
+
+class TestKeywordExpressions:
+    def test_colon_operator(self):
+        ast = parse_query("c:r")
+        assert isinstance(ast, ComparisonNode)
+        assert ast.keyword == "color"
+        assert ast.operator == ":"
+        assert ast.value == "r"
+
+    def test_equals_operator(self):
+        ast = parse_query("c=rg")
+        assert isinstance(ast, ComparisonNode)
+        assert ast.operator == "="
+        assert ast.value == "rg"
+
+    def test_gte_operator(self):
+        ast = parse_query("mv>=3")
+        assert isinstance(ast, ComparisonNode)
+        assert ast.keyword == "mana_value"
+        assert ast.operator == ">="
+        assert ast.value == "3"
+
+    def test_lte_operator(self):
+        ast = parse_query("pow<=5")
+        assert isinstance(ast, ComparisonNode)
+        assert ast.keyword == "power"
+        assert ast.operator == "<="
+        assert ast.value == "5"
+
+    def test_ne_operator(self):
+        ast = parse_query("c!=r")
+        assert isinstance(ast, ComparisonNode)
+        assert ast.operator == "!="
+
+    def test_gt_operator(self):
+        ast = parse_query("tou>3")
+        assert isinstance(ast, ComparisonNode)
+        assert ast.keyword == "toughness"
+        assert ast.operator == ">"
+
+    def test_lt_operator(self):
+        ast = parse_query("cmc<4")
+        assert isinstance(ast, ComparisonNode)
+        assert ast.keyword == "mana_value"
+        assert ast.operator == "<"
+
+    def test_quoted_value(self):
+        ast = parse_query('o:"enters tapped"')
+        assert isinstance(ast, ComparisonNode)
+        assert ast.keyword == "oracle"
+        assert ast.value == "enters tapped"
+
+    def test_type_keyword(self):
+        ast = parse_query("t:creature")
+        assert isinstance(ast, ComparisonNode)
+        assert ast.keyword == "type"
+        assert ast.value == "creature"
+
+    def test_set_keyword(self):
+        ast = parse_query("s:lea")
+        assert isinstance(ast, ComparisonNode)
+        assert ast.keyword == "set"
+        assert ast.value == "lea"
+
+    def test_rarity_keyword(self):
+        ast = parse_query("r:rare")
+        assert isinstance(ast, ComparisonNode)
+        assert ast.keyword == "rarity"
+
+    def test_format_keyword(self):
+        ast = parse_query("f:modern")
+        assert isinstance(ast, ComparisonNode)
+        assert ast.keyword == "format"
+
+    def test_artist_keyword(self):
+        ast = parse_query("a:rush")
+        assert isinstance(ast, ComparisonNode)
+        assert ast.keyword == "artist"
+
+
+class TestKeywordAliases:
+    def test_color_aliases(self):
+        for alias in ("c", "color", "colours"):
+            ast = parse_query(f"{alias}:r")
+            assert ast.keyword == "color", f"Failed for alias: {alias}"
+
+    def test_type_aliases(self):
+        for alias in ("t", "type"):
+            ast = parse_query(f"{alias}:creature")
+            assert ast.keyword == "type"
+
+    def test_mana_value_aliases(self):
+        for alias in ("mv", "cmc", "manavalue"):
+            ast = parse_query(f"{alias}>=3")
+            assert ast.keyword == "mana_value"
+
+    def test_power_aliases(self):
+        for alias in ("pow", "power"):
+            ast = parse_query(f"{alias}>=3")
+            assert ast.keyword == "power"
+
+
+class TestBooleanLogic:
+    def test_implicit_and(self):
+        ast = parse_query("c:r t:creature")
+        assert isinstance(ast, AndNode)
+        assert len(ast.children) == 2
+
+    def test_explicit_or(self):
+        ast = parse_query("c:r or c:g")
+        assert isinstance(ast, OrNode)
+        assert len(ast.children) == 2
+
+    def test_or_case_insensitive(self):
+        ast = parse_query("c:r OR c:g")
+        assert isinstance(ast, OrNode)
+
+    def test_negation(self):
+        ast = parse_query("-c:r")
+        assert isinstance(ast, NotNode)
+        assert isinstance(ast.child, ComparisonNode)
+
+    def test_negation_with_and(self):
+        ast = parse_query("-c:r t:creature")
+        assert isinstance(ast, AndNode)
+        assert isinstance(ast.children[0], NotNode)
+        assert isinstance(ast.children[1], ComparisonNode)
+
+    def test_parentheses(self):
+        ast = parse_query("(c:r or c:g) t:creature")
+        assert isinstance(ast, AndNode)
+        assert isinstance(ast.children[0], OrNode)
+        assert isinstance(ast.children[1], ComparisonNode)
+
+    def test_nested_parens(self):
+        ast = parse_query("((c:r or c:g) t:creature)")
+        # Should still be valid
+        assert isinstance(ast, AndNode)
+
+    def test_negated_group(self):
+        ast = parse_query("-(c:r or c:g)")
+        assert isinstance(ast, NotNode)
+        assert isinstance(ast.child, OrNode)
+
+
+class TestComplexQueries:
+    def test_full_scryfall_query(self):
+        ast = parse_query('c:r t:instant mv<=2 o:"deals damage"')
+        assert isinstance(ast, AndNode)
+        assert len(ast.children) == 4
+
+    def test_mixed_or_and(self):
+        ast = parse_query("(c:r or c:g) t:creature pow>=4")
+        assert isinstance(ast, AndNode)
+        assert len(ast.children) == 3
+
+    def test_is_flag(self):
+        ast = parse_query("is:foil")
+        assert isinstance(ast, ComparisonNode)
+        assert ast.keyword == "is_flag"
+        assert ast.value == "foil"
+
+
+class TestEdgeCases:
+    def test_empty_string(self):
+        """Empty string should raise or return empty."""
+        with pytest.raises(SearchError):
+            parse_query("")
+
+    def test_whitespace_only(self):
+        with pytest.raises(SearchError):
+            parse_query("   ")
+
+    def test_unknown_keyword(self):
+        with pytest.raises(SearchError) as exc_info:
+            parse_query("xyz:value")
+        assert "xyz" in str(exc_info.value).lower()
+
+    def test_unknown_keyword_position(self):
+        with pytest.raises(SearchError) as exc_info:
+            parse_query("xyz:value")
+        assert exc_info.value.position >= 0

--- a/tests/test_search_scryfall.py
+++ b/tests/test_search_scryfall.py
@@ -1,0 +1,57 @@
+"""Tier 2: Scryfall API agreement tests.
+
+Verifies that our parser and Scryfall agree on whether each corpus query is valid.
+Requires --scryfall flag to run (skipped by default).
+"""
+
+import pathlib
+
+import pytest
+import yaml
+
+from mtg_collector.search import SearchError, parse_query
+
+_CORPUS_PATH = pathlib.Path(__file__).parent / "fixtures" / "search_query_corpus.yaml"
+with open(_CORPUS_PATH) as f:
+    _CORPUS = yaml.safe_load(f)
+
+# Only test entries that have an opinion on parseability
+_ALL_ENTRIES = [e for e in _CORPUS if e["query"].strip()]
+
+
+def _qid(entry):
+    return entry["query"] or "<empty>"
+
+
+@pytest.mark.scryfall
+class TestScryfallAgreement:
+    """Our parser and Scryfall should agree on whether a query is valid."""
+
+    @pytest.mark.parametrize("entry", _ALL_ENTRIES, ids=[_qid(e) for e in _ALL_ENTRIES])
+    def test_parse_agreement(self, scryfall_cache, entry):
+        from tests.search_helpers.scryfall_client import scryfall_search
+
+        query = entry["query"]
+
+        # Our parser result
+        our_parses = True
+        try:
+            parse_query(query)
+        except SearchError:
+            our_parses = False
+
+        # Scryfall result
+        result = scryfall_search(scryfall_cache, query)
+        scryfall_accepts = result["status_code"] == 200
+
+        if our_parses and not scryfall_accepts:
+            # We accept but Scryfall rejects — might be syntax we parse
+            # but Scryfall doesn't support (or vice versa). Log but don't
+            # hard-fail since our syntax is a subset.
+            pass
+
+        if not our_parses and scryfall_accepts:
+            pytest.fail(
+                f"Scryfall accepts but we reject: {query!r}\n"
+                f"  Scryfall returned {result['total_cards']} cards"
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -666,6 +666,15 @@ wheels = [
 ]
 
 [[package]]
+name = "lark"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
+]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -681,6 +690,7 @@ source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "beautifulsoup4" },
+    { name = "lark" },
     { name = "numpy" },
     { name = "onnxruntime" },
     { name = "rapidocr" },
@@ -709,6 +719,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.18.0" },
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
+    { name = "lark", specifier = ">=1.1" },
     { name = "numpy", specifier = "<2" },
     { name = "onnxruntime", specifier = ">=1.18.0,<=1.23.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },


### PR DESCRIPTION
## Summary

- **Scryfall-syntax search engine**: Parser → AST → SQL compiler → new `/api/search` endpoint. Supports bare words, `c:r`, `t:instant`, `mv>=3`, `o:"enters tapped"`, `r>=r`, `f:modern`, `is:foil`, `kw:flying`, boolean logic (`AND`/`OR`/`NOT`/parens), exact names (`!"Lightning Bolt"`), and 50+ keyword prefixes with all operators.
- **Schema migration v42**: Extracts power, toughness, loyalty, layout, keywords, legalities, flavor_text, and 8 other fields from `raw_json` into real columns. Adds FTS5 virtual table for future text search optimization.
- **Frontend integration**: Search bar auto-detects Scryfall syntax and routes to `/api/search`. Existing pill filters still work as client-side post-filters. Error display for invalid syntax.
- **Query timing instrumentation**: Response headers (`X-Search-Parse-Ms`, `X-Search-Query-Ms`, etc.) and slow query logging with `EXPLAIN QUERY PLAN` output.
- **Three-tier test automation** (940 tests passing):
  - **Tier 1**: 193-entry query corpus (Scryfall docs + community sources) with parameterized parse/compile/execute tests
  - **Tier 2**: Scryfall API agreement tests (`--scryfall` flag, SQLite-cached responses)
  - **Tier 3**: Generative testing via reverse parser — builds random valid queries from seeded RNG, executes locally and compares against Scryfall API. Cache auto-invalidates when generator source changes. 91.9% agreement rate on 50 seeds against full 110K-card DB.

## Test plan

- [x] `uv run pytest tests/ -q --ignore=tests/ui/ --ignore=tests/integration/ --ignore=tests/test_ocr.py --ignore=tests/test_reprocess_refinish.py --seeds 200` — 940 passed
- [x] `uv run pytest tests/test_search_scryfall.py --scryfall` — 163 corpus queries agree with Scryfall API
- [x] `uv run pytest tests/test_search_generative.py --scryfall --seeds 50` — 91.9% agreement rate, 3 residual edge cases (MB2 playtest cards)
- [ ] Container validation with `bash deploy/setup.sh scryfall-search --test`
- [ ] `/qa-finish` for UI scenario tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)