### PR TITLE
Rework collection header: brand logo, larger search, visible Syntax pill

### DIFF
--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -22,20 +22,54 @@ body {
 
 header {
   background: #16213e;
-  padding: 16px 24px;
+  padding: 12px 24px;
   display: flex;
-  align-items: center;
-  gap: 16px;
-  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 10px;
   border-bottom: 2px solid #0f3460;
 }
 
-header h1 {
-  font-size: 1.3rem;
-  color: #e94560;
-  margin-right: 16px;
-  white-space: nowrap;
+.header-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
 }
+.header-row-search {
+  gap: 12px;
+  flex-wrap: nowrap;
+}
+
+.brand-logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #e94560;
+  width: 44px;
+  height: 44px;
+  flex-shrink: 0;
+  border-radius: 8px;
+  text-decoration: none;
+  transition: background 0.15s;
+}
+.brand-logo:hover { background: rgba(233,69,96,0.12); }
+.brand-logo svg { display: block; }
+
+.syntax-help-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+  padding: 6px 12px;
+  border: 1px solid #0f3460;
+  border-radius: 6px;
+  background: #1a1a2e;
+  color: #888;
+  text-decoration: none;
+  font-size: 0.85rem;
+}
+.syntax-help-link:hover { color: #e94560; border-color: #e94560; }
 
 .controls {
   display: flex;
@@ -93,12 +127,18 @@ button.secondary.active { background: #0f3460; border-color: #e94560; }
   position: relative;
 }
 
-#search-input { flex: 1; min-width: 280px; }
+#search-input {
+  flex: 1;
+  width: 100%;
+  min-width: 0;
+  font-size: 1rem;
+  padding: 11px 16px;
+}
 #search-error { color: #e94560; font-size: 11px; position: absolute; top: 100%; left: 0; white-space: nowrap; z-index: 10; }
-.search-wrap { position: relative; }
+.search-wrap { position: relative; flex: 1; min-width: 0; display: flex; align-items: center; }
 /* Autocomplete dropdown */
 .ac-dropdown {
-  display: none; position: absolute; top: 100%; left: 0; right: 40px;
+  display: none; position: absolute; top: 100%; left: 0; right: 0;
   background: #16213e; border: 1px solid #0f3460; border-top: none;
   border-radius: 0 0 6px 6px; max-height: 260px; overflow-y: auto;
   z-index: 100; box-shadow: 0 4px 12px rgba(0,0,0,0.4);
@@ -1076,9 +1116,10 @@ tr.ordered td:first-child { border-left: 3px solid #f0a030; }
 #sel-delete-btn:hover { background: #7a2a2a; color: #fff; }
 
 @media (max-width: 768px) {
-  #search-input { width: 100%; }
-  .search-wrap { width: 100%; order: -1; }
-  .controls { flex-wrap: wrap; }
+  header { padding: 10px 12px; }
+  .header-row-search { gap: 8px; }
+  .brand-logo { width: 40px; height: 40px; }
+  #search-input { font-size: 1rem; padding: 10px 14px; }
   .wishlist-panel { width: 280px; right: -300px; }
 }
 </style>
@@ -1087,14 +1128,20 @@ tr.ordered td:first-child { border-left: 3px solid #f0a030; }
 <body>
 
 <header>
-  <h1><a href="/" style="color:inherit;text-decoration:none">Collection</a></h1>
-  <div class="controls">
-    <div class="search-wrap" style="flex:1;display:flex;align-items:center;gap:4px">
+  <div class="header-row header-row-search">
+    <a href="/" class="brand-logo" title="Home" aria-label="Home">
+      <svg viewBox="0 0 32 32" width="30" height="30" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linejoin="round" stroke-linecap="round">
+        <rect x="5" y="6" width="14" height="20" rx="2" transform="rotate(-9 12 16)"/>
+        <rect x="13" y="6" width="14" height="20" rx="2" transform="rotate(9 20 16)"/>
+      </svg>
+    </a>
+    <div class="search-wrap">
       <input type="text" id="search-input" placeholder="Search (e.g. t:creature c:r mv>=3)" autocomplete="off">
-      <a href="/search-help" target="_blank" title="Search syntax help" style="color:#888;font-size:0.8rem;text-decoration:none">?</a>
       <div id="search-error"></div>
       <div class="ac-dropdown" id="ac-dropdown"></div>
     </div>
+  </div>
+  <div class="header-row">
     <div class="view-toggle-group" id="view-toggle-group">
       <button class="secondary" id="view-table-btn" title="Table view"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><rect x="1" y="2" width="14" height="2" rx=".5"/><rect x="1" y="7" width="14" height="2" rx=".5"/><rect x="1" y="12" width="14" height="2" rx=".5"/></svg></button>
       <button class="secondary" id="view-grid-btn" title="Grid view"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><rect x="1" y="1" width="6" height="6" rx="1"/><rect x="9" y="1" width="6" height="6" rx="1"/><rect x="1" y="9" width="6" height="6" rx="1"/><rect x="9" y="9" width="6" height="6" rx="1"/></svg></button>
@@ -1122,6 +1169,7 @@ tr.ordered td:first-child { border-left: 3px solid #f0a030; }
       </div>
     </div>
     <div class="col-controls" id="grid-size-wrap" style="display:none"><button class="col-btn" id="col-minus">&minus;</button><div class="col-count" id="col-count"></div><button class="col-btn" id="col-plus">+</button></div>
+    <a href="/search-help" target="_blank" class="syntax-help-link" title="Search syntax help"><span aria-hidden="true">?</span> Syntax</a>
   </div>
   <div id="status"></div>
 </header>

--- a/tests/ui/hints/collection_brand_logo_links_home.yaml
+++ b/tests/ui/hints/collection_brand_logo_links_home.yaml
@@ -1,0 +1,10 @@
+start_page: /collection
+involves:
+  - 'brand logo link (a.brand-logo) immediately left of the search input'
+  - 'card-stack SVG icon inside the brand logo'
+  - 'homepage h1 "MTG Collection Tools" as the navigation target marker'
+notes: >
+  Start on /collection. Wait for the search input to be ready, then
+  assert the brand logo (a.brand-logo) is visible. Click it. The
+  browser should navigate to the homepage; wait for the "MTG Collection
+  Tools" h1 text to confirm we landed there.

--- a/tests/ui/hints/collection_syntax_help_pill.yaml
+++ b/tests/ui/hints/collection_syntax_help_pill.yaml
@@ -1,0 +1,13 @@
+start_page: /collection
+involves:
+  - 'syntax help pill (a.syntax-help-link) on the second header row'
+  - 'pill text "Syntax" with leading "?" glyph'
+  - 'pill href points to /search-help and opens in a new tab'
+notes: >
+  Start on /collection. Wait for the search input to be ready, then
+  assert the syntax help pill (a.syntax-help-link) is visible. Verify
+  the visible "Syntax" text is on the page (the leading "?" glyph is
+  aria-hidden so we don't assert on it). Verify the link's href and
+  target attributes via an attribute selector. We don't actually click
+  the link because target="_blank" opens a new tab; coverage of the
+  destination page itself lives in collection_search_help_page.

--- a/tests/ui/implementations/collection_brand_logo_links_home.py
+++ b/tests/ui/implementations/collection_brand_logo_links_home.py
@@ -1,0 +1,22 @@
+"""
+Hand-written implementation for collection_brand_logo_links_home.
+
+Verifies the new card-stack brand logo in the collection header links
+back to the homepage. Replaces the role of the removed "Collection"
+title row as the way to navigate out of the collection view.
+"""
+
+
+def steps(harness):
+    # start_page: /collection — auto-navigated by test runner.
+    harness.wait_for_visible("#search-input")
+
+    # Brand logo sits immediately left of the search box.
+    harness.assert_visible("a.brand-logo")
+    harness.assert_visible("a.brand-logo[href='/']")
+
+    # Clicking the logo navigates to the homepage.
+    harness.click_by_selector("a.brand-logo")
+    harness.wait_for_text("MTG Collection Tools")
+
+    harness.screenshot("final_state")

--- a/tests/ui/implementations/collection_syntax_help_pill.py
+++ b/tests/ui/implementations/collection_syntax_help_pill.py
@@ -1,0 +1,24 @@
+"""
+Hand-written implementation for collection_syntax_help_pill.
+
+Verifies the new visible "? Syntax" pill in the collection header is
+discoverable and points at /search-help. Replaces the previous tiny
+inline "?" link that was hard to find and hard to tap on touch devices.
+The destination page itself is covered by collection_search_help_page.
+"""
+
+
+def steps(harness):
+    # start_page: /collection — auto-navigated by test runner.
+    harness.wait_for_visible("#search-input")
+
+    # The pill is rendered as a bordered link, easy to spot.
+    harness.assert_visible("a.syntax-help-link")
+    harness.assert_text_present("Syntax")
+
+    # Verify the pill links to the search help page in a new tab.
+    harness.assert_visible(
+        "a.syntax-help-link[href='/search-help'][target='_blank']"
+    )
+
+    harness.screenshot("final_state")

--- a/tests/ui/implementations/homepage_nav_links_collection.py
+++ b/tests/ui/implementations/homepage_nav_links_collection.py
@@ -9,9 +9,10 @@ def steps(harness):
     # start_page: / — auto-navigated by test runner.
 
     # Click Cards link and verify navigation.
-    # The h1 on /collection says "Collection" (title is "Collection Browser").
+    # The collection page no longer has a "Collection" h1; wait for the
+    # search input which is the most stable marker on the new layout.
     harness.click_by_selector("a[href='/collection']")
-    harness.wait_for_text("Collection")
+    harness.wait_for_visible("#search-input")
     harness.navigate("/")
 
     # Click Decks link and verify navigation

--- a/tests/ui/intents/collection_brand_logo_links_home.yaml
+++ b/tests/ui/intents/collection_brand_logo_links_home.yaml
@@ -1,0 +1,11 @@
+# Scenario: Brand logo in collection header navigates back to homepage
+#
+# Related:
+#   issues: []
+#   pull_requests: []
+
+description: >
+  When I am on the Collection page, I can see a small card-stack logo
+  at the left end of the search row. Clicking the logo takes me back
+  to the homepage, giving me a consistent way out of the collection
+  view now that the standalone "Collection" title row has been removed.

--- a/tests/ui/intents/collection_syntax_help_pill.yaml
+++ b/tests/ui/intents/collection_syntax_help_pill.yaml
@@ -1,0 +1,12 @@
+# Scenario: Visible "? Syntax" pill in collection header is discoverable
+#
+# Related:
+#   issues: []
+#   pull_requests: []
+
+description: >
+  When I am on the Collection page, I can see a clearly bordered
+  "? Syntax" pill at the right end of the second header row. The pill
+  is much easier to find and tap than the previous tiny "?" icon, and
+  it links to the search syntax help page so I can look up query
+  operators without hunting for a hidden link.


### PR DESCRIPTION
## Summary
- Restructure the collection header into two rows: a card-stack brand logo (links home) + wide search input on row one; view toggle, hamburger, grid-size, and a visible **? Syntax** pill on row two
- Bump the search input to `1rem` font + `11px 16px` padding so it's easier to read; on mobile the search bar now fills the narrow viewport naturally
- Replace the easy-to-miss tiny `?` help link inside the search wrap with a clearly bordered `.syntax-help-link` pill at the right end of row two
- Drop the standalone "Collection" h1 row that was mostly empty space — the brand logo is now the way home

## Why
The old `?` was 0.8rem gray text crammed inside the search input wrap — invisible on desktop, basically untappable on a touchscreen, and gave no indication of what it was. The "Collection" title row added a whole header row that did nothing useful.

## Test plan
- [x] New UI scenario `collection_brand_logo_links_home` — asserts `a.brand-logo` is visible left of `#search-input`, clicks it, waits for the `MTG Collection Tools` h1
- [x] New UI scenario `collection_syntax_help_pill` — asserts the visible `a.syntax-help-link` pill is present with "Syntax" text and points at `/search-help` with `target="_blank"`
- [x] Fixed `homepage_nav_links_collection` — was waiting on the removed `Collection` h1; now waits for `#search-input` instead
- [x] All three pass against a `--test` container (`uv run pytest tests/ui/ -v --instance qa-finish -k "collection_brand_logo_links_home or collection_syntax_help_pill or homepage_nav_links_collection"`)
- [x] Visually verified at 1280px desktop and 390px mobile widths via `shot-scraper`

🤖 Generated with [Claude Code](https://claude.com/claude-code)