### PR TITLE
Pin collection header and move status onto the controls row

### DIFF
--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -22,12 +22,15 @@ body {
 
 header {
   background: #16213e;
-  padding: 12px 24px;
+  padding: 10px 24px;
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  gap: 10px;
+  gap: 8px;
   border-bottom: 2px solid #0f3460;
+  position: sticky;
+  top: 0;
+  z-index: 50;
 }
 
 .header-row {
@@ -39,6 +42,14 @@ header {
 .header-row-search {
   gap: 12px;
   flex-wrap: nowrap;
+}
+.header-row-right {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .brand-logo {
@@ -60,7 +71,6 @@ header {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  margin-left: auto;
   padding: 6px 12px;
   border: 1px solid #0f3460;
   border-radius: 6px;
@@ -164,7 +174,9 @@ button.secondary.active { background: #0f3460; border-color: #e94560; }
 #status {
   font-size: 0.85rem;
   color: #888;
-  margin-left: auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* Layout */
@@ -1169,9 +1181,11 @@ tr.ordered td:first-child { border-left: 3px solid #f0a030; }
       </div>
     </div>
     <div class="col-controls" id="grid-size-wrap" style="display:none"><button class="col-btn" id="col-minus">&minus;</button><div class="col-count" id="col-count"></div><button class="col-btn" id="col-plus">+</button></div>
-    <a href="/search-help" target="_blank" class="syntax-help-link" title="Search syntax help"><span aria-hidden="true">?</span> Syntax</a>
+    <div class="header-row-right">
+      <div id="status"></div>
+      <a href="/search-help" target="_blank" class="syntax-help-link" title="Search syntax help"><span aria-hidden="true">?</span> Syntax</a>
+    </div>
   </div>
-  <div id="status"></div>
 </header>
 
 <div class="selection-bar" id="selection-bar">

--- a/tests/ui/hints/collection_header_sticky_on_scroll.yaml
+++ b/tests/ui/hints/collection_header_sticky_on_scroll.yaml
@@ -1,0 +1,15 @@
+start_page: /collection
+involves:
+  - 'sticky <header> element (position: sticky; top: 0; z-index: 50)'
+  - 'brand logo (a.brand-logo), search input (#search-input), and syntax help pill (a.syntax-help-link) inside the header'
+  - 'window scrollY > 0 after scrolling'
+  - 'header.getBoundingClientRect().top stays at 0 after scrolling'
+notes: >
+  Start on /collection. Wait for the card list (.layout #main) to
+  finish rendering. Use harness.scroll("down") several times to drive
+  window.scrollY meaningfully positive. Then read window.scrollY and
+  the header's bounding rect via harness.page.evaluate. Assert
+  scrollY is > 100 (proving we actually scrolled) and that the
+  header's top is at 0 (proving sticky held). Also spot-check that
+  the brand logo and search input are still visible so the test's
+  intent is obvious from the assertion log.

--- a/tests/ui/hints/collection_modal_overlays_sticky_header.yaml
+++ b/tests/ui/hints/collection_modal_overlays_sticky_header.yaml
@@ -1,0 +1,16 @@
+start_page: /collection
+involves:
+  - 'any card row in the table (first tbody tr)'
+  - 'card detail modal overlay (#card-modal-overlay.active) at z-index 100'
+  - 'sticky <header> element at z-index 50'
+  - 'document.elementFromPoint at a point inside the header region returns an element inside #card-modal-overlay after the modal opens'
+notes: >
+  Start on /collection. Wait for the table to render. Click the first
+  card row to open the modal. Wait for #card-modal-overlay to become
+  visible with the .active class. Then use harness.page.evaluate with
+  document.elementFromPoint(window.innerWidth / 2, 20) — at y=20 we're
+  well inside the header region. If the modal's z-index stack is
+  correct, the returned element will be inside #card-modal-overlay.
+  If someone later bumps header's z-index above 100 (or drops the
+  modal's below 50), the returned element will be the header or one
+  of its children, and the test catches it.

--- a/tests/ui/implementations/collection_header_sticky_on_scroll.py
+++ b/tests/ui/implementations/collection_header_sticky_on_scroll.py
@@ -1,0 +1,43 @@
+"""
+Hand-written implementation for collection_header_sticky_on_scroll.
+
+Verifies position: sticky on the collection header holds after the
+user scrolls the card list. Reads window.scrollY + header bounding
+rect via page.evaluate to prove both that we actually scrolled and
+that the header stayed pinned at the top of the viewport.
+"""
+
+
+def steps(harness):
+    # start_page: /collection — auto-navigated by test runner.
+    harness.wait_for_visible("#search-input")
+    # Wait for the table body to populate so scrolling has somewhere to go.
+    harness.wait_for_visible(".layout #main")
+
+    # Scroll down several times to drive scrollY meaningfully positive.
+    # harness.scroll("down") uses mouse wheel delta 500.
+    for _ in range(5):
+        harness.scroll("down")
+
+    # Read scroll position and header bounding rect from the live page.
+    state = harness.page.evaluate("""() => {
+      const header = document.querySelector('header');
+      const rect = header.getBoundingClientRect();
+      return { scrollY: window.scrollY, headerTop: rect.top, headerVisible: rect.bottom > 0 };
+    }""")
+    assert state["scrollY"] > 100, (
+        f"Expected window.scrollY > 100 after scrolling, got {state['scrollY']}. "
+        f"If this is 0 the test didn't actually scroll and the sticky assertion is meaningless."
+    )
+    assert abs(state["headerTop"]) < 2, (
+        f"Expected sticky header to stay pinned at top (y=0), got headerTop={state['headerTop']}. "
+        f"The header has scrolled off with the rest of the page — position: sticky is broken."
+    )
+    assert state["headerVisible"], "Header bounding rect has zero height — something is very wrong."
+
+    # Sanity: key header elements are still visible to the user after scroll.
+    harness.assert_visible("a.brand-logo")
+    harness.assert_visible("#search-input")
+    harness.assert_visible("a.syntax-help-link")
+
+    harness.screenshot("final_state")

--- a/tests/ui/implementations/collection_modal_overlays_sticky_header.py
+++ b/tests/ui/implementations/collection_modal_overlays_sticky_header.py
@@ -1,0 +1,42 @@
+"""
+Hand-written implementation for collection_modal_overlays_sticky_header.
+
+Proves the card detail modal (z-index 100) still visually covers the
+sticky header (z-index 50). Uses document.elementFromPoint at a
+coordinate inside the header region to verify that what's at that
+point after the modal opens is part of the modal, not the header.
+"""
+
+
+def steps(harness):
+    # start_page: /collection — auto-navigated by test runner.
+    harness.wait_for_visible("#search-input")
+    harness.wait_for_visible("tr[data-idx]")
+
+    # Switch to grid view before clicking a card: table rows center-click
+    # often lands on a [data-filter-type] cell (mana cost, color pill, etc.)
+    # which triggers the filter path instead of the modal. Grid cards are
+    # a single clickable region with a cleaner target.
+    harness.click_by_selector("#view-grid-btn")
+    harness.click_by_selector(".sheet-card[data-idx]")
+    harness.wait_for_visible("#card-modal-overlay.active")
+
+    # What element sits at (viewportCenterX, 20)? y=20 is inside the
+    # header's vertical band. With modal z-index 100 above header's 50,
+    # it must be something inside #card-modal-overlay.
+    result = harness.page.evaluate("""() => {
+      const el = document.elementFromPoint(window.innerWidth / 2, 20);
+      if (!el) return { tag: null, underModal: false };
+      return {
+        tag: el.tagName.toLowerCase(),
+        underModal: el.closest('#card-modal-overlay') !== null,
+        inHeader: el.closest('header') !== null,
+      };
+    }""")
+    assert result["underModal"], (
+        f"Expected element at (centerX, 20) to be inside #card-modal-overlay, "
+        f"but got <{result['tag']}> (inHeader={result.get('inHeader')}). "
+        f"The sticky header is bleeding through the modal — z-index stack regression."
+    )
+
+    harness.screenshot("final_state")

--- a/tests/ui/intents/collection_header_sticky_on_scroll.yaml
+++ b/tests/ui/intents/collection_header_sticky_on_scroll.yaml
@@ -1,0 +1,12 @@
+# Scenario: Collection header stays pinned when the list is scrolled
+#
+# Related:
+#   issues: []
+#   pull_requests: []
+
+description: >
+  When I am on the Collection page and I scroll the card list down, the
+  dark blue header bar stays pinned to the top of the viewport. The
+  brand logo, search input, layout controls, and "? Syntax" pill remain
+  visible and reachable without scrolling back up, so long lists don't
+  require constant jumping between top and the content I'm browsing.

--- a/tests/ui/intents/collection_modal_overlays_sticky_header.yaml
+++ b/tests/ui/intents/collection_modal_overlays_sticky_header.yaml
@@ -1,0 +1,13 @@
+# Scenario: Card detail modal visually covers the pinned header
+#
+# Related:
+#   issues: []
+#   pull_requests: []
+
+description: >
+  When I click a card on the Collection page, the card detail modal
+  opens and its dark backdrop fully covers the page — including the
+  now-sticky header at the top. I cannot see the search bar or layout
+  controls bleeding through the modal, because the modal's z-index
+  sits above the header's. This preserves the pre-sticky feeling that
+  the modal is a true "on top of everything" overlay.


### PR DESCRIPTION
## Summary
- Fold the "N entries, M cards — \$X" status line into row 2 of the collection header (alongside the "? Syntax" pill), eliminating the standalone third row that used to take a full line for half a line of text
- Pin the header to the top with `position: sticky` so the collection list now scrolls underneath it
- Card modal (z-index 100) and columns drawer (z-index 91) still overlay the pinned header (z-index 50) as before

## Why
The previous header was 3 rows tall: search, controls, status. Row 3 was visual noise — half a line of text on its own strip — and contributed no value the row-2 gap couldn't absorb. Pinning the whole thing was a natural follow-up since on long collections you'd lose the search bar entirely after a few pages of scroll.

## Test plan
- [x] Screenshot at 1280px desktop: row-2 status text visible next to "? Syntax" pill, header ~2 rows tall
- [x] Screenshot at 390px mobile: row 2 wraps gracefully, status ellipsizes on narrow viewports via `white-space: nowrap; text-overflow: ellipsis`
- [x] Scroll test (`window.scrollTo(0, 600)`): header stays pinned at top while collection rows change underneath
- [x] Card modal test (open modal via click): modal overlay cleanly covers the sticky header
- [x] No UI test depends on `#status` being in its own row — verified via grep; `collection_syntax_help_pill.py` still finds `a.syntax-help-link` in its new position inside `.header-row-right`

🤖 Generated with [Claude Code](https://claude.com/claude-code)