### PR TITLE
Fix clipped More menu and add is:unowned search keyword

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ Cards use CSS custom properties `--rarity-color` and `--set-color` with `linear-
 
 ### Collection page filtering
 
-All filtering uses a single Scryfall-style query bar (`?q=...`). Standard Scryfall syntax plus collection extensions: `status:`, `added:`, `price:`, `deck:`, `binder:`, `is:unassigned`, `is:decked`, `is:bindered`, `is:wanted`, `order:price`. Default filter: `status:owned OR status:ordered` (when no explicit `status:` in query). Autocomplete suggests keywords and values. Help page at `/search-help`.
+All filtering uses a single Scryfall-style query bar (`?q=...`). Standard Scryfall syntax plus collection extensions: `status:`, `added:`, `price:`, `deck:`, `binder:`, `is:unassigned`, `is:decked`, `is:bindered`, `is:wanted`, `is:unowned`, `order:price`. Default filter: `status:owned OR status:ordered` (when no explicit `status:` in query). `is:unowned` flips the query to a LEFT JOIN against `printings` so cards not yet in the collection appear (useful for adding a card from its modal/detail page). Autocomplete suggests keywords and values. Help page at `/search-help`.
 
 ### Card data access policy
 

--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -2001,9 +2001,13 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                 self._send_json({"error": str(e), "position": e.position}, 400)
                 return
 
+        # is:unowned flips to the LEFT-JOIN template so cards not in the
+        # collection can appear in results.
+        include_unowned = bool(compiled and compiled.include_unowned)
+
         # Status default: owned (unless query has explicit status: filter)
         has_status = compiled and compiled.has_status_filter
-        if not has_status and not card_pairs:
+        if not has_status and not card_pairs and not include_unowned:
             if where_sql == "1=1":
                 where_sql = "c.status IN ('owned', 'ordered')"
             else:
@@ -2067,8 +2071,8 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                 )
             return "\n                ".join(joins)
 
-        if card_pairs:
-            # Shared card links: LEFT JOIN so unowned cards appear
+        if card_pairs or include_unowned:
+            # LEFT JOIN template: shared-link cards or is:unowned queries
             query = f"""
                 SELECT
                     card.oracle_id, card.name, card.type_line, card.mana_cost, card.cmc,
@@ -2189,7 +2193,7 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         cursor = conn.execute(query, sql_params)
         rows = cursor.fetchall()
 
-        include_unowned = bool(card_pairs)
+        include_unowned = bool(card_pairs) or include_unowned
         results = []
         for row in rows:
             mana_cost = row["mana_cost"]

--- a/mtg_collector/search/compiler.py
+++ b/mtg_collector/search/compiler.py
@@ -23,7 +23,7 @@ class CompiledQuery:
     __slots__ = (
         "where_sql", "params", "needs_fts", "order_by", "order_dir",
         "needs_deck_join", "needs_price_join", "needs_wishlist_join",
-        "has_status_filter",
+        "has_status_filter", "include_unowned",
     )
 
     def __init__(self):
@@ -36,6 +36,7 @@ class CompiledQuery:
         self.needs_price_join: bool = False
         self.needs_wishlist_join: bool = False
         self.has_status_filter: bool = False
+        self.include_unowned: bool = False
 
 
 class CompileError(Exception):
@@ -667,6 +668,11 @@ def _compile_is_flag(val: str, ctx: CompiledQuery | None = None) -> tuple[str, l
         if ctx:
             ctx.needs_wishlist_join = True
         return "_wl.id IS NOT NULL", []
+    if lower == "unowned":
+        if ctx:
+            ctx.include_unowned = True
+            ctx.has_status_filter = True
+        return "c.id IS NULL", []
 
     sql = _IS_FLAG_MAP.get(lower)
     if sql:

--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -613,13 +613,15 @@ a.lineage-link {
   display: none;
   position: absolute;
   top: 100%;
-  right: 0;
+  left: 0;
+  right: auto;
   background: #16213e;
   border: 1px solid #0f3460;
   border-radius: 6px;
   padding: 6px 0;
   z-index: 60;
-  min-width: 160px;
+  min-width: 200px;
+  max-width: calc(100vw - 24px);
   box-shadow: 0 4px 12px rgba(0,0,0,0.4);
 }
 .col-config-dropdown.open { display: block; }
@@ -2969,7 +2971,7 @@ const AC_VALUES = {
   'id:': ['w','u','b','r','g','c','m','azorius','dimir','rakdos','gruul','selesnya'],
   'r:': ['common','uncommon','rare','mythic'],
   't:': ['creature','instant','sorcery','enchantment','artifact','planeswalker','land','battle','legendary','token','elf','goblin','human','merfolk','dragon','wizard','angel','demon'],
-  'is:': ['foil','nonfoil','etched','fullart','borderless','showcase','extendedart','promo','reprint','reserved','firstprint','commander','vanilla','split','transform','mdfc','adventure','saga','unassigned','decked','bindered','wanted'],
+  'is:': ['foil','nonfoil','etched','fullart','borderless','showcase','extendedart','promo','reprint','reserved','firstprint','commander','vanilla','split','transform','mdfc','adventure','saga','unassigned','decked','bindered','wanted','unowned'],
   'has:': ['watermark','flavor','power','toughness','loyalty'],
   'f:': ['standard','modern','legacy','vintage','commander','pioneer','pauper'],
   'status:': ['owned','ordered','sold','traded','gifted','lost'],

--- a/mtg_collector/static/search-help.html
+++ b/mtg_collector/static/search-help.html
@@ -428,6 +428,10 @@ They filter based on your personal collection data.</p>
       <td><code>is:wanted</code></td>
       <td>Cards on your unfulfilled wishlist</td>
     </tr>
+    <tr>
+      <td><code>is:unowned</code></td>
+      <td>Cards in the local database that you don't own yet. Useful for finding a printing to add from its modal or detail page (e.g. <code>is:unowned "Lightning Bolt"</code>).</td>
+    </tr>
   </tbody>
 </table>
 

--- a/tests/test_search_compiler.py
+++ b/tests/test_search_compiler.py
@@ -290,6 +290,12 @@ class TestCollectionKeywords:
         assert "NOT" in c.where_sql
         assert "_wl.id IS NOT NULL" in c.where_sql
 
+    def test_is_unowned(self):
+        c = _compile("is:unowned")
+        assert c.include_unowned
+        assert c.has_status_filter
+        assert "c.id IS NULL" in c.where_sql
+
 
 class TestSQLValidity:
     """Test that compiled queries produce valid SQL by executing against an in-memory DB."""

--- a/tests/ui/hints/collection_more_menu_in_viewport.yaml
+++ b/tests/ui/hints/collection_more_menu_in_viewport.yaml
@@ -1,0 +1,14 @@
+start_page: /collection
+involves:
+  - 'vertical-ellipsis More button (#more-menu-btn)'
+  - 'dropdown panel (#more-menu-dropdown, toggled open via .col-config-dropdown.open)'
+  - 'menu items: Wishlist, Toggle Multi-Select, Image Display, Saved Views'
+fixture_data: {}
+notes: >
+  The panel is positioned absolutely relative to the col-config-wrap
+  container with left:0 and max-width:calc(100vw - 24px). When the
+  More button is clicked, #more-menu-dropdown receives the "open"
+  class which sets display:block. The test should open the menu and
+  verify the Wishlist, Toggle Multi-Select, Image Display, and Saved
+  Views labels are visible on the page (the CSS fix ensures the panel
+  is not clipped off the left edge of the viewport).

--- a/tests/ui/hints/collection_search_unowned.yaml
+++ b/tests/ui/hints/collection_search_unowned.yaml
@@ -1,0 +1,20 @@
+start_page: /collection
+involves:
+  - 'search input (#search-input) with placeholder "Search (e.g. t:creature c:r mv>=3)"'
+  - 'status text (#status) showing entry/card counts'
+  - 'collection table (.collection-table)'
+fixture_data:
+  owned_lotus_cards: 0
+  unowned_lotus_printings: 3
+  unowned_lotus_names:
+    - "Gilded Lotus"
+    - "Lotus Bloom"
+    - "Lotus Petal"
+notes: >
+  The test fixture contains 0 collection rows matching "lotus". Three
+  printings exist in the card database that match: Gilded Lotus,
+  Lotus Bloom, Lotus Petal. Searching "lotus" alone returns "0
+  entries". Searching "is:unowned lotus" triggers the LEFT-JOIN
+  template in _api_collection and surfaces all three printings, each
+  rendered with the .unowned class (dimmed opacity) and the status
+  bar shows "3 entries, 0 cards" (qty=0 because they're not owned).

--- a/tests/ui/implementations/collection_more_menu_in_viewport.py
+++ b/tests/ui/implementations/collection_more_menu_in_viewport.py
@@ -1,0 +1,31 @@
+"""
+Hand-written implementation for collection_more_menu_in_viewport.
+
+Opens the More (vertical-ellipsis) menu on the collection page and
+verifies its items are visible and readable. Guards against regressions
+of the CSS fix that switched the panel from right-anchored (which
+clipped off-screen) to left-anchored.
+"""
+
+
+def steps(harness):
+    harness.navigate("/collection")
+    harness.wait_for_visible(".collection-table", timeout=15000)
+
+    # Open the More menu
+    harness.click_by_selector("#more-menu-btn")
+    harness.wait_for_visible("#more-menu-dropdown.open")
+
+    # The four item labels inside the panel must be visible and readable
+    harness.assert_text_present("Toggle Multi-Select")
+    harness.assert_text_present("Image Display")
+    harness.assert_text_present("Saved Views")
+    harness.assert_visible("#wishlist-toggle-btn")
+    harness.assert_visible("#toggle-multiselect-btn")
+
+    # Click an item inside the panel — Playwright will error if the
+    # element is not actually hit-testable, proving the panel is on-screen
+    harness.click_by_selector("#toggle-multiselect-btn")
+    harness.wait_for_visible("#selection-bar")
+
+    harness.screenshot("final_state")

--- a/tests/ui/implementations/collection_search_unowned.py
+++ b/tests/ui/implementations/collection_search_unowned.py
@@ -1,0 +1,32 @@
+"""
+Hand-written implementation for collection_search_unowned.
+
+Verifies that "is:unowned" routes the collection query through the
+LEFT-JOIN template and surfaces cards from the local database that
+aren't in the user's collection. The fixture contains 0 owned "lotus"
+rows but 3 unowned printings in the card database.
+"""
+
+
+def steps(harness):
+    harness.navigate("/collection")
+    harness.wait_for_visible(".collection-table", timeout=15000)
+
+    # Default search for "lotus" — no owned lotus cards in the fixture
+    harness.fill_by_placeholder("Search (e.g. t:creature c:r mv>=3)", "lotus")
+    harness.wait_for_text("0 entries")
+    harness.screenshot("default_lotus_empty")
+
+    # Prepend is:unowned — three printings from the card DB appear
+    harness.fill_by_placeholder("Search (e.g. t:creature c:r mv>=3)", "is:unowned lotus")
+    harness.wait_for_text("3 entries")
+
+    # Each of the three printings is named
+    harness.assert_text_present("Gilded Lotus")
+    harness.assert_text_present("Lotus Bloom")
+    harness.assert_text_present("Lotus Petal")
+
+    # Rows are dimmed via the .unowned class
+    harness.assert_visible("tr.unowned")
+
+    harness.screenshot("final_state")

--- a/tests/ui/intents/collection_more_menu_in_viewport.yaml
+++ b/tests/ui/intents/collection_more_menu_in_viewport.yaml
@@ -1,0 +1,12 @@
+# Scenario: More menu on the collection page renders within the viewport
+#
+# Related:
+#   issues: []
+#   pull_requests: []
+
+description: >
+  When I click the vertical-ellipsis More button in the collection
+  header, the dropdown panel opens below the button and its items are
+  fully readable — Wishlist, Toggle Multi-Select, Image Display, and
+  Saved Views. The panel is not clipped off the left edge of the
+  screen.

--- a/tests/ui/intents/collection_search_unowned.yaml
+++ b/tests/ui/intents/collection_search_unowned.yaml
@@ -1,0 +1,14 @@
+# Scenario: is:unowned query surfaces cards not in the collection
+#
+# Related:
+#   issues: []
+#   pull_requests: []
+
+description: >
+  When I search the collection for "lotus" with the default filter,
+  no results appear because I don't own any lotus cards. When I
+  prepend "is:unowned" to the same query, the collection list shows
+  lotus printings from the local card database that I don't yet own,
+  dimmed to indicate they aren't part of my collection. This lets me
+  find and add a card I want to buy from its row in the collection
+  view.


### PR DESCRIPTION
## Summary
- **Menu off-screen**: `.col-config-dropdown` was right-anchored against a button that sits near the left edge of the header row, so the ~200px panel extended off-screen to the left. Switched to `left: 0` with `max-width: calc(100vw - 24px)` so it's always inside the viewport.
- **`is:unowned` search keyword**: the old include-unowned toggle was removed during the search-bar consolidation (cf63c53) and no query-bar equivalent replaced it. `is:unowned` now flips `_api_collection` through the existing LEFT-JOIN template, surfaces printings from the local card database with `owned=false`, suppresses the default `status:owned` clause, and is wired into autocomplete, `/search-help`, and `CLAUDE.md`.

## Test plan
- [x] `uv run pytest tests/test_search_compiler.py tests/test_search_parser.py tests/test_search_corpus.py` — new `test_is_unowned` passes, no regressions.
- [x] `uv run ruff check mtg_collector/search/compiler.py mtg_collector/cli/crack_pack_server.py` — clean.
- [x] `uv run pytest tests/ui/ -v --instance qa-finish -k "collection_more_menu_in_viewport or collection_search_unowned"` — both new scenarios pass.
- [x] Manual: `is:unowned lotus` on the `qa-finish` test container returns 3 printings (Gilded Lotus, Lotus Bloom, Lotus Petal) vs. 0 for the default search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)