### PR TITLE
Fix printing upsert crash on duplicate set+collector_number

### DIFF
--- a/mtg_collector/db/models.py
+++ b/mtg_collector/db/models.py
@@ -535,10 +535,9 @@ class PrintingRepository:
              watermark, digital, reserved, reprint, produced_mana, games)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
                     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(printing_id) DO UPDATE SET
+            ON CONFLICT(set_code, collector_number) DO UPDATE SET
+                printing_id = excluded.printing_id,
                 oracle_id = excluded.oracle_id,
-                set_code = excluded.set_code,
-                collector_number = excluded.collector_number,
                 rarity = excluded.rarity,
                 frame_effects = excluded.frame_effects,
                 border_color = excluded.border_color,


### PR DESCRIPTION
## Summary

- The `PrintingRepository.upsert()` used `ON CONFLICT(printing_id)`, but the `printings` table also has `UNIQUE(set_code, collector_number)`. When Scryfall assigns a new printing UUID to an existing set+CN pair (e.g. finish variants), the insert bypassed the `printing_id` handler and crashed on the second constraint.
- Switches the conflict target to `(set_code, collector_number)` so the row updates in place, and includes `printing_id` in the update set to track the latest Scryfall UUID.
- Confirmed: `mtg cache all` now completes successfully (111,136 cards, 993 sets).

## Test plan

- [x] Ran `mtg cache all` against prod DB — completed without errors
- [x] Verified new SOA cards are present in the database
- [ ] Run existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)