### PR TITLE
Keep-alive, gzip, and longer cache for static assets

### DIFF
--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -970,6 +970,22 @@ class ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
 class CrackPackHandler(BaseHTTPRequestHandler):
     """HTTP handler for crack-a-pack web UI."""
 
+    # HTTP/1.1 keep-alive: reuses one TCP+TLS connection for the whole page's
+    # assets instead of a fresh handshake per request. Requires Content-Length
+    # on every response, which all handlers already set.
+    protocol_version = "HTTP/1.1"
+
+    # Gzippable content types for static responses.
+    _GZIPPABLE = frozenset({
+        "text/html; charset=utf-8",
+        "text/css",
+        "text/javascript; charset=utf-8",
+        "application/javascript",
+        "application/json",
+        "image/svg+xml",
+        "font/ttf",
+    })
+
     def __init__(self, generator: PackGenerator, static_dir: Path, db_path: str, *args, **kwargs):
         self.generator = generator
         self.static_dir = static_dir
@@ -1748,6 +1764,23 @@ class CrackPackHandler(BaseHTTPRequestHandler):
     def _serve_homepage(self):
         self._serve_static("index.html")
 
+    def _write_static_response(self, content: bytes, content_type: str,
+                                cache_control: str | None = None):
+        encoding = None
+        if content_type in self._GZIPPABLE and len(content) > 1024 \
+                and "gzip" in self.headers.get("Accept-Encoding", ""):
+            content = gzip.compress(content)
+            encoding = "gzip"
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(content)))
+        if encoding:
+            self.send_header("Content-Encoding", encoding)
+        if cache_control:
+            self.send_header("Cache-Control", cache_control)
+        self.end_headers()
+        self.wfile.write(content)
+
     def _serve_static(self, filename: str):
         filepath = self.static_dir / filename
         if not filepath.resolve().is_relative_to(self.static_dir.resolve()):
@@ -1758,12 +1791,7 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             return
         content = filepath.read_bytes()
         content_type = self._CONTENT_TYPES.get(filepath.suffix, "application/octet-stream")
-        self.send_response(200)
-        self.send_header("Content-Type", content_type)
-        self.send_header("Content-Length", str(len(content)))
-        self.send_header("Cache-Control", "public, max-age=300")
-        self.end_headers()
-        self.wfile.write(content)
+        self._write_static_response(content, content_type, "public, max-age=86400")
 
     def _serve_static_with_data(self, filename: str, data_fn):
         """Serve a static HTML file with /*INIT_DATA*/ replaced by JSON."""
@@ -1777,12 +1805,7 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             return
         html = filepath.read_text(encoding="utf-8")
         html = html.replace("/*INIT_DATA*/", _json.dumps(data_fn()))
-        content = html.encode("utf-8")
-        self.send_response(200)
-        self.send_header("Content-Type", "text/html; charset=utf-8")
-        self.send_header("Content-Length", str(len(content)))
-        self.end_headers()
-        self.wfile.write(content)
+        self._write_static_response(html.encode("utf-8"), "text/html; charset=utf-8")
 
     def _decks_init_data(self):
         from mtg_collector.db.models import DeckRepository


### PR DESCRIPTION
## Summary

Three changes to `CrackPackHandler` that collectively make every page dramatically faster on slow links:

- **HTTP/1.1 keep-alive** (`protocol_version = "HTTP/1.1"`). The server was serving `HTTP/1.0` with `Connection: close`, so every asset did a fresh TCP + TLS handshake. Browsers will now reuse 1–2 sockets for the whole page.
- **Gzip for static text responses.** `_send_json` already gzipped; `_serve_static` / `_serve_static_with_data` didn't. `deck-builder.js` drops from 46,856 B → 10,488 B on the wire (~4.5×).
- **`Cache-Control` bumped from `max-age=300` to `max-age=86400`** on static assets. Five minutes was effectively no caching for most reloads.

## Background

User reported `/decks/9` hanging on a "Loading…" spinner for a long time on a slow connection. Chrome's network tab showed ~14 assets each taking 3–15 s, with the JS arriving last. Server-side timing showed the SQL was fast (~7 ms) and `_send_json` already gzips — so the bottleneck was static-asset delivery. Verified after the change: `HTTP/1.1 200 OK`, `Content-Encoding: gzip`, 46,856 → 10,488 B.

## Test plan

- [x] `curl -skv https://localhost:8080/static/deck-builder.js` returns `HTTP/1.1 200 OK`, `Content-Encoding: gzip`, `Cache-Control: public, max-age=86400`
- [x] API responses still work: `/api/deck-builder/9` and `/api/decks/9/cards` return valid JSON
- [x] Pages render end-to-end (`/decks/9` loaded in browser)
- [ ] Verify in prod after deploy that all pages (collection, decks, binders, sealed, …) still load

🤖 Generated with [Claude Code](https://claude.com/claude-code)