### PR TITLE
Fetch sealed prices in the daily price timer

### DIFF
--- a/deploy/mtgc-prices.service
+++ b/deploy/mtgc-prices.service
@@ -4,4 +4,5 @@ Description=MTGC daily price fetch ({{INSTANCE}})
 [Service]
 Type=oneshot
 ExecStart=podman exec systemd-mtgc-{{INSTANCE}} mtg data fetch-prices --force
-TimeoutStartSec=600
+ExecStart=podman exec systemd-mtgc-{{INSTANCE}} mtg data fetch-sealed-prices
+TimeoutStartSec=900


### PR DESCRIPTION
## Summary
- `mtgc-prices.timer` only ran `mtg data fetch-prices` (singles via MTGJSON), so `sealed_prices` only updated when someone ran `mtg data fetch-sealed-prices` by hand.
- Append `fetch-sealed-prices` as a second `ExecStart` on the existing oneshot service so the daily 06:00 run covers both. Bumped `TimeoutStartSec` from 600s to 900s for the extra TCGCSV fetch.
- Already ran the command against `prod` to backfill today's prices (~2,851 sealed prices recorded).

## Test plan
- [ ] After merging, re-run `bash deploy/setup.sh <instance>` (or manually re-template `mtgc-prices-<instance>.service`) on each existing host so installed units pick up the new `ExecStart`.
- [ ] Confirm next daily firing populates `sealed_prices` with today's date: `sqlite3 ~/.mtgc/collection.sqlite "SELECT MAX(observed_at) FROM sealed_prices"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)