### PR TITLE
Fix virtual scroll empty viewport on long collections

### DIFF
--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -2995,6 +2995,8 @@ function render() {
 function renderTable() {
   if (_tableScrollCleanup) { _tableScrollCleanup(); _tableScrollCleanup = null; }
 
+  const savedScrollX = window.scrollX;
+
   if (allCards.length === 0) {
     main.innerHTML = '<div class="empty-state">No cards found</div>';
     return;
@@ -3055,9 +3057,9 @@ function renderTable() {
 
   function renderVisibleRows() {
     const tableRect = table.getBoundingClientRect();
-    const theadEl = table.querySelector('thead');
-    const theadHeight = theadEl ? theadEl.offsetHeight : 0;
-    const offset = -(tableRect.top - theadHeight);
+    const headerRow = table.querySelector('thead > tr:not(.vscroll-spacer)');
+    const headerHeight = headerRow ? headerRow.offsetHeight : 0;
+    const offset = -(tableRect.top - headerHeight);
     const viewportHeight = window.innerHeight;
 
     const firstRow = Math.max(0, Math.floor(offset / rowHeight) - bufferRows);
@@ -3109,6 +3111,8 @@ function renderTable() {
   }
 
   renderVisibleRows();
+
+  if (savedScrollX) window.scrollTo(savedScrollX, window.scrollY);
 
   let ticking = false;
   function onScroll() {


### PR DESCRIPTION
## Summary
Cherry-picks an existing fix that was authored on `fix/table-scroll-flicker` but never merged — PR #254 only included up to commit `1b6011b` ("Move virtual scroll spacers out of tbody"); the follow-up fix in `1518777` was left behind.

## Bug
Scrolling a few rows down in a large result set (the user hit it on the default collection view, ~3000 rows, sorted by date added) blanks out the table.

## Root cause
In `renderVisibleRows()`, `offset` was computed from `theadEl.offsetHeight`. After the spacer move, the top spacer lives inside `<thead>`, so `theadEl.offsetHeight` grows with the dynamic spacer as the user scrolls. The bigger `theadHeight` pushes `firstRow` past `totalRows`, the tbody empties, and `bottomSpacer` blows up to tens of MB (`document.body.scrollHeight` reaches ~33 MB on the test fixture).

## Fix
Measure the column header `<tr>` directly via `thead > tr:not(.vscroll-spacer)` instead of the whole `<thead>`. Also preserve `window.scrollX` across `renderTable` rebuilds so a column-sort doesn't reset horizontal scroll.

## Verification
- All 36 `collection_*` UI scenarios pass against a `--test` container with the fix.
- Manually reproduced the bug (0 rows, scrollH=33 MB) on the buggy code; verified the fix renders 19 rows post-scroll with scrollH=2259.
- Note: the existing `collection_table_scroll_reveals_more_cards` scenario does not catch this regression because its 45-row fixture is too small to trigger the math at the harness's 1280×900 viewport. Hardening it would need a larger fixture, which is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)