### PR TITLE
Backup resilience, WAL/perf, autocomplete polish, and price formatting

### DIFF
--- a/deploy/backup.sh
+++ b/deploy/backup.sh
@@ -18,7 +18,11 @@
 # Backup directory (default ~/mtgc-backups):
 #   Override with MTGC_BACKUP_DIR env var.
 #
-# Retention:
+# Retention (after S3 upload succeeds, when MTGC_BACKUP_S3_BUCKET is set):
+#   daily/   — last 2  (override with MTGC_KEEP_DAILY)
+#   weekly/  — last 0  (override with MTGC_KEEP_WEEKLY)
+#   monthly/ — last 0  (override with MTGC_KEEP_MONTHLY)
+# Retention (local-only, when S3 is unset or upload fails):
 #   daily/   — last 7
 #   weekly/  — last 8 (~2 months)
 #   monthly/ — last 12 (~1 year)
@@ -42,7 +46,6 @@
 set -euo pipefail
 
 INSTANCE="${1:-prod}"
-CONTAINER="systemd-mtgc-${INSTANCE}"
 BACKUP_DIR="${MTGC_BACKUP_DIR:-$HOME/mtgc-backups}"
 INSTANCE_DIR="${BACKUP_DIR}/${INSTANCE}"
 DAILY_DIR="${INSTANCE_DIR}/daily"
@@ -54,23 +57,48 @@ TARBALL_NAME="mtgc-${INSTANCE}-${TIMESTAMP}.tar.gz"
 
 echo "==> MTGC backup"
 echo "    Instance:  $INSTANCE"
-echo "    Container: $CONTAINER"
 echo "    Backup to: $INSTANCE_DIR"
 
 # --- Ensure directories exist ---
 
 mkdir -p "$DAILY_DIR" "$WEEKLY_DIR" "$MONTHLY_DIR"
 
-# --- Verify container is running ---
+# --- Discover the data volume mount on the host ---
+#
+# We snapshot host-side rather than via `podman exec` + `podman cp` so we
+# don't need ~2× the DB size of free space inside the container's writable
+# layer (a recurring source of silent disk-full failures). WAL mode on
+# collection.sqlite makes a concurrent host-side sqlite3.backup() safe.
 
-if ! podman container exists "$CONTAINER" 2>/dev/null; then
-    echo "ERROR: Container '$CONTAINER' not found."
-    echo "    Is the instance running? systemctl --user start mtgc-${INSTANCE}"
+VOLUME_NAME="mtgc-${INSTANCE}-data"
+if ! podman volume exists "$VOLUME_NAME" 2>/dev/null; then
+    echo "ERROR: Volume '$VOLUME_NAME' not found."
+    exit 1
+fi
+VOLUME_MOUNT="$(podman volume inspect "$VOLUME_NAME" --format '{{.Mountpoint}}')"
+SRC_DB="${VOLUME_MOUNT}/collection.sqlite"
+if [ ! -f "$SRC_DB" ]; then
+    echo "ERROR: Database not found at $SRC_DB"
     exit 1
 fi
 
-if [ "$(podman inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null)" != "true" ]; then
-    echo "ERROR: Container '$CONTAINER' exists but is not running."
+# --- Pre-flight disk-space check ---
+#
+# Need room for: (a) the host-side sqlite snapshot (~DB size), and (b) the
+# compressed tarball (~half of DB size in practice). Bail loudly rather than
+# half-succeed and leave stale staging behind.
+
+DB_BYTES=$(stat -c%s "$SRC_DB")
+# Peak usage during backup ≈ snapshot copy + compressed tarball.
+# Compressed tarball runs ~30% of DB size for this dataset (mostly IDs/numbers).
+# Budget 1.4× DB + 200 MB headroom for images and gzip overhead.
+NEEDED_BYTES=$((DB_BYTES + (DB_BYTES * 2 / 5) + 200 * 1024 * 1024))
+AVAIL_BYTES=$(df --output=avail -B1 "$BACKUP_DIR" | tail -1)
+if [ "$AVAIL_BYTES" -lt "$NEEDED_BYTES" ]; then
+    AVAIL_MB=$((AVAIL_BYTES / 1024 / 1024))
+    NEEDED_MB=$((NEEDED_BYTES / 1024 / 1024))
+    echo "ERROR: only ${AVAIL_MB} MB free at $BACKUP_DIR, need ~${NEEDED_MB} MB."
+    echo "       Free up space (e.g. 'podman image prune -af', prune old backups) and retry."
     exit 1
 fi
 
@@ -80,36 +108,30 @@ rm -rf "$STAGING_DIR"
 mkdir -p "$STAGING_DIR"
 trap 'rm -rf "$STAGING_DIR"' EXIT
 
-# --- Snapshot SQLite database ---
+# --- Snapshot SQLite database (host-side) ---
 
-echo "==> Creating SQLite snapshot..."
-podman exec "$CONTAINER" python3 -c "
-import sqlite3, sys
-src = sqlite3.connect('/data/collection.sqlite')
-dst = sqlite3.connect('/tmp/mtgc_backup.sqlite')
+echo "==> Creating SQLite snapshot from $SRC_DB ..."
+python3 - "$SRC_DB" "$STAGING_DIR/collection.sqlite" <<'PY'
+import sys, sqlite3
+src_path, dst_path = sys.argv[1], sys.argv[2]
+src = sqlite3.connect(src_path, timeout=60)
+dst = sqlite3.connect(dst_path)
 src.backup(dst)
 dst.close()
 src.close()
-print('Snapshot created successfully')
-"
+PY
 
-echo "==> Copying database snapshot out..."
-podman cp "$CONTAINER:/tmp/mtgc_backup.sqlite" "$STAGING_DIR/collection.sqlite"
-podman exec "$CONTAINER" rm -f /tmp/mtgc_backup.sqlite
+# --- Copy images directly from the volume mount ---
 
-# --- Copy images ---
-
-echo "==> Copying source_images..."
-podman cp "$CONTAINER:/data/source_images" "$STAGING_DIR/source_images" 2>/dev/null || {
-    echo "    (no source_images directory — skipping)"
-    mkdir -p "$STAGING_DIR/source_images"
-}
-
-echo "==> Copying ingest_images..."
-podman cp "$CONTAINER:/data/ingest_images" "$STAGING_DIR/ingest_images" 2>/dev/null || {
-    echo "    (no ingest_images directory — skipping)"
-    mkdir -p "$STAGING_DIR/ingest_images"
-}
+for IMG_DIR in source_images ingest_images; do
+    echo "==> Copying ${IMG_DIR}..."
+    if [ -d "${VOLUME_MOUNT}/${IMG_DIR}" ]; then
+        cp -a "${VOLUME_MOUNT}/${IMG_DIR}" "$STAGING_DIR/${IMG_DIR}"
+    else
+        echo "    (no ${IMG_DIR} directory — skipping)"
+        mkdir -p "$STAGING_DIR/${IMG_DIR}"
+    fi
+done
 
 # --- Create tarball ---
 
@@ -156,27 +178,55 @@ promote_oldest() {
     fi
 }
 
-echo "==> Running retention pruning..."
+# --- Optional S3 sync (runs BEFORE local pruning so we never delete the
+#     only copy on a failed upload) ---
 
-# Promote before pruning so we don't lose the oldest
-promote_oldest "$WEEKLY_DIR" "$MONTHLY_DIR" 8
-promote_oldest "$DAILY_DIR" "$WEEKLY_DIR" 7
-
-prune_dir "$DAILY_DIR" 7
-prune_dir "$WEEKLY_DIR" 8
-prune_dir "$MONTHLY_DIR" 12
-
-# --- Optional S3 sync ---
-
+S3_SYNCED=false
 if [ -n "${MTGC_BACKUP_S3_BUCKET:-}" ]; then
     if command -v aws &>/dev/null; then
         echo "==> Syncing to s3://${MTGC_BACKUP_S3_BUCKET}/mtgc-${INSTANCE}/..."
-        aws s3 sync "$INSTANCE_DIR" "s3://${MTGC_BACKUP_S3_BUCKET}/mtgc-${INSTANCE}/" \
-            --exclude "staging/*"
-        echo "    S3 sync complete."
+        if aws s3 sync "$INSTANCE_DIR" "s3://${MTGC_BACKUP_S3_BUCKET}/mtgc-${INSTANCE}/" \
+                --exclude "staging/*"; then
+            echo "    S3 sync complete."
+            S3_SYNCED=true
+        else
+            echo "WARNING: S3 sync failed — keeping full local retention as fallback."
+        fi
     else
         echo "WARNING: MTGC_BACKUP_S3_BUCKET is set but 'aws' CLI not found. Skipping S3 sync."
     fi
 fi
+
+# --- Retention pruning ---
+#
+# When S3 is the durable copy, keep a minimal local window for fast restore
+# (defaults: 2 daily, 0 weekly, 0 monthly). Without S3, fall back to a full
+# rolling 7/8/12 local-only window.
+# Override any of these with MTGC_KEEP_DAILY / _WEEKLY / _MONTHLY env vars.
+
+if [ "$S3_SYNCED" = "true" ]; then
+    KEEP_DAILY="${MTGC_KEEP_DAILY:-2}"
+    KEEP_WEEKLY="${MTGC_KEEP_WEEKLY:-0}"
+    KEEP_MONTHLY="${MTGC_KEEP_MONTHLY:-0}"
+else
+    KEEP_DAILY="${MTGC_KEEP_DAILY:-7}"
+    KEEP_WEEKLY="${MTGC_KEEP_WEEKLY:-8}"
+    KEEP_MONTHLY="${MTGC_KEEP_MONTHLY:-12}"
+fi
+
+echo "==> Running retention pruning (daily=${KEEP_DAILY}, weekly=${KEEP_WEEKLY}, monthly=${KEEP_MONTHLY})..."
+
+# Promote before pruning so we don't lose the oldest. Skip promotion when
+# the destination tier is set to keep 0 — that would just move-then-delete.
+if [ "$KEEP_MONTHLY" -gt 0 ]; then
+    promote_oldest "$WEEKLY_DIR" "$MONTHLY_DIR" "$KEEP_WEEKLY"
+fi
+if [ "$KEEP_WEEKLY" -gt 0 ]; then
+    promote_oldest "$DAILY_DIR" "$WEEKLY_DIR" "$KEEP_DAILY"
+fi
+
+prune_dir "$DAILY_DIR" "$KEEP_DAILY"
+prune_dir "$WEEKLY_DIR" "$KEEP_WEEKLY"
+prune_dir "$MONTHLY_DIR" "$KEEP_MONTHLY"
 
 echo "==> Backup complete: $DAILY_DIR/$TARBALL_NAME"

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -48,6 +48,14 @@ else
 
     echo "==> Restarting $SERVICE_NAME..."
     systemctl --user restart "$SERVICE_NAME"
+
+    # Reclaim disk from the previous image layers. Each build leaves the
+    # prior `mtgc:latest` content dangling once the tag moves. Without this
+    # the host accumulates ~1 GB per deploy and eventually fills the disk,
+    # which is what historically broke nightly backups (no room to stage
+    # the SQLite snapshot).
+    echo "==> Pruning dangling images..."
+    podman image prune -f >/dev/null
 fi
 # Wait briefly for the container to start, then discover the assigned port
 sleep 2

--- a/deploy/prune-instances.sh
+++ b/deploy/prune-instances.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#
+# Find and remove orphaned MTGC instance artifacts on this host:
+# image tags, data volumes, Quadlet units, env files, and timer units.
+#
+# An "orphan" is any candidate instance name that:
+#   - is NOT in the protected list (default: "prod"), AND
+#   - has NO currently-running container.
+#
+# Usage:
+#   bash deploy/prune-instances.sh --dry-run    # preview, no changes
+#   bash deploy/prune-instances.sh              # apply
+#
+# Override the protected list with MTGC_PROTECT_INSTANCES (space-separated):
+#   MTGC_PROTECT_INSTANCES="prod staging" bash deploy/prune-instances.sh
+#
+# Safe to run while other instances are active — the running-container
+# check protects them. Always run --dry-run first if unsure.
+
+set -euo pipefail
+
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help) sed -n '2,20p' "$0" | sed 's/^# \?//'; exit 0 ;;
+        *) echo "Unknown argument: $arg"; exit 1 ;;
+    esac
+done
+
+PROTECTED="${MTGC_PROTECT_INSTANCES:-prod}"
+
+is_protected() {
+    for p in $PROTECTED; do
+        [ "$1" = "$p" ] && return 0
+    done
+    return 1
+}
+
+is_running() {
+    [ "$(podman inspect -f '{{.State.Running}}' "systemd-mtgc-$1" 2>/dev/null)" = "true" ]
+}
+
+# --- Discover candidate instance names from every artifact location ---
+
+declare -A CANDIDATES
+
+# Image tags: localhost/mtgc:<instance>  (skip "latest" — that's the rolling alias)
+while IFS= read -r tag; do
+    inst="${tag#localhost/mtgc:}"
+    [ "$inst" = "latest" ] && continue
+    CANDIDATES["$inst"]=1
+done < <(podman images --format '{{.Repository}}:{{.Tag}}' 2>/dev/null | grep -E '^localhost/mtgc:' || true)
+
+# Volumes: mtgc-<instance>-data
+while IFS= read -r vol; do
+    [[ "$vol" =~ ^mtgc-(.+)-data$ ]] || continue
+    CANDIDATES["${BASH_REMATCH[1]}"]=1
+done < <(podman volume ls --format '{{.Name}}' 2>/dev/null || true)
+
+# Quadlet container units
+for f in "$HOME/.config/containers/systemd/mtgc-"*.container; do
+    [ -f "$f" ] || continue
+    base="$(basename "$f" .container)"
+    CANDIDATES["${base#mtgc-}"]=1
+done
+
+# Per-instance env files (skip default.env, which is the shared template)
+for f in "$HOME/.config/mtgc/"*.env; do
+    [ -f "$f" ] || continue
+    name="$(basename "$f" .env)"
+    [ "$name" = "default" ] && continue
+    CANDIDATES["$name"]=1
+done
+
+# Timer units (prices/sealed-catalog/backup/edhrec, one of each per instance)
+for f in "$HOME/.config/systemd/user/mtgc-"*.timer; do
+    [ -f "$f" ] || continue
+    base="$(basename "$f" .timer)"
+    for role in prices sealed-catalog backup edhrec; do
+        prefix="mtgc-${role}-"
+        case "$base" in
+            "${prefix}"*) CANDIDATES["${base#${prefix}}"]=1 ;;
+        esac
+    done
+done
+
+# --- Classify each candidate ---
+
+ORPHANS=()
+KEPT=()
+for inst in "${!CANDIDATES[@]}"; do
+    if is_protected "$inst"; then
+        KEPT+=("$inst (protected)")
+    elif is_running "$inst"; then
+        KEPT+=("$inst (running)")
+    else
+        ORPHANS+=("$inst")
+    fi
+done
+
+# --- Report ---
+
+echo "=== MTGC instance audit ==="
+echo "Protected: $PROTECTED"
+echo
+if [ "${#KEPT[@]}" -gt 0 ]; then
+    echo "Keeping:"
+    printf "  - %s\n" "${KEPT[@]}"
+    echo
+fi
+if [ "${#ORPHANS[@]}" -eq 0 ]; then
+    echo "No orphans found. Nothing to do."
+    exit 0
+fi
+echo "Orphans:"
+printf "  - %s\n" "${ORPHANS[@]}"
+echo
+
+if [ "$DRY_RUN" = "true" ]; then
+    echo "(dry-run) No changes made. Re-run without --dry-run to apply."
+    exit 0
+fi
+
+# --- Remove each orphan's artifacts ---
+#
+# Inlined rather than calling teardown.sh because teardown.sh requires the
+# Quadlet to exist; partial-state orphans (e.g. Quadlet already removed but
+# image+timer still around) would make it bail.
+
+for inst in "${ORPHANS[@]}"; do
+    echo "==> Removing $inst..."
+
+    # Stop and remove role timers (prices, sealed-catalog, backup, edhrec)
+    for ROLE in prices sealed-catalog backup edhrec; do
+        systemctl --user stop "mtgc-${ROLE}-${inst}.timer" 2>/dev/null || true
+        systemctl --user disable "mtgc-${ROLE}-${inst}.timer" 2>/dev/null || true
+        rm -f "$HOME/.config/systemd/user/mtgc-${ROLE}-${inst}.service" \
+              "$HOME/.config/systemd/user/mtgc-${ROLE}-${inst}.timer"
+    done
+
+    # Stop main service and remove Quadlet
+    systemctl --user stop "mtgc-${inst}" 2>/dev/null || true
+    systemctl --user disable "mtgc-${inst}" 2>/dev/null || true
+    rm -f "$HOME/.config/containers/systemd/mtgc-${inst}.container"
+
+    # Remove image tag, data volume, and env file
+    podman rmi "mtgc:${inst}" 2>/dev/null || true
+    podman volume rm "mtgc-${inst}-data" 2>/dev/null || true
+    rm -f "$HOME/.config/mtgc/${inst}.env"
+
+    echo "    Done."
+done
+
+systemctl --user daemon-reload
+echo
+echo "==> Removed ${#ORPHANS[@]} orphan instance(s)."

--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -996,6 +996,7 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         """Get a DB connection, optionally ATTACHing a shared reference DB."""
         conn = sqlite3.connect(self.db_path, timeout=10.0)
         conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode = WAL")
         if _shared_db_path and os.path.exists(_shared_db_path):
             from mtg_collector.db.connection import attach_shared
             attach_shared(conn, _shared_db_path)
@@ -2072,7 +2073,7 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         # Conditional JOINs from the search engine
         # Note: expand_copies and default templates already include dc/d/b joins.
         # Only the shared-links (card_pairs) template needs them dynamically.
-        needs_price_join = compiled and compiled.needs_price_join
+        needs_price_join = (compiled and compiled.needs_price_join) or sort_col == "_lp.price"
         needs_wishlist_join = compiled and compiled.needs_wishlist_join
 
         def _build_extra_joins(*, has_deck_binder_joins: bool) -> str:

--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -1050,6 +1050,8 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             self._api_sets()
         elif path == "/api/cached-sets":
             self._api_cached_sets()
+        elif path == "/api/search-suggest":
+            self._api_search_suggest(params)
         elif path == "/api/products":
             set_code = params.get("set", [""])[0]
             self._api_products(set_code)
@@ -1831,6 +1833,99 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         result = [{"code": row["set_code"], "name": row["set_name"]} for row in cursor]
         conn.close()
         self._send_json(result)
+
+    def _api_search_suggest(self, params: dict):
+        """Return autocomplete suggestions for a search keyword's value.
+
+        Restricted to the user's actual collection corpus — suggestions only
+        include values present on printings the user owns. Free-text keys
+        (oracle, flavor) aren't supported because suggesting substrings
+        from those isn't useful.
+        """
+        key = params.get("key", [""])[0].lower().strip()
+        prefix = params.get("prefix", [""])[0].strip()
+        limit = 12
+
+        conn = self._get_conn()
+        suggestions: list = []
+
+        if key == "added":
+            aliases = [
+                ("today",     "today",     "Today (local)"),
+                ("yesterday", "yesterday", "Yesterday (local)"),
+                ("7d",        "7d",        "7 days ago"),
+                ("30d",       "30d",       "30 days ago"),
+                ("90d",       "90d",       "90 days ago"),
+                ("1y",        "1y",        "1 year ago"),
+            ]
+            plow = prefix.lower()
+            for value, label, hint in aliases:
+                if not prefix or value.startswith(plow):
+                    suggestions.append({"value": value, "label": label, "hint": hint})
+            for row in conn.execute(
+                "SELECT DISTINCT SUBSTR(acquired_at, 1, 4) AS y FROM collection "
+                "WHERE acquired_at IS NOT NULL ORDER BY y DESC"
+            ):
+                y = row["y"]
+                if y and (not prefix or y.startswith(prefix)):
+                    suggestions.append({"value": y, "label": y, "hint": "Year"})
+            for row in conn.execute(
+                "SELECT DISTINCT SUBSTR(acquired_at, 1, 7) AS ym FROM collection "
+                "WHERE acquired_at IS NOT NULL ORDER BY ym DESC LIMIT 36"
+            ):
+                ym = row["ym"]
+                if ym and (not prefix or ym.startswith(prefix)):
+                    suggestions.append({"value": ym, "label": ym, "hint": "Month"})
+
+        elif key in ("artist", "a"):
+            like = f"%{prefix}%"
+            for row in conn.execute(
+                "SELECT DISTINCT p.artist FROM printings p "
+                "INNER JOIN collection c ON c.printing_id = p.printing_id "
+                "WHERE p.artist IS NOT NULL AND p.artist LIKE ? COLLATE NOCASE "
+                "ORDER BY p.artist LIMIT ?",
+                (like, limit),
+            ):
+                artist = row[0]
+                # Wrap in quotes if the artist name has whitespace.
+                value = f'"{artist}"' if " " in artist else artist
+                suggestions.append({"value": value, "label": artist, "hint": "Artist"})
+
+        elif key in ("keyword", "kw"):
+            like = f"%{prefix}%"
+            for row in conn.execute(
+                "SELECT DISTINCT je.value AS kw FROM cards card "
+                "INNER JOIN printings p ON p.oracle_id = card.oracle_id "
+                "INNER JOIN collection c ON c.printing_id = p.printing_id, "
+                "json_each(card.keywords) je "
+                "WHERE card.keywords IS NOT NULL AND card.keywords != '[]' "
+                "AND je.value LIKE ? COLLATE NOCASE "
+                "ORDER BY kw LIMIT ?",
+                (like, limit),
+            ):
+                kw = row["kw"]
+                value = f'"{kw}"' if " " in kw else kw
+                suggestions.append({"value": value, "label": kw, "hint": "Keyword"})
+
+        elif key == "set":
+            like = f"%{prefix}%"
+            plow = prefix.lower()
+            for row in conn.execute(
+                "SELECT DISTINCT p.set_code, s.set_name FROM printings p "
+                "INNER JOIN collection c ON c.printing_id = p.printing_id "
+                "LEFT JOIN sets s ON s.set_code = p.set_code "
+                "WHERE p.set_code LIKE ? OR s.set_name LIKE ? COLLATE NOCASE "
+                "ORDER BY s.set_name LIMIT ?",
+                (like, like, limit),
+            ):
+                code = (row["set_code"] or "").lower()
+                if not code or (prefix and not code.startswith(plow) and plow not in (row["set_name"] or "").lower()):
+                    continue
+                suggestions.append({"value": code, "label": code.upper(),
+                                    "hint": row["set_name"] or ""})
+
+        conn.close()
+        self._send_json(suggestions[:limit])
 
     def _api_products(self, set_code: str):
         if not self.generator:

--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -1907,7 +1907,8 @@ class CrackPackHandler(BaseHTTPRequestHandler):
 
         # Compile
         t0 = _time.monotonic()
-        compiled = compile_query(ast)
+        tz = params.get("tz", [""])[0] or None
+        compiled = compile_query(ast, tz=tz)
         timings["compile_ms"] = round((_time.monotonic() - t0) * 1000, 1)
 
         # Execute
@@ -2012,13 +2013,14 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         conn = self._get_conn()
 
         # Parse and compile the Scryfall query
+        tz = params.get("tz", [""])[0] or None
         where_sql = "1=1"
         sql_params: list = []
         compiled = None
         if q:
             try:
                 ast = parse_query(q)
-                compiled = compile_query(ast)
+                compiled = compile_query(ast, tz=tz)
                 where_sql = compiled.where_sql
                 sql_params = list(compiled.params)
             except SearchError as e:

--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -1924,6 +1924,28 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                 suggestions.append({"value": code, "label": code.upper(),
                                     "hint": row["set_name"] or ""})
 
+        elif key == "deck":
+            like = f"%{prefix}%"
+            for row in conn.execute(
+                "SELECT id, name FROM decks WHERE name LIKE ? COLLATE NOCASE "
+                "ORDER BY name LIMIT ?",
+                (like, limit),
+            ):
+                name = row["name"] or ""
+                value = f'"{name}"' if " " in name else name
+                suggestions.append({"value": value, "label": name, "hint": "Deck"})
+
+        elif key == "binder":
+            like = f"%{prefix}%"
+            for row in conn.execute(
+                "SELECT id, name FROM binders WHERE name LIKE ? COLLATE NOCASE "
+                "ORDER BY name LIMIT ?",
+                (like, limit),
+            ):
+                name = row["name"] or ""
+                value = f'"{name}"' if " " in name else name
+                suggestions.append({"value": value, "label": name, "hint": "Binder"})
+
         conn.close()
         self._send_json(suggestions[:limit])
 

--- a/mtg_collector/db/connection.py
+++ b/mtg_collector/db/connection.py
@@ -76,8 +76,9 @@ def get_connection(db_path: Optional[str] = None) -> sqlite3.Connection:
     db_dir.mkdir(parents=True, exist_ok=True)
 
     # Create new connection
-    _connection = sqlite3.connect(path)
+    _connection = sqlite3.connect(path, timeout=10.0)
     _connection.row_factory = sqlite3.Row
+    _connection.execute("PRAGMA journal_mode = WAL")
     # FK enforcement is deferred until after potential ATTACH — see below
     _db_path = path
     _attached = False

--- a/mtg_collector/search/compiler.py
+++ b/mtg_collector/search/compiler.py
@@ -141,10 +141,16 @@ def _compile_name_search(term: str, ctx: CompiledQuery) -> tuple[str, list]:
 
     Matches Scryfall's behavior: bare words match card name and flavor_name
     only. Type line requires t:, oracle text requires o:.
+
+    The card.name half is rewritten as `p.oracle_id IN (subselect)` so the
+    cards table is scanned once (37k rows) instead of via per-printing index
+    lookups during a 112k-row printings scan. The flavor_name half is gated
+    on IS NOT NULL because only ~0.5% of printings have flavor names, which
+    lets SQLite short-circuit the LIKE for the vast majority.
     """
     return (
-        "(card.name LIKE ? COLLATE NOCASE"
-        " OR p.flavor_name LIKE ? COLLATE NOCASE)",
+        "(p.oracle_id IN (SELECT oracle_id FROM cards WHERE name LIKE ? COLLATE NOCASE)"
+        " OR (p.flavor_name IS NOT NULL AND p.flavor_name LIKE ? COLLATE NOCASE))",
         [f"%{term}%", f"%{term}%"],
     )
 

--- a/mtg_collector/search/compiler.py
+++ b/mtg_collector/search/compiler.py
@@ -23,10 +23,10 @@ class CompiledQuery:
     __slots__ = (
         "where_sql", "params", "needs_fts", "order_by", "order_dir",
         "needs_deck_join", "needs_price_join", "needs_wishlist_join",
-        "has_status_filter", "include_unowned",
+        "has_status_filter", "include_unowned", "tz",
     )
 
-    def __init__(self):
+    def __init__(self, tz: str | None = None):
         self.where_sql: str = "1=1"
         self.params: list = []
         self.needs_fts: bool = False
@@ -37,15 +37,20 @@ class CompiledQuery:
         self.needs_wishlist_join: bool = False
         self.has_status_filter: bool = False
         self.include_unowned: bool = False
+        self.tz: str = tz or "UTC"
 
 
 class CompileError(Exception):
     """Raised when the AST cannot be compiled to SQL."""
 
 
-def compile_query(ast: ASTNode) -> CompiledQuery:
-    """Compile an AST into a CompiledQuery with WHERE clause and params."""
-    result = CompiledQuery()
+def compile_query(ast: ASTNode, tz: str | None = None) -> CompiledQuery:
+    """Compile an AST into a CompiledQuery with WHERE clause and params.
+
+    ``tz`` is an IANA timezone name used for resolving date-valued keywords
+    like ``added:today`` against the user's local calendar. Defaults to UTC.
+    """
+    result = CompiledQuery(tz=tz)
     # Extract display modifiers before compiling
     ast = _extract_modifiers(ast, result)
     if ast is None:
@@ -311,8 +316,7 @@ def _compile_comparison(node: ComparisonNode, ctx: CompiledQuery) -> tuple[str, 
 
     # --- Collection-specific: added (acquired_at date) ---
     if kw == "added":
-        return _compile_text_like("c.acquired_at", op, val) if op in (":", "=", "!=") \
-            else _compile_date("c.acquired_at", op, val)
+        return _compile_added(op, val, ctx.tz)
 
     # --- Collection-specific: price ---
     if kw == "price":
@@ -514,10 +518,37 @@ def _compile_numeric(expr: str, op: str, val: str,
     return f"({' AND '.join(parts)})", params
 
 
-def _compile_date(column: str, op: str, val: str) -> tuple[str, list]:
-    """Compile a date comparison (ISO 8601 string ordering)."""
-    sql_op = _SAFE_OPS.get(op, "=")
-    return f"(SUBSTR({column}, 1, 10) {sql_op} ?)", [val]
+def _compile_added(op: str, val: str, tz: str) -> tuple[str, list]:
+    """Compile an ``added`` (acquired_at) comparison.
+
+    Resolves ``val`` to a UTC ``[start, end)`` range in the user's local
+    timezone (so ``added:today`` matches their local calendar day, not the
+    UTC day). Compares against ``SUBSTR(c.acquired_at, 1, 19)`` — a fixed
+    19-char prefix that sidesteps lex ordering issues from trailing ``Z``
+    and fractional seconds.
+    """
+    from .dates import ACQUIRED_AT_PREFIX_LEN, parse_date_value
+
+    rng = parse_date_value(val, tz)
+    if rng is None:
+        return "1=0 /* invalid date */", []
+
+    start, end = rng
+    col = f"SUBSTR(c.acquired_at, 1, {ACQUIRED_AT_PREFIX_LEN})"
+
+    if op in (":", "="):
+        return f"({col} >= ? AND {col} < ?)", [start, end]
+    if op == "!=":
+        return f"NOT ({col} >= ? AND {col} < ?)", [start, end]
+    if op == ">=":
+        return f"{col} >= ?", [start]
+    if op == "<":
+        return f"{col} < ?", [start]
+    if op == ">":
+        return f"{col} >= ?", [end]
+    if op == "<=":
+        return f"{col} < ?", [end]
+    return "1=1", []
 
 
 def _compile_stat(column: str, op: str, val: str) -> tuple[str, list]:

--- a/mtg_collector/search/dates.py
+++ b/mtg_collector/search/dates.py
@@ -1,0 +1,158 @@
+"""Date-value parsing for the search compiler.
+
+Translates user-facing date inputs into UTC datetime ranges suitable for
+comparing against ``collection.acquired_at`` (which is stored as ISO 8601
+UTC strings).
+
+Accepted inputs (case-insensitive for aliases):
+    Aliases:    ``today``, ``yesterday``
+    Relative:   ``Nd``, ``Nw``, ``Nm``, ``Ny`` (N days/weeks/months/years ago)
+    ISO date:   ``YYYY``, ``YYYY-MM``, ``YYYY-MM-DD``
+    ISO datetime: ``YYYY-MM-DDTHH:MM[:SS[.f]][Z|+HH:MM]``
+
+All resolution happens in the user's local timezone so that
+``added:today`` matches cards added during the user's calendar day rather
+than the UTC day.
+"""
+
+from __future__ import annotations
+
+import calendar
+import re
+from datetime import date, datetime, time, timedelta, timezone
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+_REL_RE = re.compile(r"^(\d+)([dwmy])$")
+_YEAR_RE = re.compile(r"^\d{4}$")
+_YEAR_MONTH_RE = re.compile(r"^\d{4}-\d{2}$")
+_YEAR_MONTH_DAY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+# 19-char prefix of acquired_at (YYYY-MM-DDTHH:MM:SS) is what we compare
+# against. Using a fixed-width prefix sidesteps lex ordering issues caused
+# by the trailing ``Z`` vs ``+00:00`` vs fractional seconds.
+ACQUIRED_AT_PREFIX_LEN = 19
+
+
+def resolve_tz(tz: str | None) -> ZoneInfo:
+    """Return a ZoneInfo for ``tz``. Falls back to UTC if unknown/missing.
+
+    Why: clients send IANA names via Intl API; defensive callers may pass
+    None or junk. UTC is the safe default.
+    """
+    if not tz:
+        return ZoneInfo("UTC")
+    try:
+        return ZoneInfo(tz)
+    except (ZoneInfoNotFoundError, ValueError):
+        return ZoneInfo("UTC")
+
+
+def parse_date_value(val: str, tz: str | None = None) -> tuple[str, str] | None:
+    """Parse a user date value into a UTC ``[start, end)`` prefix pair.
+
+    Returns ``(start_prefix, end_prefix)`` where each is a 19-char string
+    ``YYYY-MM-DDTHH:MM:SS`` suitable for direct comparison against
+    ``SUBSTR(c.acquired_at, 1, 19)``. ``end`` is exclusive.
+
+    Returns ``None`` when the input cannot be parsed.
+    """
+    if not val:
+        return None
+    lz = resolve_tz(tz)
+    lower = val.strip().lower()
+
+    today_local = datetime.now(lz).date()
+
+    if lower == "today":
+        return _day_range(today_local, lz)
+    if lower == "yesterday":
+        return _day_range(today_local - timedelta(days=1), lz)
+
+    m = _REL_RE.match(lower)
+    if m:
+        n = int(m.group(1))
+        unit = m.group(2)
+        if unit == "d":
+            return _day_range(today_local - timedelta(days=n), lz)
+        if unit == "w":
+            return _day_range(today_local - timedelta(weeks=n), lz)
+        if unit == "m":
+            return _day_range(_subtract_months(today_local, n), lz)
+        if unit == "y":
+            return _day_range(_subtract_years(today_local, n), lz)
+
+    if _YEAR_RE.match(val):
+        y = int(val)
+        if not (1 <= y <= 9999):
+            return None
+        start = datetime(y, 1, 1, tzinfo=lz)
+        end = datetime(y + 1, 1, 1, tzinfo=lz) if y < 9999 else datetime(9999, 12, 31, 23, 59, 59, tzinfo=lz)
+        return _utc_prefix_pair(start, end)
+
+    if _YEAR_MONTH_RE.match(val):
+        y, mo = (int(x) for x in val.split("-"))
+        if not (1 <= mo <= 12):
+            return None
+        start = datetime(y, mo, 1, tzinfo=lz)
+        if mo == 12:
+            end = datetime(y + 1, 1, 1, tzinfo=lz)
+        else:
+            end = datetime(y, mo + 1, 1, tzinfo=lz)
+        return _utc_prefix_pair(start, end)
+
+    if _YEAR_MONTH_DAY_RE.match(val):
+        try:
+            d = date.fromisoformat(val)
+        except ValueError:
+            return None
+        return _day_range(d, lz)
+
+    # Full ISO datetime (treat naive as local-tz).
+    try:
+        # fromisoformat in 3.10 does not accept trailing Z; normalize.
+        dt = datetime.fromisoformat(val.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=lz)
+    # A precise datetime is treated as a point match at second precision.
+    start_utc = dt.astimezone(timezone.utc)
+    end_utc = start_utc + timedelta(seconds=1)
+    return (_fmt_prefix(start_utc), _fmt_prefix(end_utc))
+
+
+def _day_range(d: date, lz: ZoneInfo) -> tuple[str, str]:
+    """[start, end) covering the full local day, expressed as UTC prefixes."""
+    start = datetime.combine(d, time.min).replace(tzinfo=lz)
+    end = start + timedelta(days=1)
+    return _utc_prefix_pair(start, end)
+
+
+def _utc_prefix_pair(start: datetime, end: datetime) -> tuple[str, str]:
+    return (_fmt_prefix(start.astimezone(timezone.utc)),
+            _fmt_prefix(end.astimezone(timezone.utc)))
+
+
+def _fmt_prefix(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def _subtract_months(d: date, n: int) -> date:
+    y = d.year
+    m = d.month - n
+    while m <= 0:
+        m += 12
+        y -= 1
+    while m > 12:
+        m -= 12
+        y += 1
+    last_day = calendar.monthrange(y, m)[1]
+    return date(y, m, min(d.day, last_day))
+
+
+def _subtract_years(d: date, n: int) -> date:
+    try:
+        return d.replace(year=d.year - n)
+    except ValueError:
+        # Feb 29 in a non-leap year — clamp to Feb 28.
+        return d.replace(year=d.year - n, day=28)

--- a/mtg_collector/static/binders.html
+++ b/mtg_collector/static/binders.html
@@ -217,6 +217,11 @@ main { padding: 24px; }
 </div>
 
 <script>
+function formatPrice(value) {
+  const n = parseFloat(value);
+  if (!Number.isFinite(n)) return '$0.00';
+  return '$' + n.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+}
 let binders = [];
 let currentBinder = null;
 let binderCards = [];
@@ -247,7 +252,7 @@ function renderBinderList() {
       </div>
       <div class="stats">
         <span>${b.card_count} cards</span>
-        ${b.total_value ? `<span>$${Number(b.total_value).toFixed(2)}</span>` : ''}
+        ${b.total_value ? `<span>${formatPrice(b.total_value)}</span>` : ''}
       </div>
     </div>
   `).join('');
@@ -283,7 +288,7 @@ function renderBinderDetail() {
   if (b.storage_location) meta.push(`<span class="label">Location</span><span>${esc(b.storage_location)}</span>`);
   if (b.description) meta.push(`<span class="label">Notes</span><span>${esc(b.description)}</span>`);
   meta.push(`<span class="label">Cards</span><span>${b.card_count}</span>`);
-  if (b.total_value) meta.push(`<span class="label">Value</span><span>$${Number(b.total_value).toFixed(2)}</span>`);
+  if (b.total_value) meta.push(`<span class="label">Value</span><span>${formatPrice(b.total_value)}</span>`);
   document.getElementById('binder-meta').innerHTML = meta.join('');
 }
 

--- a/mtg_collector/static/card-detail.css
+++ b/mtg_collector/static/card-detail.css
@@ -256,7 +256,8 @@
   cursor: pointer;
   font-weight: 600;
 }
-.dispose-btn:hover { background: #1a4a7a; }
+.dispose-btn:hover:not(:disabled) { background: #1a4a7a; }
+.dispose-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
 .delete-copy-btn {
   padding: 4px 10px;

--- a/mtg_collector/static/card-detail.css
+++ b/mtg_collector/static/card-detail.css
@@ -299,7 +299,7 @@
 .price-range-pill:hover { background: #163d6f; }
 .price-range-pill.active { background: var(--accent); color: #fff; }
 .price-range-pill.disabled { opacity: 0.3; pointer-events: none; }
-.price-chart-canvas-wrap { height: 180px; position: relative; }
+.price-chart-canvas-wrap { height: 360px; position: relative; }
 
 /* History timeline */
 .history-toggle {

--- a/mtg_collector/static/card-detail.js
+++ b/mtg_collector/static/card-detail.js
@@ -76,8 +76,8 @@
   const rarity = card.rarity ? card.rarity.charAt(0).toUpperCase() + card.rarity.slice(1) : '';
 
   // Prices
-  const tcgPrice = card.tcg_price ? `$${parseFloat(card.tcg_price).toFixed(2)}` : '';
-  const ckPrice = card.ck_price ? `$${parseFloat(card.ck_price).toFixed(2)}` : '';
+  const tcgPrice = card.tcg_price ? formatPrice(card.tcg_price) : '';
+  const ckPrice = card.ck_price ? formatPrice(card.ck_price) : '';
   const sfUrl = `https://scryfall.com/card/${sc}/${card.collector_number}`;
   const ckUrl = getCkUrl(card);
 
@@ -308,10 +308,10 @@
 
     let priceHtml = '';
     if (copy.purchase_price) {
-      priceHtml = `<div class="detail-row"><span class="label">Price</span><span class="value">$${parseFloat(copy.purchase_price).toFixed(2)}</span></div>`;
+      priceHtml = `<div class="detail-row"><span class="label">Price</span><span class="value">${formatPrice(copy.purchase_price)}</span></div>`;
     }
     if (copy.sale_price) {
-      priceHtml += `<div class="detail-row"><span class="label">Sale Price</span><span class="value">$${parseFloat(copy.sale_price).toFixed(2)}</span></div>`;
+      priceHtml += `<div class="detail-row"><span class="label">Sale Price</span><span class="value">${formatPrice(copy.sale_price)}</span></div>`;
     }
 
     const changePrintingHtml = isActive
@@ -825,7 +825,7 @@
         ctx.setLineDash([]);
         ctx.fillStyle = 'rgba(126,232,176,0.7)';
         ctx.font = '9px sans-serif';
-        ctx.fillText('$' + price.toFixed(2), left + 3, y - 3);
+        ctx.fillText(formatPrice(price), left + 3, y - 3);
       }
       ctx.restore();
     }
@@ -925,7 +925,7 @@
           y: {
             ticks: {
               color: '#666', font: { size: 10 },
-              callback: v => '$' + v.toFixed(2),
+              callback: v => formatPrice(v),
             },
             grid: { color: 'rgba(255,255,255,0.06)' },
           },
@@ -933,7 +933,7 @@
         plugins: {
           legend: { position: 'top', labels: { color: '#888', font: { size: 10 }, boxWidth: 12 } },
           tooltip: {
-            callbacks: { label: ctx => `${ctx.dataset.label}: $${ctx.parsed.y.toFixed(2)}` },
+            callbacks: { label: ctx => `${ctx.dataset.label}: ${formatPrice(ctx.parsed.y)}` },
           },
           purchaseLines: { prices: purchasePrices },
         },

--- a/mtg_collector/static/card-detail.js
+++ b/mtg_collector/static/card-detail.js
@@ -375,7 +375,7 @@
         </select>
         <input type="number" step="0.01" placeholder="Price" class="dispose-price">
         <input type="text" placeholder="Note" class="dispose-note">
-        <button class="dispose-btn" data-id="${copy.id}">Dispose</button>
+        <button class="dispose-btn" data-id="${copy.id}" disabled>Dispose</button>
         ${isDeleteable ? `<button class="delete-copy-btn" data-id="${copy.id}">Delete</button>` : ''}
       </div>`;
     } else if (isDeleteable) {
@@ -418,6 +418,12 @@
     });
 
     // Dispose
+    container.querySelectorAll('.dispose-select').forEach(sel => {
+      sel.addEventListener('change', () => {
+        const btn = sel.closest('.copy-section').querySelector('.dispose-btn');
+        if (btn) btn.disabled = !sel.value;
+      });
+    });
     container.querySelectorAll('.dispose-btn').forEach(btn => {
       btn.addEventListener('click', async () => {
         const id = parseInt(btn.dataset.id);

--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -164,10 +164,32 @@ button.secondary.active { background: #0f3460; border-color: #e94560; }
   width: 100%;
   min-width: 0;
   font-size: 1rem;
-  padding: 11px 16px;
+  padding: 11px 36px 11px 16px;
 }
 #search-error { color: #e94560; font-size: 11px; position: absolute; top: 100%; left: 0; white-space: nowrap; z-index: 10; }
 .search-wrap { position: relative; flex: 1; min-width: 0; display: flex; align-items: center; }
+.search-clear {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: #333;
+  color: #ccc;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+  display: none;
+  align-items: center;
+  justify-content: center;
+}
+.search-clear:hover { background: #e94560; color: #fff; }
+.search-clear.visible { display: flex; }
 /* Autocomplete dropdown */
 .ac-dropdown {
   display: none; position: absolute; top: 100%; left: 0; right: 0;
@@ -1262,6 +1284,7 @@ tr.ordered td:first-child { border-left: 3px solid #f0a030; }
     </a>
     <div class="search-wrap">
       <input type="text" id="search-input" placeholder="Search (e.g. t:creature c:r mv>=3)" autocomplete="off">
+      <button type="button" class="search-clear" id="search-clear" title="Clear search" aria-label="Clear search">&times;</button>
       <div id="search-error"></div>
       <div class="ac-dropdown" id="ac-dropdown"></div>
     </div>
@@ -2843,6 +2866,7 @@ function applyFilterViaSearch(type, value) {
   const q = queryMap[type] || '';
   if (q) {
     searchInput.value = q;
+    updateSearchClearVisibility();
     fetchCollection();
   }
 }
@@ -3273,11 +3297,22 @@ function renderGrid() {
 
 // --- Event listeners ---
 // Search input triggers server fetch
+const searchClearBtn = document.getElementById('search-clear');
+function updateSearchClearVisibility() {
+  searchClearBtn.classList.toggle('visible', searchInput.value.length > 0);
+}
 searchInput.addEventListener('input', () => {
   clearTimeout(debounceTimer);
   debounceTimer = setTimeout(fetchCollection, 300);
   acUpdate();
+  updateSearchClearVisibility();
 });
+searchClearBtn.addEventListener('click', () => {
+  searchInput.value = '';
+  searchInput.focus();
+  searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+});
+updateSearchClearVisibility();
 
 // ---------------------------------------------------------------------------
 // Autocomplete
@@ -3457,6 +3492,7 @@ function acAccept(idx) {
   const newPos = start + item.text.length + suffix.length;
   searchInput.setSelectionRange(newPos, newPos);
   searchInput.focus();
+  updateSearchClearVisibility();
   acHide();
   // If we inserted a full keyword:value, trigger fetch
   if (suffix === ' ') {
@@ -3681,6 +3717,7 @@ document.getElementById('view-select').addEventListener('change', async function
     try {
       const f = typeof view.filters_json === 'string' ? JSON.parse(view.filters_json) : view.filters_json;
       searchInput.value = f.q || '';
+      updateSearchClearVisibility();
       fetchCollection();
     } catch {}
   }
@@ -3834,7 +3871,10 @@ function restoreFiltersFromURL() {
 
   // Search query
   const q = params.get('q');
-  if (q) searchInput.value = q;
+  if (q) {
+    searchInput.value = q;
+    updateSearchClearVisibility();
+  }
 
   // Sort
   if (params.get('sort')) sortColumn = params.get('sort');

--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -188,6 +188,12 @@ button.secondary.active { background: #0f3460; border-color: #e94560; }
   align-items: center;
   justify-content: center;
 }
+/* Render the × via a pseudo-element so the button has no DOM text content.
+   The page already contains four other × close buttons (modals, wishlist
+   row remove); putting the glyph here as text would make Playwright's
+   get_by_text("×") locator collide with this button and break the
+   collection_modal_close test. */
+.search-clear::before { content: "\00d7"; }
 .search-clear:hover { background: #e94560; color: #fff; }
 .search-clear.visible { display: flex; }
 /* Autocomplete dropdown */
@@ -1284,7 +1290,7 @@ tr.ordered td:first-child { border-left: 3px solid #f0a030; }
     </a>
     <div class="search-wrap">
       <input type="text" id="search-input" placeholder="Search (e.g. t:creature c:r mv>=3)" autocomplete="off">
-      <button type="button" class="search-clear" id="search-clear" title="Clear search" aria-label="Clear search">&times;</button>
+      <button type="button" class="search-clear" id="search-clear" title="Clear search" aria-label="Clear search"></button>
       <div id="search-error"></div>
       <div class="ac-dropdown" id="ac-dropdown"></div>
     </div>

--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -2908,6 +2908,12 @@ function getFetchParams() {
   if (multiSelectMode) {
     params.set('expand', 'copies');
   }
+  // Pass the browser's IANA timezone so `added:today` and friends resolve
+  // in the user's local calendar rather than UTC.
+  try {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    if (tz) params.set('tz', tz);
+  } catch {}
   return params.toString();
 }
 

--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -644,7 +644,7 @@ a.badge.link:hover { color: #fff; background: #555; border-color: #777; }
 .price-range-pill:hover { background: #163d6f; }
 .price-range-pill.active { background: #e94560; color: #fff; }
 .price-range-pill.disabled { opacity: 0.3; pointer-events: none; }
-.price-chart-canvas-wrap { height: 150px; position: relative; }
+.price-chart-canvas-wrap { height: 300px; position: relative; }
 
 a.lineage-link {
   display: block;

--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -1231,7 +1231,8 @@ tr.ordered td:first-child { border-left: 3px solid #f0a030; }
   cursor: pointer;
   font-weight: 600;
 }
-.dispose-btn:hover { background: #1a4a7a; }
+.dispose-btn:hover:not(:disabled) { background: #1a4a7a; }
+.dispose-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 .delete-copy-btn {
   padding: 4px 10px;
   font-size: 0.8rem;
@@ -2429,6 +2430,12 @@ async function loadModalCopies(card) {
     container.innerHTML = `<div class="modal-section"><span class="modal-section-title">Copies (${copies.length})</span></div>` +
       copies.map(copy => renderCopySection(copy)).join('');
     // Wire up dispose/delete handlers
+    container.querySelectorAll('.dispose-select').forEach(sel => {
+      sel.addEventListener('change', () => {
+        const btn = sel.closest('.copy-section').querySelector('.dispose-btn');
+        if (btn) btn.disabled = !sel.value;
+      });
+    });
     container.querySelectorAll('.dispose-btn').forEach(btn => {
       btn.addEventListener('click', async () => {
         const id = parseInt(btn.dataset.id);
@@ -2792,7 +2799,7 @@ function renderCopySection(copy) {
       </select>
       <input type="number" step="0.01" placeholder="Price" class="dispose-price">
       <input type="text" placeholder="Note" class="dispose-note">
-      <button class="dispose-btn" data-id="${copy.id}">Dispose</button>
+      <button class="dispose-btn" data-id="${copy.id}" disabled>Dispose</button>
       ${isDeleteable ? `<button class="delete-copy-btn" data-id="${copy.id}">Delete</button>` : ''}
     </div>`;
   } else if (isDeleteable) {

--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -1424,6 +1424,11 @@ tr.ordered td:first-child { border-left: 3px solid #f0a030; }
 <script src="/static/shared-card-table.js"></script>
 <script>
 function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+function formatPrice(value) {
+  const n = parseFloat(value);
+  if (!Number.isFinite(n)) return '$0.00';
+  return '$' + n.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+}
 const searchInput = document.getElementById('search-input');
 const viewTableBtn = document.getElementById('view-table-btn');
 const viewGridBtn = document.getElementById('view-grid-btn');
@@ -1860,11 +1865,11 @@ function _renderPriceBlock(label, stats) {
     <div class="modal-section">
       <div class="modal-section-title">${label}<span class="stats-section-tag">${stats.count.toLocaleString()} priced</span></div>
       <div class="stats-grid">
-        <span class="label">Total</span><span class="value">$${stats.total.toFixed(2)}</span>
-        <span class="label">Mean</span><span class="value">$${stats.mean.toFixed(2)}</span>
-        <span class="label">Median</span><span class="value">$${stats.median.toFixed(2)}</span>
-        <span class="label">99th pct</span><span class="value">$${stats.p99.toFixed(2)}</span>
-        <span class="label">Max</span><span class="value">$${stats.max.toFixed(2)}</span>
+        <span class="label">Total</span><span class="value">${formatPrice(stats.total)}</span>
+        <span class="label">Mean</span><span class="value">${formatPrice(stats.mean)}</span>
+        <span class="label">Median</span><span class="value">${formatPrice(stats.median)}</span>
+        <span class="label">99th pct</span><span class="value">${formatPrice(stats.p99)}</span>
+        <span class="label">Max</span><span class="value">${formatPrice(stats.max)}</span>
       </div>
     </div>`;
 }
@@ -1975,7 +1980,7 @@ const purchaseLinesPlugin = {
       ctx.setLineDash([]);
       ctx.fillStyle = 'rgba(126,232,176,0.7)';
       ctx.font = '9px sans-serif';
-      ctx.fillText('$' + price.toFixed(2), left + 3, y - 3);
+      ctx.fillText(formatPrice(price), left + 3, y - 3);
     }
     ctx.restore();
   }
@@ -2076,7 +2081,7 @@ async function renderPriceChart(card) {
         y: {
           ticks: {
             color: '#666', font: { size: 10 },
-            callback: v => '$' + v.toFixed(2),
+            callback: v => formatPrice(v),
           },
           grid: { color: 'rgba(255,255,255,0.06)' },
         },
@@ -2084,7 +2089,7 @@ async function renderPriceChart(card) {
       plugins: {
         legend: { position: 'top', labels: { color: '#888', font: { size: 10 }, boxWidth: 12 } },
         tooltip: {
-          callbacks: { label: ctx => `${ctx.dataset.label}: $${ctx.parsed.y.toFixed(2)}` },
+          callbacks: { label: ctx => `${ctx.dataset.label}: ${formatPrice(ctx.parsed.y)}` },
         },
         purchaseLines: { prices: purchasePrices },
       },
@@ -2133,8 +2138,8 @@ function showCardModal(card) {
   const finish = card.finish ? card.finish.charAt(0).toUpperCase() + card.finish.slice(1) : 'Nonfoil';
 
   // Prices
-  const tcgPrice = card.tcg_price ? `$${parseFloat(card.tcg_price).toFixed(2)}` : '—';
-  const ckPrice = card.ck_price ? `$${parseFloat(card.ck_price).toFixed(2)}` : '—';
+  const tcgPrice = card.tcg_price ? formatPrice(card.tcg_price) : '—';
+  const ckPrice = card.ck_price ? formatPrice(card.ck_price) : '—';
 
   // Links
   const sfUrl = `https://scryfall.com/card/${card.set_code.toLowerCase()}/${card.collector_number}`;
@@ -2214,7 +2219,7 @@ function showCardModal(card) {
         const addedDate = wl.added_at ? new Date(wl.added_at).toLocaleDateString() : '';
         return `<div class="modal-section"><span class="modal-section-title" style="color:#7ee8b0">Wishlist</span>
           ${addedDate ? `<div class="modal-row"><span class="label">Added</span><span class="value">${addedDate}</span></div>` : ''}
-          ${wl.max_price ? `<div class="modal-row"><span class="label">Max Price</span><span class="value">$${parseFloat(wl.max_price).toFixed(2)}</span></div>` : ''}
+          ${wl.max_price ? `<div class="modal-row"><span class="label">Max Price</span><span class="value">${formatPrice(wl.max_price)}</span></div>` : ''}
           ${wl.priority ? `<div class="modal-row"><span class="label">Priority</span><span class="value">${wl.priority}</span></div>` : ''}
           ${wl.notes ? `<div class="modal-row"><span class="label">Notes</span><span class="value">${wl.notes}</span></div>` : ''}
           ${wl.source ? `<div class="modal-row"><span class="label">Source</span><span class="value">${wl.source}</span></div>` : ''}
@@ -2268,7 +2273,7 @@ function showCardModal(card) {
           const seller = sellerName
             ? ` &middot; <a href="/orders/${copy.order_id}" style="color:#e94560;font-size:0.8rem">${sellerName}</a>`
             : '';
-          const price = copy.purchase_price ? ` &middot; $${parseFloat(copy.purchase_price).toFixed(2)}` : '';
+          const price = copy.purchase_price ? ` &middot; ${formatPrice(copy.purchase_price)}` : '';
           const source = copy.source && copy.source !== 'manual' ? ` &middot; ${copy.source}` : '';
           const receiveBtn = copy.status === 'ordered'
             ? `<button class="receive-btn" data-collection-id="${copy.id}">Receive</button>`
@@ -2738,10 +2743,10 @@ function renderCopySection(copy) {
 
   let priceHtml = '';
   if (copy.purchase_price) {
-    priceHtml = `<div class="modal-row"><span class="label">Price</span><span class="value">$${parseFloat(copy.purchase_price).toFixed(2)}</span></div>`;
+    priceHtml = `<div class="modal-row"><span class="label">Price</span><span class="value">${formatPrice(copy.purchase_price)}</span></div>`;
   }
   if (copy.sale_price) {
-    priceHtml += `<div class="modal-row"><span class="label">Sale Price</span><span class="value">$${parseFloat(copy.sale_price).toFixed(2)}</span></div>`;
+    priceHtml += `<div class="modal-row"><span class="label">Sale Price</span><span class="value">${formatPrice(copy.sale_price)}</span></div>`;
   }
 
   const changePrintingHtml = isActive
@@ -2831,11 +2836,11 @@ function buildCardBadges(card) {
   let html = '';
   const sources = (_settings.price_sources || 'tcg,ck').split(',');
   if (sources.includes('tcg') && card.printing_id) {
-    const sfPrice = card.tcg_price ? ` $${parseFloat(card.tcg_price).toFixed(2)}` : '';
+    const sfPrice = card.tcg_price ? ` ${formatPrice(card.tcg_price)}` : '';
     html += `<a class="badge link" href="https://scryfall.com/card/${card.set_code.toLowerCase()}/${card.collector_number}" target="_blank" rel="noopener" onclick="event.stopPropagation()">SF${sfPrice}</a>`;
   }
   if (sources.includes('ck')) {
-    const ckPrice = card.ck_price ? ` $${parseFloat(card.ck_price).toFixed(2)}` : '';
+    const ckPrice = card.ck_price ? ` ${formatPrice(card.ck_price)}` : '';
     html += `<a class="badge link" href="${getCkUrl(card)}" target="_blank" rel="noopener" onclick="event.stopPropagation()">CK${ckPrice}</a>`;
   }
   const fe = parseJsonField(card.frame_effects);
@@ -2974,7 +2979,7 @@ function updateStatusText() {
   const useQty = totalQty > 0;
   const count = useQty ? totalQty : allCards.length;
   const noun = useQty ? (count === 1 ? 'card' : 'cards') : (count === 1 ? 'result' : 'results');
-  const valueSuffix = totalValue > 0 ? `, $${totalValue.toFixed(2)}` : '';
+  const valueSuffix = totalValue > 0 ? `, ${formatPrice(totalValue)}` : '';
   statusEl.textContent = `${count.toLocaleString()} ${noun}${valueSuffix}`;
   statusEl.classList.toggle('empty', allCards.length === 0);
 }

--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -3339,10 +3339,6 @@ updateSearchClearVisibility();
 const acDropdown = document.getElementById('ac-dropdown');
 let acIdx = -1;
 let acItems = [];
-// Dynamic data loaded once on first focus
-let acSets = null;   // [{code, name}]
-let acDecks = null;  // [{id, name}]
-let acBinders = null; // [{id, name}]
 
 const AC_KEYWORDS = [
   {k:'c:',    label:'c:',    hint:'Color',          cat:'card'},
@@ -3373,26 +3369,75 @@ const AC_KEYWORDS = [
   {k:'direction:', label:'direction:', hint:'Sort direction', cat:'modifier'},
 ];
 
-const AC_VALUES = {
-  'c:': ['w','u','b','r','g','c','m','azorius','dimir','rakdos','gruul','selesnya','orzhov','izzet','golgari','boros','simic','esper','grixis','jund','naya','bant','abzan','jeskai','sultai','mardu','temur'],
-  'id:': ['w','u','b','r','g','c','m','azorius','dimir','rakdos','gruul','selesnya'],
-  'r:': ['common','uncommon','rare','mythic'],
-  't:': ['creature','instant','sorcery','enchantment','artifact','planeswalker','land','battle','legendary','token','elf','goblin','human','merfolk','dragon','wizard','angel','demon'],
-  'is:': ['foil','nonfoil','etched','fullart','borderless','showcase','extendedart','promo','reprint','reserved','firstprint','commander','vanilla','split','transform','mdfc','adventure','saga','unassigned','decked','bindered','wanted','unowned'],
-  'has:': ['watermark','flavor','power','toughness','loyalty'],
-  'f:': ['standard','modern','legacy','vintage','commander','pioneer','pauper'],
-  'status:': ['owned','ordered','sold','traded','gifted','lost'],
-  'order:': ['name','cmc','rarity','set','color','power','toughness','artist','collector_number','price','added'],
-  'direction:': ['asc','desc'],
-  'layout:': ['normal','split','flip','transform','modal_dfc','adventure','meld','leveler','class','saga','battle','prototype'],
+// Per-keyword AC spec.
+//   ops: operators the keyword accepts (used to generate operator-suggestions
+//        when a bare keyword is typed and to validate the splitter output)
+//   kind: 'enum' (static values) | 'numeric' | 'date' | 'dynamic' | 'text'
+//   values: static value list (for enum/numeric)
+//   source: corpus key for /api/search-suggest (for dynamic kinds)
+//   extra: hard-coded items always shown (e.g. deck:*)
+const _SMALL_INTS = ['0','1','2','3','4','5','6','7','8','9','10'];
+const _LOYALTIES  = ['1','2','3','4','5','6','7','8'];
+const _PRICE_BREAKS = ['0.25','1','5','10','25','50','100','500'];
+const _CMP_OPS = [':','=','!=','>=','<=','>','<'];
+
+const AC_KEYWORD_SPECS = {
+  c:         {ops: _CMP_OPS, kind: 'enum',
+              values: ['w','u','b','r','g','c','m','azorius','dimir','rakdos','gruul','selesnya','orzhov','izzet','golgari','boros','simic','esper','grixis','jund','naya','bant','abzan','jeskai','sultai','mardu','temur']},
+  id:        {ops: _CMP_OPS, kind: 'enum',
+              values: ['w','u','b','r','g','c','m','azorius','dimir','rakdos','gruul','selesnya']},
+  r:         {ops: _CMP_OPS, kind: 'enum',
+              values: ['common','uncommon','rare','mythic']},
+  t:         {ops: [':','=','!='], kind: 'enum',
+              values: ['creature','instant','sorcery','enchantment','artifact','planeswalker','land','battle','legendary','token','elf','goblin','human','merfolk','dragon','wizard','angel','demon']},
+  is:        {ops: [':'], kind: 'enum',
+              values: ['foil','nonfoil','etched','fullart','borderless','showcase','extendedart','promo','reprint','reserved','firstprint','commander','vanilla','split','transform','mdfc','adventure','saga','unassigned','decked','bindered','wanted','unowned']},
+  has:       {ops: [':'], kind: 'enum',
+              values: ['watermark','flavor','power','toughness','loyalty']},
+  f:         {ops: [':'], kind: 'enum',
+              values: ['standard','modern','legacy','vintage','commander','pioneer','pauper']},
+  status:    {ops: [':','=','!='], kind: 'enum',
+              values: ['owned','ordered','sold','traded','gifted','lost']},
+  order:     {ops: [':'], kind: 'enum',
+              values: ['name','cmc','rarity','set','color','power','toughness','artist','collector_number','price','added']},
+  direction: {ops: [':'], kind: 'enum', values: ['asc','desc']},
+  layout:    {ops: [':','='], kind: 'enum',
+              values: ['normal','split','flip','transform','modal_dfc','adventure','meld','leveler','class','saga','battle','prototype']},
+  // Numeric (operator-driven)
+  mv:        {ops: _CMP_OPS, kind: 'numeric', values: _SMALL_INTS},
+  cmc:       {ops: _CMP_OPS, kind: 'numeric', values: _SMALL_INTS},
+  pow:       {ops: _CMP_OPS, kind: 'numeric', values: _SMALL_INTS},
+  tou:       {ops: _CMP_OPS, kind: 'numeric', values: _SMALL_INTS},
+  loy:       {ops: _CMP_OPS, kind: 'numeric', values: _LOYALTIES},
+  cn:        {ops: [':','=','>=','<=','>','<'], kind: 'numeric',
+              values: ['1','10','50','100','200','500']},
+  year:      {ops: _CMP_OPS, kind: 'numeric',
+              values: ['1993','2000','2010','2015','2020','2024','2025','2026']},
+  price:     {ops: _CMP_OPS, kind: 'numeric', values: _PRICE_BREAKS},
+  // Dynamic (corpus-driven via /api/search-suggest)
+  added:     {ops: _CMP_OPS, kind: 'dynamic', source: 'added'},
+  a:         {ops: [':','=','!='], kind: 'dynamic', source: 'artist'},
+  kw:        {ops: [':'], kind: 'dynamic', source: 'keyword'},
+  s:         {ops: [':','=','!='], kind: 'dynamic', source: 'set'},
+  deck:      {ops: [':','=','!='], kind: 'dynamic', source: 'deck',
+              extra: [{value: '*', label: '*', hint: 'Any deck'}]},
+  binder:    {ops: [':','=','!='], kind: 'dynamic', source: 'binder',
+              extra: [{value: '*', label: '*', hint: 'Any binder'}]},
 };
 
-function acLoadDynamic() {
-  if (acSets) return;
-  acSets = []; acDecks = []; acBinders = [];
-  fetch('/api/cached-sets').then(r=>r.json()).then(d => { acSets = d; }).catch(()=>{});
-  fetch('/api/decks').then(r=>r.json()).then(d => { acDecks = d; }).catch(()=>{});
-  fetch('/api/binders').then(r=>r.json()).then(d => { acBinders = d; }).catch(()=>{});
+const AC_OP_SPLIT_RE = /^(-?[a-zA-Z_][a-zA-Z0-9_]*)(!=|<=|>=|<|>|=|:)(.*)$/;
+const AC_OP_RANK = [':', '>=', '<=', '>', '<', '=', '!='];
+
+// Per-source dynamic suggestion cache: source::prefix -> array.
+const acDynamicCache = {};
+function acFetchDynamic(source, prefix, onReady) {
+  const key = `${source}::${prefix}`;
+  if (acDynamicCache[key]) { onReady(acDynamicCache[key]); return; }
+  acDynamicCache[key] = []; // pending sentinel — avoid duplicate fetches
+  fetch(`/api/search-suggest?key=${encodeURIComponent(source)}&prefix=${encodeURIComponent(prefix)}`)
+    .then(r => r.ok ? r.json() : [])
+    .then(data => { acDynamicCache[key] = data; onReady(data); })
+    .catch(() => onReady([]));
 }
 
 function acGetCurrentToken() {
@@ -3412,64 +3457,35 @@ function acUpdate() {
   acItems = [];
   const lower = token.toLowerCase();
 
-  // Check if we're after a keyword prefix (e.g. "s:" or "is:")
-  const colonIdx = token.indexOf(':');
-  if (colonIdx >= 0) {
-    const prefix = token.substring(0, colonIdx + 1).toLowerCase();
-    const valPart = token.substring(colonIdx + 1).toLowerCase();
-
-    // Static value completions
-    let pool = AC_VALUES[prefix];
-    if (pool) {
-      for (const v of pool) {
-        if (v.startsWith(valPart) && v !== valPart) {
-          acItems.push({text: prefix + v, label: v, hint: '', cat: ''});
-        }
-      }
+  // Try to split as keyword + operator + value. Recognizes : = != >= <= > <
+  // (the same set the search tokenizer accepts).
+  const m = token.match(AC_OP_SPLIT_RE);
+  if (m) {
+    const rawKw = m[1];
+    const op = m[2];
+    const valPart = m[3];
+    const negated = rawKw.startsWith('-');
+    const kwLookup = negated ? rawKw.substring(1).toLowerCase() : rawKw.toLowerCase();
+    const spec = AC_KEYWORD_SPECS[kwLookup];
+    if (spec && spec.ops.includes(op)) {
+      _acAppendValueSuggestions(spec, rawKw, op, valPart);
     }
-    // Dynamic: set codes
-    if (prefix === 's:' && acSets) {
-      for (const s of acSets) {
-        const code = s.code.toLowerCase();
-        const name = (s.name||'').toLowerCase();
-        if ((code.startsWith(valPart) || name.includes(valPart)) && code !== valPart) {
-          acItems.push({text: 's:' + code, label: code.toUpperCase(), hint: s.name, cat: ''});
-        }
-        if (acItems.length >= 12) break;
-      }
-    }
-    // Dynamic: deck names
-    if (prefix === 'deck:' && acDecks) {
-      acItems.push({text: 'deck:*', label: '*', hint: 'Any deck', cat: ''});
-      for (const d of acDecks) {
-        const name = (d.name||'');
-        if (name.toLowerCase().includes(valPart)) {
-          const q = name.includes(' ') ? `deck:"${name}"` : `deck:${name}`;
-          acItems.push({text: q, label: name, hint: '', cat: ''});
-        }
-        if (acItems.length >= 12) break;
-      }
-    }
-    // Dynamic: binder names
-    if (prefix === 'binder:' && acBinders) {
-      acItems.push({text: 'binder:*', label: '*', hint: 'Any binder', cat: ''});
-      for (const b of acBinders) {
-        const name = (b.name||'');
-        if (name.toLowerCase().includes(valPart)) {
-          const q = name.includes(' ') ? `binder:"${name}"` : `binder:${name}`;
-          acItems.push({text: q, label: name, hint: '', cat: ''});
-        }
-        if (acItems.length >= 12) break;
-      }
+  } else if (AC_KEYWORD_SPECS[lower] || AC_KEYWORD_SPECS[lower.replace(/^-/, '')]) {
+    // User typed an exact keyword with no operator yet — suggest operators.
+    const isNeg = lower.startsWith('-');
+    const kwLookup = isNeg ? lower.substring(1) : lower;
+    const spec = AC_KEYWORD_SPECS[kwLookup];
+    const ops = [...spec.ops].sort((a, b) => AC_OP_RANK.indexOf(a) - AC_OP_RANK.indexOf(b));
+    for (const op of ops) {
+      acItems.push({text: token + op, label: token + op, hint: _acOpHint(op), cat: ''});
     }
   } else {
-    // Keyword suggestions
+    // Keyword-name suggestions.
     for (const kw of AC_KEYWORDS) {
       if (kw.k.startsWith(lower) && kw.k !== lower) {
         acItems.push({text: kw.k, label: kw.label, hint: kw.hint, cat: kw.cat});
       }
     }
-    // Also suggest negation
     if (lower === '-') {
       acItems.push({text: '-', label: '-...', hint: 'Negate next term', cat: ''});
     }
@@ -3479,6 +3495,64 @@ function acUpdate() {
   if (acItems.length === 0) { acHide(); return; }
   acIdx = -1;
   acRender();
+}
+
+function _acOpHint(op) {
+  if (op === ':') return 'value';
+  if (op === '=') return 'equals';
+  if (op === '!=') return 'not equal';
+  if (op === '>=') return 'at or after';
+  if (op === '<=') return 'at or before';
+  if (op === '>') return 'after';
+  if (op === '<') return 'before';
+  return '';
+}
+
+function _acAppendValueSuggestions(spec, rawKw, op, valPart) {
+  const valLower = valPart.toLowerCase();
+  const prefix = rawKw + op;
+
+  if (spec.extra) {
+    for (const item of spec.extra) {
+      if (!valPart || item.value.startsWith(valPart)) {
+        acItems.push({text: prefix + item.value, label: item.label, hint: item.hint, cat: ''});
+      }
+    }
+  }
+
+  if (spec.values) {
+    for (const v of spec.values) {
+      if (v.toLowerCase().startsWith(valLower) && v !== valPart) {
+        acItems.push({text: prefix + v, label: v, hint: '', cat: ''});
+      }
+      if (acItems.length >= 15) break;
+    }
+    return;
+  }
+
+  if (spec.kind !== 'dynamic') return;
+
+  // Dynamic: serve from cache synchronously if available; else fetch + re-render.
+  const cacheKey = `${spec.source}::${valPart}`;
+  const cached = acDynamicCache[cacheKey];
+  if (cached && cached.length) {
+    _acRenderDynamic(cached, spec, prefix, valPart);
+  } else {
+    acFetchDynamic(spec.source, valPart, (data) => {
+      // Only re-render if the token is still the same — user may have typed more.
+      const cur = acGetCurrentToken().token;
+      if (cur === rawKw + op + valPart) acUpdate();
+    });
+  }
+}
+
+function _acRenderDynamic(data, spec, prefix, valPart) {
+  for (const item of data) {
+    if (item.value === valPart) continue;
+    acItems.push({text: prefix + item.value, label: item.label || item.value,
+                  hint: item.hint || '', cat: ''});
+    if (acItems.length >= 15) break;
+  }
 }
 
 function acRender() {
@@ -3552,7 +3626,7 @@ acDropdown.addEventListener('mousedown', (e) => {
   if (item) acAccept(parseInt(item.dataset.i));
 });
 
-searchInput.addEventListener('focus', () => { acLoadDynamic(); acUpdate(); });
+searchInput.addEventListener('focus', () => { acUpdate(); });
 searchInput.addEventListener('blur', () => { setTimeout(acHide, 150); });
 
 function applySettings() {

--- a/mtg_collector/static/crack_pack.html
+++ b/mtg_collector/static/crack_pack.html
@@ -536,6 +536,11 @@ a.badge.link:hover { color: #fff; background: #555; border-color: #777; }
 </div>
 
 <script>
+function formatPrice(value) {
+  const n = parseFloat(value);
+  if (!Number.isFinite(n)) return '$0.00';
+  return '$' + n.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+}
 const setInput = document.getElementById('set-input');
 const setDropdown = document.getElementById('set-dropdown');
 const productRadios = document.getElementById('product-radios');
@@ -691,11 +696,11 @@ function buildCardBadges(card, packSetCode) {
   let html = '';
   const sources = (_settings.price_sources || 'tcg,ck').split(',');
   if (sources.includes('tcg') && card.printing_id) {
-    const sfPrice = card.tcg_price ? ` $${parseFloat(card.tcg_price).toFixed(2)}` : '';
+    const sfPrice = card.tcg_price ? ` ${formatPrice(card.tcg_price)}` : '';
     html += `<a class="badge link" href="https://scryfall.com/card/${card.set_code.toLowerCase()}/${card.collector_number}" target="_blank" rel="noopener" onclick="event.stopPropagation()">SF${sfPrice}</a>`;
   }
   if (sources.includes('ck') && card.ck_url) {
-    const ckPrice = card.ck_price ? ` $${parseFloat(card.ck_price).toFixed(2)}` : '';
+    const ckPrice = card.ck_price ? ` ${formatPrice(card.ck_price)}` : '';
     html += `<a class="badge link" href="${card.ck_url}" target="_blank" rel="noopener" onclick="event.stopPropagation()">CK${ckPrice}</a>`;
   }
   if (card.border_color === 'borderless') html += '<span class="badge treatment">BL</span>';
@@ -942,7 +947,7 @@ async function openPack(seed, hashRevealed) {
     if (sources.includes('ck') && c.ck_price) return sum + parseFloat(c.ck_price);
     return sum;
   }, 0);
-  const totalStr = packTotal > 0 ? ` — $${packTotal.toFixed(2)}` : '';
+  const totalStr = packTotal > 0 ? ` — ${formatPrice(packTotal)}` : '';
   packHeader.textContent = `${setCode} ${product} — ${currentPack.length} cards (variant ${result.variant_index}, ${pct}%)${totalStr}`;
 
   packGrid.innerHTML = '';

--- a/mtg_collector/static/deck-builder.js
+++ b/mtg_collector/static/deck-builder.js
@@ -776,7 +776,7 @@
     container.innerHTML = cards.map(c => {
       const key = isVirtual ? String(c.printing_id) : String(c.collection_id);
       const cond = c.condition ? ` [${esc(c.condition)}]` : '';
-      const price = c.purchase_price ? ` $${parseFloat(c.purchase_price).toFixed(2)}` : '';
+      const price = c.purchase_price ? ` ${formatPrice(c.purchase_price)}` : '';
       return `<div class="picker-card ${pickerSelected.has(key) ? 'selected' : ''}" data-key="${esc(key)}">
         <span>${esc(c.name)}</span>
         <span style="color:var(--text-secondary);font-size:0.85rem">${esc(c.set_code.toUpperCase())} #${esc(c.collector_number)} · ${esc(c.finish)}${cond}${price}</span>

--- a/mtg_collector/static/decks.html
+++ b/mtg_collector/static/decks.html
@@ -399,6 +399,11 @@ main { padding: 24px; }
 </div>
 
 <script>
+function formatPrice(value) {
+  const n = parseFloat(value);
+  if (!Number.isFinite(n)) return '$0.00';
+  return '$' + n.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+}
 let decks = /*INIT_DATA*/;
 let viewMode = localStorage.getItem('decks-view') || 'grid';
 let sortCol = 'name';
@@ -624,7 +629,7 @@ function renderDeckCard(d) {
       </div>
       <div class="stats">
         <span>${cardCount} cards</span>
-        ${d.total_value ? `<span>$${Number(d.total_value).toFixed(2)}</span>` : ''}
+        ${d.total_value ? `<span>${formatPrice(d.total_value)}</span>` : ''}
       </div>
       <div class="deck-links">
         <a href="/decks/${d.id}">View</a>

--- a/mtg_collector/static/explore_sheets.html
+++ b/mtg_collector/static/explore_sheets.html
@@ -443,6 +443,11 @@ a.badge.link:hover { color: #fff; background: #555; border-color: #777; }
 <div id="zoom-overlay"><img id="zoom-img" src="" alt=""></div>
 
 <script>
+function formatPrice(value) {
+  const n = parseFloat(value);
+  if (!Number.isFinite(n)) return '$0.00';
+  return '$' + n.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+}
 const setInput = document.getElementById('set-input');
 const setDropdown = document.getElementById('set-dropdown');
 const productRadios = document.getElementById('product-radios');
@@ -807,11 +812,11 @@ async function loadSheets() {
         let badges = `<span class="badge pull-rate">${pullPct}%</span>`;
         if (sources.includes('tcg') && card.printing_id) {
           const sfUrl = `https://scryfall.com/card/${card.set_code.toLowerCase()}/${card.collector_number}`;
-          const tcgPrice = card.tcg_price ? ` $${parseFloat(card.tcg_price).toFixed(2)}` : '';
+          const tcgPrice = card.tcg_price ? ` ${formatPrice(card.tcg_price)}` : '';
           badges += `<a class="badge link" href="${sfUrl}" target="_blank" rel="noopener">SF${tcgPrice}</a>`;
         }
         if (sources.includes('ck') && card.ck_url) {
-          const ckPrice = card.ck_price ? ` $${parseFloat(card.ck_price).toFixed(2)}` : '';
+          const ckPrice = card.ck_price ? ` ${formatPrice(card.ck_price)}` : '';
           badges += `<a class="badge link" href="${card.ck_url}" target="_blank" rel="noopener">CK${ckPrice}</a>`;
         }
         if (card.border_color === 'borderless') badges += '<span class="badge treatment">BL</span>';

--- a/mtg_collector/static/ingest_order.html
+++ b/mtg_collector/static/ingest_order.html
@@ -297,6 +297,11 @@ header h1 { font-size: 1.2rem; color: #e0e0e0; }
 </div>
 
 <script>
+function formatPrice(value) {
+  const n = parseFloat(value);
+  if (!Number.isFinite(n)) return '$0.00';
+  return '$' + n.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+}
 const orderText = document.getElementById('order-text');
 const fileInput = document.getElementById('file-input');
 const fileDrop = document.getElementById('file-drop');
@@ -410,7 +415,7 @@ function renderResolved() {
 
   for (const order of resolvedOrders) {
     const seller = order.seller_name || 'Unknown Seller';
-    const totalStr = order.total != null ? `$${order.total.toFixed(2)}` : '';
+    const totalStr = order.total != null ? formatPrice(order.total) : '';
     const itemCount = order.items.reduce((s, i) => s + i.quantity, 0);
 
     html += `<div class="order-group">
@@ -434,7 +439,7 @@ function renderResolved() {
       const foilTag = item.foil ? '<span class="foil-tag">Foil</span>' : '';
       const name = item.card_name || item.parsed_name;
       const setInfo = resolved ? `${(item.set_code || '').toUpperCase()} #${item.collector_number || ''}` : (item.set_hint || '');
-      const price = item.price != null ? `$${item.price.toFixed(2)}` : '';
+      const price = item.price != null ? formatPrice(item.price) : '';
       const errorInfo = !resolved ? `<div class="error-tag">${item.error || 'Not resolved'}</div>` : '';
 
       html += `<tr${rowClass}>

--- a/mtg_collector/static/order_detail.html
+++ b/mtg_collector/static/order_detail.html
@@ -368,6 +368,11 @@ header button.receive-all-btn.received {
 </div>
 
 <script>
+function formatPrice(value) {
+  const n = parseFloat(value);
+  if (!Number.isFinite(n)) return '$0.00';
+  return '$' + n.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+}
 // URL shape: /orders/:id
 const pathMatch = location.pathname.match(/^\/orders\/(\d+)$/);
 const orderId = pathMatch ? pathMatch[1] : null;
@@ -536,7 +541,7 @@ function renderCards() {
   let html = `
     <div class="summary-bar">
       <span><span class="count">${orderCards.length}</span> card${orderCards.length !== 1 ? 's' : ''}</span>
-      <span>Total value: <span class="count">$${totalValue.toFixed(2)}</span></span>
+      <span>Total value: <span class="count">${formatPrice(totalValue)}</span></span>
       <span style="margin-left:auto"><button class="btn-secondary" id="add-card-btn">+ Add Card</button></span>
     </div>
     <div class="card-list">

--- a/mtg_collector/static/orders.html
+++ b/mtg_collector/static/orders.html
@@ -209,11 +209,17 @@ function esc(s) {
   return d.innerHTML;
 }
 
+function formatPrice(value) {
+  const n = parseFloat(value);
+  if (!Number.isFinite(n)) return '$0.00';
+  return '$' + n.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+}
+
 function fmtMoney(v) {
   if (v == null || v === '') return '';
   const n = typeof v === 'number' ? v : parseFloat(v);
   if (isNaN(n)) return '';
-  return '$' + n.toFixed(2);
+  return formatPrice(n);
 }
 
 function fmtDate(iso) {

--- a/mtg_collector/static/sealed.html
+++ b/mtg_collector/static/sealed.html
@@ -1153,6 +1153,11 @@ tr.selected { background: rgba(233, 69, 96, 0.12) !important; }
 </div>
 
 <script>
+function formatPrice(value) {
+  const n = parseFloat(value);
+  if (!Number.isFinite(n)) return '$0.00';
+  return '$' + n.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+}
 // ─── State ───────────────────────────────────────────────────────────────────
 let allEntries = [];
 let allEntriesFiltered = [];
@@ -1288,13 +1293,13 @@ async function fetchSets() {
 
 function updateStats(stats) {
   const parts = [`${stats.total_entries} entries`, `${stats.total_quantity} items`];
-  if (stats.total_cost > 0) parts.push(`$${stats.total_cost.toFixed(2)} invested`);
+  if (stats.total_cost > 0) parts.push(`${formatPrice(stats.total_cost)} invested`);
   if (stats.market_value > 0) {
-    parts.push(`$${stats.market_value.toFixed(2)} market value`);
+    parts.push(`${formatPrice(stats.market_value)} market value`);
     const gl = stats.gain_loss;
     const sign = gl >= 0 ? '+' : '';
     const cls = gl >= 0 ? 'gain' : 'loss';
-    parts.push(`<span class="${cls}">${sign}$${gl.toFixed(2)}</span>`);
+    parts.push(`<span class="${cls}">${sign}${formatPrice(Math.abs(gl))}</span>`);
   }
   statusEl.innerHTML = parts.join(' · ') + ' ' + pricesStatus.outerHTML;
   // Re-acquire ref after innerHTML replacement
@@ -1882,8 +1887,8 @@ function renderGrid() {
 
     const qtyBadge = product.total_quantity > 1 ? `<span class="qty-badge">${product.total_quantity}x</span>` : '';
     const statusBadge = `<span class="status-badge ${product.primary_status}">${product.primary_status}</span>`;
-    const costText = product.min_cost != null ? `$${product.min_cost.toFixed(2)}` : '';
-    const marketText = product.market_total != null ? `$${product.market_total.toFixed(2)}` : '';
+    const costText = product.min_cost != null ? formatPrice(product.min_cost) : '';
+    const marketText = product.market_total != null ? formatPrice(product.market_total) : '';
     const selectable = selectionMode ? ' selectable' : '';
     const selected = selectionMode && isProductSelected(product) ? ' selected' : '';
     const checkboxHtml = selectionMode ? `<input type="checkbox" class="select-checkbox" ${isProductSelected(product) ? 'checked' : ''}>` : '';
@@ -1929,10 +1934,10 @@ function renderTable() {
   html += '</tr></thead><tbody>';
 
   aggregatedProducts.forEach(product => {
-    const minCost = product.min_cost != null ? `$${product.min_cost.toFixed(2)}` : '';
-    const maxCost = product.max_cost != null ? `$${product.max_cost.toFixed(2)}` : '';
-    const avgCost = product.avg_cost != null ? `$${product.avg_cost.toFixed(2)}` : '';
-    const market = product.market_total != null ? `$${product.market_total.toFixed(2)}` : '';
+    const minCost = product.min_cost != null ? formatPrice(product.min_cost) : '';
+    const maxCost = product.max_cost != null ? formatPrice(product.max_cost) : '';
+    const avgCost = product.avg_cost != null ? formatPrice(product.avg_cost) : '';
+    const market = product.market_total != null ? formatPrice(product.market_total) : '';
     const added = product.added_at ? product.added_at.slice(0, 10) : '';
 
     const rowSelected = selectionMode && isProductSelected(product) ? ' selected' : '';
@@ -1977,7 +1982,7 @@ function openDetailModal(product) {
   }
 
   const fmtCat = c => c ? c.replace(/_/g, ' ').replace(/\b\w/g, ch => ch.toUpperCase()) : '—';
-  const fmtPrice = v => v != null ? `$${v.toFixed(2)}` : '—';
+  const fmtPrice = v => v != null ? formatPrice(v) : '—';
 
   let html = `<h2>${esc(product.name || 'Unknown Product')}</h2>`;
 
@@ -2044,7 +2049,7 @@ function openDetailModal(product) {
     <div class="modal-section-title">Entries (${product.entries.length})</div>`;
   product.entries.forEach((entry, idx) => {
     const transitions = VALID_TRANSITIONS[entry.status] || [];
-    const costStr = entry.purchase_price != null ? `${entry.quantity} × $${entry.purchase_price.toFixed(2)}` : `${entry.quantity}x`;
+    const costStr = entry.purchase_price != null ? `${entry.quantity} × ${formatPrice(entry.purchase_price)}` : `${entry.quantity}x`;
     const dateStr = entry.purchase_date || (entry.added_at ? entry.added_at.slice(0, 10) : '');
     const sourceStr = [entry.source, entry.seller_name].filter(Boolean).join(' / ');
 
@@ -2073,7 +2078,7 @@ function openDetailModal(product) {
         <div class="modal-edit-row"><span class="label">Source</span><input type="text" class="ee-source" value="${esc(entry.source || '')}" placeholder="e.g. TCGPlayer, LGS"></div>
         <div class="modal-edit-row"><span class="label">Seller</span><input type="text" class="ee-seller" value="${esc(entry.seller_name || '')}" placeholder="Store name"></div>
         <div class="modal-edit-row"><span class="label">Notes</span><textarea class="ee-notes" rows="2" placeholder="Optional notes">${esc(entry.notes || '')}</textarea></div>
-        ${entry.sale_price != null ? `<div class="modal-row"><span class="label">Sale Price</span><span class="value">$${entry.sale_price.toFixed(2)}</span></div>` : ''}
+        ${entry.sale_price != null ? `<div class="modal-row"><span class="label">Sale Price</span><span class="value">${formatPrice(entry.sale_price)}</span></div>` : ''}
         <div class="entry-edit-actions">
           <button class="entry-save-btn" data-entry-id="${entry.id}" data-idx="${idx}">Save</button>
           ${transitions.length > 0 ? `
@@ -2109,7 +2114,7 @@ function openDetailModal(product) {
         if (!section || !body || !prices.length) return;
         let tbl = '<table class="price-history-table"><thead><tr><th>Date</th><th>Low</th><th>Mid</th><th>Market</th><th>High</th></tr></thead><tbody>';
         prices.forEach(p => {
-          const fmt = v => v != null ? `$${v.toFixed(2)}` : '—';
+          const fmt = v => v != null ? formatPrice(v) : '—';
           tbl += `<tr><td>${p.observed_at}</td><td>${fmt(p.low_price)}</td><td>${fmt(p.mid_price)}</td><td>${fmt(p.market_price)}</td><td>${fmt(p.high_price)}</td></tr>`;
         });
         tbl += '</tbody></table>';

--- a/mtg_collector/static/search-help.html
+++ b/mtg_collector/static/search-help.html
@@ -336,19 +336,44 @@ They filter based on your personal collection data.</p>
 </table>
 
 <h3>Date Added</h3>
-<p>Filter by the date a card was added to your collection. Uses ISO 8601 format (YYYY-MM-DD).</p>
+<p>Filter by the date a card was added to your collection. All comparisons resolve in your browser's local timezone, so <code>added:today</code> matches the cards you added during <em>your</em> calendar day — not the UTC day.</p>
+<p>Accepted forms:</p>
 <table class="keyword-table">
   <thead>
     <tr><th>Query</th><th>Description</th></tr>
   </thead>
   <tbody>
     <tr>
+      <td><code>added:today</code></td>
+      <td>Cards added today (local time)</td>
+    </tr>
+    <tr>
+      <td><code>added:yesterday</code></td>
+      <td>Cards added yesterday (local time)</td>
+    </tr>
+    <tr>
+      <td><code>added>=7d</code></td>
+      <td>Cards added in the last 7 days (also <code>Nw</code>, <code>Nm</code>, <code>Ny</code>)</td>
+    </tr>
+    <tr>
+      <td><code>added:2024</code></td>
+      <td>Cards added at any point in 2024</td>
+    </tr>
+    <tr>
+      <td><code>added:2024-03</code></td>
+      <td>Cards added in March 2024</td>
+    </tr>
+    <tr>
       <td><code>added>=2024-01-01</code></td>
       <td>Cards added on or after January 1, 2024</td>
     </tr>
     <tr>
       <td><code>added<=2025-12-31</code></td>
-      <td>Cards added on or before December 31, 2025</td>
+      <td>Cards added on or before December 31, 2025 (inclusive)</td>
+    </tr>
+    <tr>
+      <td><code>added>2024-01-15</code></td>
+      <td>Cards added strictly after January 15 (i.e. from the 16th onward)</td>
     </tr>
   </tbody>
 </table>

--- a/mtg_collector/static/set_value.html
+++ b/mtg_collector/static/set_value.html
@@ -435,6 +435,11 @@ header h1 {
 </div>
 
 <script>
+function formatPrice(value) {
+  const n = parseFloat(value);
+  if (!Number.isFinite(n)) return '$0.00';
+  return '$' + n.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+}
 // State
 let allSets = [];
 let selectedSets = new Map(); // code -> name
@@ -861,7 +866,7 @@ function updateSummary(cards) {
 
   document.getElementById('stat-total').textContent = total;
   document.getElementById('stat-priced').textContent = priced.length;
-  document.getElementById('stat-median').textContent = '$' + median.toFixed(2);
+  document.getElementById('stat-median').textContent = formatPrice(median);
   document.getElementById('stat-chaff').textContent = pct(prices.filter(p => p < 0.40).length);
   document.getElementById('stat-modest').textContent = pct(prices.filter(p => p >= 0.40 && p < 2).length);
   document.getElementById('stat-high').textContent = pct(prices.filter(p => p >= 2 && p < 10).length);
@@ -886,7 +891,7 @@ function updateTopCards(cards) {
       <td>${c.rarity ? c.rarity[0].toUpperCase() : ''}</td>
       <td>${getTreatmentTags(c)}</td>
       <td>${ownedHtml}</td>
-      <td>$${parseFloat(c.price).toFixed(2)}</td>`;
+      <td>${formatPrice(c.price)}</td>`;
     tbody.appendChild(tr);
   });
 }

--- a/mtg_collector/static/shared-card-modal.js
+++ b/mtg_collector/static/shared-card-modal.js
@@ -67,8 +67,8 @@ function createCardModal() {
     const finish = card.finish ? card.finish.charAt(0).toUpperCase() + card.finish.slice(1) : 'Nonfoil';
 
     // Prices
-    const tcgPrice = card.tcg_price ? `$${parseFloat(card.tcg_price).toFixed(2)}` : '\u2014';
-    const ckPrice = card.ck_price ? `$${parseFloat(card.ck_price).toFixed(2)}` : '\u2014';
+    const tcgPrice = card.tcg_price ? formatPrice(card.tcg_price) : '\u2014';
+    const ckPrice = card.ck_price ? formatPrice(card.ck_price) : '\u2014';
 
     // Links
     const sfUrl = `https://scryfall.com/card/${card.set_code.toLowerCase()}/${card.collector_number}`;

--- a/mtg_collector/static/shared-card-table.js
+++ b/mtg_collector/static/shared-card-table.js
@@ -66,11 +66,11 @@ function buildPriceBadges(card, opts) {
   let html = '';
   const sources = (opts.priceSources || 'tcg,ck').split(',');
   if (sources.includes('tcg')) {
-    const sfPrice = card.tcg_price ? ` $${parseFloat(card.tcg_price).toFixed(2)}` : '';
+    const sfPrice = card.tcg_price ? ` ${formatPrice(card.tcg_price)}` : '';
     html += `<a class="badge link" href="https://scryfall.com/card/${card.set_code.toLowerCase()}/${card.collector_number}" target="_blank" rel="noopener" onclick="event.stopPropagation()">SF${sfPrice}</a>`;
   }
   if (sources.includes('ck')) {
-    const ckPrice = card.ck_price ? ` $${parseFloat(card.ck_price).toFixed(2)}` : '';
+    const ckPrice = card.ck_price ? ` ${formatPrice(card.ck_price)}` : '';
     html += `<a class="badge link" href="${getCkUrl(card)}" target="_blank" rel="noopener" onclick="event.stopPropagation()">CK${ckPrice}</a>`;
   }
   return html;
@@ -145,11 +145,11 @@ function renderCellContent(colKey, card, helpers, opts) {
       return `<span data-filter-type="date_added" data-filter-value="${isoDate}">${dateStr}</span>`;
     }
     case 'ck_price': {
-      const p = card.ck_price ? `$${parseFloat(card.ck_price).toFixed(2)}` : '';
+      const p = card.ck_price ? formatPrice(card.ck_price) : '';
       return p ? `<a class="badge link" href="${getCkUrl(card)}" target="_blank" rel="noopener" onclick="event.stopPropagation()">${p}</a>` : '';
     }
     case 'tcg_price': {
-      const p = card.tcg_price ? `$${parseFloat(card.tcg_price).toFixed(2)}` : '';
+      const p = card.tcg_price ? formatPrice(card.tcg_price) : '';
       return p ? `<a class="badge link" href="https://scryfall.com/card/${card.set_code.toLowerCase()}/${card.collector_number}" target="_blank" rel="noopener" onclick="event.stopPropagation()">${p}</a>` : '';
     }
     default: return '';

--- a/mtg_collector/static/shared.js
+++ b/mtg_collector/static/shared.js
@@ -1,6 +1,14 @@
 /* shared.js — Common utility functions for all pages.
    New pages should import this. Existing pages are untouched. */
 
+/** Format a numeric value as USD with thousands separators (e.g. 3667.51 → "$3,667.51").
+    Returns "$0.00" for null/undefined/NaN inputs. */
+function formatPrice(value) {
+  const n = parseFloat(value);
+  if (!Number.isFinite(n)) return '$0.00';
+  return '$' + n.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+}
+
 /** HTML-escape a string. */
 function esc(s) {
   if (s == null) return '';

--- a/tests/test_search_compiler.py
+++ b/tests/test_search_compiler.py
@@ -85,7 +85,9 @@ class TestNumericCompilation:
 class TestTextCompilation:
     def test_name_search(self):
         c = _compile("bolt")
-        assert "card.name LIKE" in c.where_sql
+        # Name search is rewritten as a subselect on cards (faster than a
+        # per-printing LIKE) ORed with the printings.flavor_name LIKE.
+        assert "SELECT oracle_id FROM cards WHERE name LIKE" in c.where_sql
         assert "p.flavor_name LIKE" in c.where_sql
         assert "type_line" not in c.where_sql  # type line requires t: prefix
         assert "oracle_text" not in c.where_sql  # oracle text requires o: prefix

--- a/tests/test_search_compiler.py
+++ b/tests/test_search_compiler.py
@@ -231,11 +231,62 @@ class TestCollectionKeywords:
     def test_added_gte(self):
         c = _compile("added>=2024-01-01")
         assert "acquired_at" in c.where_sql
-        assert "2024-01-01" in c.params
+        # UTC-default tz → start of local day = start of UTC day.
+        assert c.params == ["2024-01-01T00:00:00"]
 
     def test_added_lte(self):
+        # ``<=`` is inclusive: must include the entire 2025-12-31.
         c = _compile("added<=2025-12-31")
         assert "acquired_at" in c.where_sql
+        assert c.params == ["2026-01-01T00:00:00"]
+
+    def test_added_gt_excludes_target_day(self):
+        # ``>2024-01-15`` means "after that day," i.e. from the 16th onward.
+        c = _compile("added>2024-01-15")
+        assert c.params == ["2024-01-16T00:00:00"]
+
+    def test_added_eq_uses_day_range(self):
+        c = _compile("added:2024-03-15")
+        assert c.params == ["2024-03-15T00:00:00", "2024-03-16T00:00:00"]
+
+    def test_added_month_precision(self):
+        c = _compile("added:2024-03")
+        assert c.params == ["2024-03-01T00:00:00", "2024-04-01T00:00:00"]
+
+    def test_added_year_precision(self):
+        c = _compile("added:2024")
+        assert c.params == ["2024-01-01T00:00:00", "2025-01-01T00:00:00"]
+
+    def test_added_invalid_value(self):
+        c = _compile("added:lolwut")
+        assert "1=0" in c.where_sql
+
+    def test_added_today_in_local_tz(self):
+        # In Asia/Tokyo (UTC+9), "today" should resolve to a UTC range
+        # that begins 9h before midnight UTC of the same nominal day.
+        # We don't pin a specific date; we just assert the offset shape.
+        from mtg_collector.search import compile_query, parse_query
+        c = compile_query(parse_query("added:today"), tz="Asia/Tokyo")
+        assert len(c.params) == 2
+        start, end = c.params
+        # End-start should be exactly 24h.
+        from datetime import datetime
+        d_start = datetime.fromisoformat(start)
+        d_end = datetime.fromisoformat(end)
+        assert (d_end - d_start).total_seconds() == 86400
+        # UTC start should be 15:00 (24-9 = 15h after UTC midnight of prior day).
+        assert d_start.hour == 15
+
+    def test_added_relative_days_ago(self):
+        c = _compile("added>=7d")
+        assert len(c.params) == 1
+        # Param is a valid ISO prefix.
+        from datetime import datetime
+        datetime.fromisoformat(c.params[0])
+
+    def test_added_yesterday(self):
+        c = _compile("added:yesterday")
+        assert len(c.params) == 2
 
     def test_price_gte(self):
         c = _compile("price>=5.00")

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -45,9 +45,22 @@ _BACKUP_CMD = (
     f"exec('if os.path.exists(p):\\n s=sqlite3.connect(p)\\n d=sqlite3.connect(b)\\n s.backup(d)\\n s.close()\\n d.close()')"
     '"'
 )
+# Restore via sqlite3.backup() in reverse rather than ``cp``: under WAL
+# mode the live ``.sqlite`` file is only one of three (.sqlite, .sqlite-wal,
+# .sqlite-shm). A plain ``cp`` over the main file leaves the WAL sidecar
+# in place and the server's open connections keep reading via the stale
+# WAL frame index — earlier tests' writes survive the "restore" and
+# pollute later tests. sqlite3.backup() copies pages through SQLite's
+# locking protocol; the server's next read sees the restored state.
 _RESTORE_CMD = (
-    f"cp {_CONTAINER_DB_BACKUP} {_CONTAINER_DB}"
-    f" && {{ [ -f {_CONTAINER_SHARED_DB_BACKUP} ] && cp {_CONTAINER_SHARED_DB_BACKUP} {_CONTAINER_SHARED_DB}; true; }}"
+    f'python3 -c "import sqlite3, os; '
+    f"s=sqlite3.connect('{_CONTAINER_DB_BACKUP}'); "
+    f"d=sqlite3.connect('{_CONTAINER_DB}'); "
+    f"s.backup(d); s.close(); d.close(); "
+    f"p='{_CONTAINER_SHARED_DB_BACKUP}'; "
+    f"q='{_CONTAINER_SHARED_DB}'; "
+    f"exec('if os.path.exists(p):\\n s=sqlite3.connect(p)\\n d=sqlite3.connect(q)\\n s.backup(d)\\n s.close()\\n d.close()')"
+    '"'
 )
 
 

--- a/tests/ui/hints/card_modal_dispose_button_disabled_until_status_selected.yaml
+++ b/tests/ui/hints/card_modal_dispose_button_disabled_until_status_selected.yaml
@@ -1,0 +1,24 @@
+start_page: /collection
+involves:
+  - "#view-grid-btn — switches collection to grid view (more stable click target than table rows, which can collide with header-cell filters)"
+  - ".sheet-card[data-idx='0'] — first card in the grid; clicking it opens the modal"
+  - "#card-modal-overlay — modal container, gains 'active' class when open"
+  - ".dispose-btn — Dispose button inside the modal's Copies section; rendered with disabled attribute"
+  - ".dispose-select — the disposition dropdown (Sold/Traded/Gifted/Lost/Listed)"
+fixture_data:
+  owned_cards: "Standard --test fixture has 45 cards with status='owned'"
+notes: >
+  IMPORTANT: switch to grid view before clicking a card. Clicking
+  tr[data-idx] in table view collides with header-cell filter controls
+  in Playwright (see prior memory).
+
+  1. Navigate to /collection. 2. Click #view-grid-btn. 3. Wait for
+  .sheet-card[data-idx='0'] to be visible. 4. Click .sheet-card[data-idx='0'].
+  5. Wait for #card-modal-overlay.active. The modal lazily loads the
+  copies section. 6. Wait for .dispose-btn to appear (the copies fetch
+  may take a beat). 7. Assert that .dispose-btn is visible and has the
+  disabled attribute (use assert_visible on .dispose-btn[disabled]).
+  8. select_by_label on .dispose-select picking "Sold". 9. The select's
+  change handler enables the button — assert that .dispose-btn no
+  longer has the disabled attribute (use assert_visible on
+  .dispose-btn:not([disabled])). 10. Screenshot.

--- a/tests/ui/hints/collection_search_autocomplete_added_operators.yaml
+++ b/tests/ui/hints/collection_search_autocomplete_added_operators.yaml
@@ -1,0 +1,15 @@
+start_page: /collection
+involves:
+  - "#search-input — the search bar at the top of the collection page"
+  - "#ac-dropdown — the autocomplete dropdown, gets class 'open' when populated"
+  - ".ac-item .ac-label — each suggestion row's primary label"
+fixture_data:
+  collection_size: "Standard --test fixture (45 cards)"
+notes: >
+  1. Navigate to /collection. 2. Fill the #search-input with the text
+  "added" (no operator). The page's input handler fires synchronously
+  and populates #ac-dropdown with operator suggestions. 3. Wait for
+  #ac-dropdown to become visible. 4. Assert that the suggestions
+  "added:", "added>=", "added<=", and "added>" all appear in the
+  dropdown. These four are the most important operators; the regex
+  splitter must recognize each. 5. Take a final-state screenshot.

--- a/tests/ui/hints/collection_search_autocomplete_added_value_shortcuts.yaml
+++ b/tests/ui/hints/collection_search_autocomplete_added_value_shortcuts.yaml
@@ -1,0 +1,16 @@
+start_page: /collection
+involves:
+  - "#search-input — the search bar at the top of the collection page"
+  - "#ac-dropdown — the autocomplete dropdown"
+  - ".ac-item .ac-label — primary label per suggestion"
+  - ".ac-item .ac-hint — secondary hint text (e.g. 'Today (local)', '7 days ago')"
+fixture_data:
+  collection_size: "Standard --test fixture (45 cards added on the fixture-build date)"
+notes: >
+  1. Navigate to /collection. 2. Fill the #search-input with "added:".
+  The colon triggers the dynamic value branch; the page makes an async
+  fetch to /api/search-suggest?key=added which returns the relative
+  shortcuts plus the years/months in the corpus. 3. Wait for the
+  dropdown to populate (the async fetch takes ~100-300ms in practice;
+  use a wait_for_text on the literal "today" to gate). 4. Assert that
+  "today", "yesterday", "7d", and "30d" all appear. 5. Screenshot.

--- a/tests/ui/hints/collection_search_clear_button_appears_after_url_restore.yaml
+++ b/tests/ui/hints/collection_search_clear_button_appears_after_url_restore.yaml
@@ -1,0 +1,19 @@
+start_page: /collection?q=Scrawling
+involves:
+  - "search input #search-input pre-populated from the URL"
+  - "clear button #search-clear inside the search input"
+  - "collection table .collection-table"
+fixture_data:
+  url_query: "Scrawling"
+  search_match: "Scrawling Crawler"
+  total_cards_label: "45 cards"
+notes: >
+  Navigate directly to /collection?q=Scrawling. The page's
+  restoreFiltersFromURL() runs during init and assigns
+  searchInput.value = "Scrawling", then calls
+  updateSearchClearVisibility() so the X should be visible without any
+  user typing.
+  Wait for "Scrawling Crawler" to confirm the URL-driven query rendered.
+  Assert #search-clear is visible.
+  Click #search-clear. Wait for "45 cards" status text to confirm the
+  full collection is back. Assert #search-clear is hidden.

--- a/tests/ui/hints/collection_search_clear_button_clears_input.yaml
+++ b/tests/ui/hints/collection_search_clear_button_clears_input.yaml
@@ -1,0 +1,20 @@
+start_page: /collection
+involves:
+  - "search input #search-input with placeholder 'Search (e.g. t:creature c:r mv>=3)'"
+  - "clear button #search-clear (× character) inside the search input"
+  - "collection table .collection-table with card rows"
+  - "status text #status showing card count"
+fixture_data:
+  search_term: "Scrawling"
+  search_match: "Scrawling Crawler"
+  total_cards_label: "45 cards"
+notes: >
+  Navigate to /collection. Wait for .collection-table.
+  Type "Scrawling" into the search input via fill_by_placeholder.
+  Wait for "Scrawling Crawler" text to confirm the filtered fetch finished.
+  Assert #search-clear is visible (it has CSS .search-clear { display: none }
+  by default and gains class .visible -> display: flex when input has content).
+  Click #search-clear. The handler clears the input value, focuses it, and
+  dispatches an input event so the existing debounced fetch fires.
+  Wait for "45 cards" status text to confirm the full default collection is
+  back. Assert #search-clear is hidden again.

--- a/tests/ui/hints/collection_search_clear_button_visibility_toggle.yaml
+++ b/tests/ui/hints/collection_search_clear_button_visibility_toggle.yaml
@@ -1,0 +1,20 @@
+start_page: /collection
+involves:
+  - "search input #search-input"
+  - "clear button #search-clear inside the search input"
+  - "collection table .collection-table"
+fixture_data:
+  search_term: "Scrawling"
+  search_match: "Scrawling Crawler"
+  total_cards_label: "45 cards"
+notes: >
+  Navigate to /collection and wait for .collection-table.
+  Initial state: input is empty, so #search-clear should be hidden
+  (display: none — assert_hidden works because the element lacks the
+  .visible class).
+  Type "Scrawling" via fill_by_placeholder. Wait for "Scrawling Crawler"
+  to confirm the input event ran and the debounced fetch completed.
+  Assert #search-clear is now visible.
+  Clear by filling the placeholder with empty string "". Wait for
+  "45 cards" to confirm the empty-query fetch completed.
+  Assert #search-clear is hidden again.

--- a/tests/ui/hints/search_help_documents_added_relative_dates.yaml
+++ b/tests/ui/hints/search_help_documents_added_relative_dates.yaml
@@ -1,0 +1,11 @@
+start_page: /search-help
+involves:
+  - "The 'Date Added' section in the help page body"
+  - "Inline <code> blocks containing 'added:today', 'added:2024', 'added:2024-03'"
+  - "Prose mentioning local timezone resolution"
+fixture_data: {}
+notes: >
+  1. Navigate to /search-help. 2. Assert the text "added:today" appears
+  on the page. 3. Assert "local timezone" appears. 4. Assert
+  "added:2024-03" appears. 5. Assert "7d" appears (relative shortcut
+  documentation). 6. Screenshot.

--- a/tests/ui/implementations/card_modal_dispose_button_disabled_until_status_selected.py
+++ b/tests/ui/implementations/card_modal_dispose_button_disabled_until_status_selected.py
@@ -1,0 +1,29 @@
+"""
+Hand-written implementation for card_modal_dispose_button_disabled_until_status_selected.
+
+Opens a card modal via grid view, asserts the Dispose button is
+disabled by default, picks a disposition, and asserts the button
+becomes enabled.
+"""
+
+
+def steps(harness):
+    harness.navigate("/collection")
+    # Grid view is the stable click path — clicking table rows can hit
+    # header-filter cells in Playwright (see project memory).
+    harness.click_by_selector("#view-grid-btn")
+    harness.wait_for_visible(".sheet-card[data-idx='0']")
+
+    # Open the card modal.
+    harness.click_by_selector(".sheet-card[data-idx='0']")
+    # The copies section is fetched lazily; wait for the dispose UI to
+    # land.
+    harness.wait_for_visible(".dispose-btn", timeout=5_000)
+
+    # Default state: button is rendered with the disabled attribute.
+    harness.assert_visible(".dispose-btn[disabled]")
+
+    # Pick a disposition — the change handler enables the button.
+    harness.select_by_label(".dispose-select", "Sold")
+    harness.assert_visible(".dispose-btn:not([disabled])")
+    harness.screenshot("final_state")

--- a/tests/ui/implementations/collection_search_autocomplete_added_operators.py
+++ b/tests/ui/implementations/collection_search_autocomplete_added_operators.py
@@ -1,0 +1,23 @@
+"""
+Hand-written implementation for collection_search_autocomplete_added_operators.
+
+Types the bare keyword "added" and verifies the autocomplete dropdown
+lists the comparison operators the search compiler accepts for date
+keywords.
+"""
+
+
+def steps(harness):
+    harness.navigate("/collection")
+    harness.wait_for_visible("#search-input")
+
+    # Bare keyword (no operator) — should trigger operator suggestions.
+    harness.fill_by_placeholder("Search (e.g. t:creature c:r mv>=3)", "added")
+
+    harness.wait_for_visible("#ac-dropdown")
+    # Each operator the date keyword accepts should appear in the dropdown.
+    harness.assert_text_present("added:")
+    harness.assert_text_present("added>=")
+    harness.assert_text_present("added<=")
+    harness.assert_text_present("added>")
+    harness.screenshot("final_state")

--- a/tests/ui/implementations/collection_search_autocomplete_added_value_shortcuts.py
+++ b/tests/ui/implementations/collection_search_autocomplete_added_value_shortcuts.py
@@ -1,0 +1,24 @@
+"""
+Hand-written implementation for collection_search_autocomplete_added_value_shortcuts.
+
+Types "added:" and verifies the autocomplete dropdown lists the
+relative-date shortcuts ("today", "yesterday", "7d", "30d") served by
+the new /api/search-suggest endpoint.
+"""
+
+
+def steps(harness):
+    harness.navigate("/collection")
+    harness.wait_for_visible("#search-input")
+
+    # Colon triggers the dynamic value branch — an async fetch to
+    # /api/search-suggest?key=added populates the dropdown.
+    harness.fill_by_placeholder("Search (e.g. t:creature c:r mv>=3)", "added:")
+
+    harness.wait_for_visible("#ac-dropdown")
+    # Wait for the async fetch to land — gating on a literal value.
+    harness.wait_for_text("today")
+    harness.assert_text_present("yesterday")
+    harness.assert_text_present("7d")
+    harness.assert_text_present("30d")
+    harness.screenshot("final_state")

--- a/tests/ui/implementations/collection_search_clear_button_appears_after_url_restore.py
+++ b/tests/ui/implementations/collection_search_clear_button_appears_after_url_restore.py
@@ -1,0 +1,28 @@
+"""
+Hand-written implementation for collection_search_clear_button_appears_after_url_restore.
+
+Loads the collection page with a query already in the URL and verifies the
+clear (×) button is visible without any user typing — the programmatic
+value-set path in restoreFiltersFromURL() must call updateSearchClearVisibility().
+"""
+
+
+def steps(harness):
+    # Open a shareable link with the search query already in the URL.
+    harness.navigate("/collection?q=Scrawling")
+
+    # Wait for the URL-driven filtered results to render.
+    harness.wait_for_text("Scrawling Crawler")
+
+    # The × button must already be visible — no typing happened.
+    harness.assert_visible("#search-clear")
+    harness.screenshot("clear_button_visible_from_url")
+
+    # Click the × to clear the URL-driven query.
+    harness.click_by_selector("#search-clear")
+
+    # Full collection comes back and the × hides.
+    harness.wait_for_text("45 cards")
+    harness.assert_hidden("#search-clear")
+
+    harness.screenshot("final_state")

--- a/tests/ui/implementations/collection_search_clear_button_clears_input.py
+++ b/tests/ui/implementations/collection_search_clear_button_clears_input.py
@@ -1,0 +1,32 @@
+"""
+Hand-written implementation for collection_search_clear_button_clears_input.
+
+Types a query, verifies the clear (×) button appears, clicks it, and confirms
+the input empties, the button hides, and the full collection comes back.
+"""
+
+
+def steps(harness):
+    # Navigate to Collection page and wait for the table to render.
+    harness.navigate("/collection")
+    harness.wait_for_visible(".collection-table", timeout=500)
+
+    # Clear button should be hidden when the input starts empty.
+    harness.assert_hidden("#search-clear")
+
+    # Type a query and wait for the filtered results.
+    harness.fill_by_placeholder("Search (e.g. t:creature c:r mv>=3)", "Scrawling")
+    harness.wait_for_text("Scrawling Crawler")
+
+    # Clear button is now visible because the input has content.
+    harness.assert_visible("#search-clear")
+    harness.screenshot("clear_button_visible")
+
+    # Click the × button to clear the search.
+    harness.click_by_selector("#search-clear")
+
+    # Full collection should be back and the × should be hidden again.
+    harness.wait_for_text("45 cards")
+    harness.assert_hidden("#search-clear")
+
+    harness.screenshot("final_state")

--- a/tests/ui/implementations/collection_search_clear_button_visibility_toggle.py
+++ b/tests/ui/implementations/collection_search_clear_button_visibility_toggle.py
@@ -1,0 +1,29 @@
+"""
+Hand-written implementation for collection_search_clear_button_visibility_toggle.
+
+Verifies the × button is hidden when the input is empty, appears when the user
+types, and hides again once the input is empty.
+"""
+
+
+def steps(harness):
+    # Navigate to Collection page and wait for the table to render.
+    harness.navigate("/collection")
+    harness.wait_for_visible(".collection-table", timeout=500)
+
+    # Empty input → clear button hidden.
+    harness.assert_hidden("#search-clear")
+    harness.screenshot("initial_hidden")
+
+    # Type a query → clear button becomes visible.
+    harness.fill_by_placeholder("Search (e.g. t:creature c:r mv>=3)", "Scrawling")
+    harness.wait_for_text("Scrawling Crawler")
+    harness.assert_visible("#search-clear")
+    harness.screenshot("with_query_visible")
+
+    # Empty the input by filling with "" → clear button hides again.
+    harness.fill_by_placeholder("Search (e.g. t:creature c:r mv>=3)", "")
+    harness.wait_for_text("45 cards")
+    harness.assert_hidden("#search-clear")
+
+    harness.screenshot("final_state")

--- a/tests/ui/implementations/deck_detail_zone_tab_switching.py
+++ b/tests/ui/implementations/deck_detail_zone_tab_switching.py
@@ -10,11 +10,12 @@ def steps(harness):
     # Navigate to deck detail page
     harness.navigate("/decks/1")
 
-    # Wait for the deck to load
+    # The deck name and the zone-count badges render in separate async
+    # passes, so wait for "(8)" with a timeout rather than asserting
+    # immediately. Under runner load there's a measurable gap between
+    # "Bolt Tribal" appearing and "(8)" landing in the DOM.
     harness.wait_for_text("Bolt Tribal")
-
-    # Verify mainboard tab shows count
-    harness.assert_text_present("(8)")
+    harness.wait_for_text("(8)")
 
     # Wait for grid to render (default view for small decks)
     harness.wait_for_visible(".grid-card")
@@ -24,13 +25,13 @@ def steps(harness):
 
     # Verify sideboard cards are shown in grid
     harness.wait_for_visible(".grid-card")
-    harness.assert_text_present("(3)")
+    harness.wait_for_text("(3)")
 
     # Switch to Commander tab
     harness.click_by_text("Commander")
 
     # Verify empty zone message
     harness.wait_for_text("No cards in this zone")
-    harness.assert_text_present("(0)")
+    harness.wait_for_text("(0)")
 
     harness.screenshot("final_state")

--- a/tests/ui/implementations/search_help_documents_added_relative_dates.py
+++ b/tests/ui/implementations/search_help_documents_added_relative_dates.py
@@ -1,0 +1,20 @@
+"""
+Hand-written implementation for search_help_documents_added_relative_dates.
+
+Verifies that the /search-help page documents the timezone-aware
+behavior and accepted formats of the `added` keyword.
+"""
+
+
+def steps(harness):
+    harness.navigate("/search-help")
+    harness.wait_for_text("Date Added")
+
+    # The new local-tz prose
+    harness.assert_text_present("added:today")
+    harness.assert_text_present("local timezone")
+    # Partial ISO date support
+    harness.assert_text_present("added:2024-03")
+    # Relative shortcut documentation
+    harness.assert_text_present("7d")
+    harness.screenshot("final_state")

--- a/tests/ui/intents/card_modal_dispose_button_disabled_until_status_selected.yaml
+++ b/tests/ui/intents/card_modal_dispose_button_disabled_until_status_selected.yaml
@@ -1,0 +1,11 @@
+# Scenario: Dispose button is disabled until a disposition is selected
+#
+# Related:
+#   pull_requests: []
+
+description: >
+  When I open a card's modal on the collection page, the Dispose button
+  in the copy controls is visibly disabled until I pick a disposition
+  (Sold, Traded, Gifted, etc.) from the dropdown. As soon as I select a
+  status the button becomes clickable, so I can never click an empty
+  Dispose action by accident.

--- a/tests/ui/intents/collection_search_autocomplete_added_operators.yaml
+++ b/tests/ui/intents/collection_search_autocomplete_added_operators.yaml
@@ -1,0 +1,10 @@
+# Scenario: Autocomplete suggests operators for the `added` keyword
+#
+# Related:
+#   pull_requests: []
+
+description: >
+  When I type "added" into the search bar on the collection page, the
+  autocomplete dropdown shows me the comparison operators I can pair
+  with that keyword — "added:", "added>=", "added<=", and so on — so I
+  can discover the valid query shapes without leaving the field.

--- a/tests/ui/intents/collection_search_autocomplete_added_value_shortcuts.yaml
+++ b/tests/ui/intents/collection_search_autocomplete_added_value_shortcuts.yaml
@@ -1,0 +1,11 @@
+# Scenario: Autocomplete suggests date shortcuts after `added:`
+#
+# Related:
+#   pull_requests: []
+
+description: >
+  After typing "added:" into the search bar on the collection page, the
+  autocomplete dropdown shows me convenient date shortcuts — "today",
+  "yesterday", "7d", "30d" — alongside the years and months actually
+  present in my collection, so I can quickly filter without having to
+  remember an exact ISO date.

--- a/tests/ui/intents/collection_search_clear_button_appears_after_url_restore.yaml
+++ b/tests/ui/intents/collection_search_clear_button_appears_after_url_restore.yaml
@@ -1,0 +1,11 @@
+# Scenario: Clear button appears for URL-driven search queries
+#
+# Related:
+#   issues: []
+#   pull_requests: []
+
+description: >
+  When I open a shareable collection link with a query already in the URL
+  (for example /collection?q=Scrawling), the search input is pre-populated
+  for me and the × clear button is already visible without my having to
+  type anything. Clicking it clears the query and brings back the full view.

--- a/tests/ui/intents/collection_search_clear_button_clears_input.yaml
+++ b/tests/ui/intents/collection_search_clear_button_clears_input.yaml
@@ -1,0 +1,11 @@
+# Scenario: Clear search via the in-input X button
+#
+# Related:
+#   issues: []
+#   pull_requests: []
+
+description: >
+  After I type a query into the collection search bar and the results filter
+  down, I can click the small × button inside the search input to clear my
+  query in one click. The input empties, the × disappears, and the collection
+  re-fetches the full default view.

--- a/tests/ui/intents/collection_search_clear_button_visibility_toggle.yaml
+++ b/tests/ui/intents/collection_search_clear_button_visibility_toggle.yaml
@@ -1,0 +1,11 @@
+# Scenario: Search clear button visibility tracks input content
+#
+# Related:
+#   issues: []
+#   pull_requests: []
+
+description: >
+  The × clear button inside the collection search input is hidden when the
+  input is empty, appears as soon as I start typing, and disappears again
+  once the input is empty — so I never see a dead X over an empty field
+  and never lose the X when I have a query that needs clearing.

--- a/tests/ui/intents/search_help_documents_added_relative_dates.yaml
+++ b/tests/ui/intents/search_help_documents_added_relative_dates.yaml
@@ -1,0 +1,11 @@
+# Scenario: Search help documents `added` date shortcuts and local-tz semantics
+#
+# Related:
+#   pull_requests: []
+
+description: >
+  When I visit the search help page, the Date Added section explains
+  that "added:today" matches my local calendar day (not UTC) and lists
+  the new accepted forms — relative shortcuts like "7d" plus partial
+  ISO dates like "added:2024" and "added:2024-03". This gives me a
+  durable reference for the timezone-aware behavior.


### PR DESCRIPTION
## Summary

Two themes on this branch:

**A. DB concurrency, query performance, backup pipeline** (commits `8fa61f4`–`734cc2b`). Already running in prod (patched directly to `/opt/mtgc-prod` earlier); this PR is so they survive the next CI deploy.

**B. Collection-page UX: search autocomplete, `added` date parsing, price formatting, two small modal fixes** (commits `2baec65`–`d6fa909`). All driven from one back-and-forth session, kept as separate commits so each piece is reviewable in isolation.

---

## A. Backup / performance / concurrency

### 1. WAL mode (`connection.py`, `crack_pack_server.py`)

`PRAGMA journal_mode = WAL` is set on every SQLite connection. The nightly `mtg data fetch-prices` opens a multi-minute write transaction; in rollback-journal mode that blocks every reader (`/api/collection` would hit `database is locked` and time out after 10 s). WAL lets readers see a consistent snapshot in parallel. Verified live: a reader against the 5 GB prod DB returned in 6 ms while a writer held a 4-second transaction.

### 2. Bare-word name search optimisation (`compiler.py`)

Rewrote `_compile_name_search` so the `card.name` half goes through `p.oracle_id IN (SELECT oracle_id FROM cards WHERE name LIKE ...)` instead of a per-printing index lookup, and gated the `p.flavor_name` LIKE on `IS NOT NULL` (only 558 of 112,809 printings have flavor names). The cards table is scanned once (37k rows) instead of per-printing during a 112k-row printings scan.

Measured on the live 5 GB DB (`akroma's will is:unowned`):
- before: 448 ms warm / ~3.5 s cold-with-lock-contention
- after: 124 ms warm / ~150 ms end-to-end through HTTP

### 3. Force the price join when `?sort=price` (`crack_pack_server.py`)

URL-level sort param `?sort=price` referenced `_lp.price` in `ORDER BY` without ever triggering the join → `sqlite3.OperationalError: no such column: _lp.price`. Bug had been live since the search-engine rewrite (`24fc389`, 2026-04-08).

### 4. Backup pipeline (`backup.sh`, `deploy.sh`)

Nightly cron backups had been silently failing since April 23 with `database or disk is full`. Root cause: the old script staged a full 5 GB copy in `/tmp` inside the container and then `podman cp`'d it out. Now we snapshot host-side from the volume mount via `sqlite3.backup()` (safe under WAL), fail loudly on a pre-flight disk check, sync to S3 *before* local pruning, and clean dangling image layers in `deploy.sh` so the disk doesn't fill up again.

---

## B. Collection-page UX

### Operator-aware search autocomplete (`f266f5b`, `4589c9b`, `6777f5e`)

The dropdown previously only fired value-suggestions after a literal `:` in the token, so keywords driven by comparison operators (`added`, `price`, `mv`, `pow`, `tou`, `year`, `cn`, `loy`, plus the relational color forms) got nothing. Now:

- The splitter recognises `: = != >= <= > <` as the kw/value separator, matching the search tokenizer.
- `AC_VALUES` → `AC_KEYWORD_SPECS`: each keyword declares its allowed operators, suggestion kind (`enum` / `numeric` / `dynamic`), and value source.
- A bare keyword token emits operator suggestions (`added:`, `added>=`, `added>`, …) so users can discover what's valid without leaving the field.
- New `/api/search-suggest` endpoint serves corpus-restricted suggestions for `added` (relative shortcuts + years/months actually present in the user's collection), `artist`, `keyword`, `set`, `deck`, `binder`.

### Timezone-aware `added` (`ac1820b`, `e279a63`)

`added` used to do naive `SUBSTR(acquired_at, 1, 10)` lex compare — UTC for day boundaries. Cards added near local midnight were silently mis-split. Now:

- Frontend sends `Intl.DateTimeFormat().resolvedOptions().timeZone` on every `/api/collection` fetch.
- Server passes it to `compile_query(ast, tz=…)`, which resolves date inputs in the user's local calendar.
- Accepted forms: `YYYY`, `YYYY-MM`, `YYYY-MM-DD`, full ISO datetime, plus `today`, `yesterday`, `Nd`, `Nw`, `Nm`, `Ny`.
- `:` / `=` semantics are half-open day-ranges (so `added:2024-03` = all of March 2024 in the user's tz). Operators `<`, `<=`, `>`, `>=` use the correct range boundary.
- Invalid input emits the same `1=0 /* invalid date */` sentinel used elsewhere — no silent fallback.

### Thousands separators on every price (`4f6b19d`)

Introduced a single `formatPrice` helper (in `shared.js` for pages that import it, inlined at the top of each script otherwise) producing `$3,667.51` instead of `$3667.51`. Replaced every ad-hoc `` `${X.toFixed(2)}` `` / `'$' + X.toFixed(2)` site in the static UI — status bar, price-statistics modal, card modals, the standalone card detail page, deck/binder/order/sealed totals, price chart axes and tooltips, the share-pack total, the set value report, etc. The 4-decimal API-cost display in `recent.html` is intentionally left alone (it isn't a product price).

### Two small modal fixes (`2baec65`, `071869e`)

- Dispose button on the card modal renders `disabled` by default and enables on a `change` event from the dropdown. The old behaviour silently no-op'd when clicked without a status picked.
- Price-history chart wrapper height bumped from 150/180 px → 300/360 px so the four overlapping price series are visually distinguishable.

### UI scenario tests (`d6fa909`)

Four new intent/hint/implementation triples under `tests/ui/`:

- `collection_search_autocomplete_added_operators` — typing the bare keyword surfaces the operator menu.
- `collection_search_autocomplete_added_value_shortcuts` — typing `added:` triggers the new endpoint and surfaces today/yesterday/Nd shortcuts.
- `card_modal_dispose_button_disabled_until_status_selected` — disabled→enabled toggle on the modal.
- `search_help_documents_added_relative_dates` — `/search-help` describes the timezone-aware behaviour.

## Test plan

- [x] `uv run ruff check mtg_collector/` — clean
- [x] `uv run pytest tests/test_search_compiler.py` — 97 passed (12 new cases covering ISO partial dates, relative shortcuts, local-tz day ranges, invalid input)
- [x] Full unit suite: `uv run pytest tests/ --ignore=tests/ui --ignore=tests/integration` — 1078 passed, 195 skipped
- [x] All 4 new UI scenarios pass against the `--test` fixture container
- [x] Live timing of `akroma's will is:unowned` against prod: 150–185 ms (vs 3.4 s pre-fix)
- [x] Concurrent reader-vs-writer test against live prod DB confirms WAL fix
- [x] Real `bash deploy/backup.sh prod` end-to-end (tarball → S3 → local prune) ran clean
- [x] In-browser smoke: `added:today` resolves to the local day, operator AC fires on `added`, value AC fires on `added:`, dispose disabled/enabled toggle works, prices render with commas

🤖 Generated with [Claude Code](https://claude.com/claude-code)
