### PR TITLE
Collection growth chart + stable table column widths

### DIFF
--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -1067,6 +1067,8 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                 self._send_json({"error": "Not found"}, 404)
         elif path == "/api/collection/copies":
             self._api_collection_copies(params)
+        elif path == "/api/collection/growth":
+            self._api_collection_growth(params)
         elif path == "/api/collection":
             self._api_collection(params)
         elif path == "/api/search":
@@ -2598,6 +2600,198 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             self._send_json({"available": True, "last_modified": log["fetched_at"]})
         else:
             self._send_json({"available": False, "last_modified": None})
+
+    def _api_collection_growth(self, params: dict):
+        """Return daily (count, tcg_value, ck_value) series for the filtered collection.
+
+        Mirrors the search-filter parsing in `/api/collection`, then walks every
+        day from the earliest acquisition through today, summing:
+          - cards acquired by that date (count)
+          - historical price on that date for each held card (value)
+
+        Prices forward-fill: the most recent known price <= D is used. Cards
+        with no price on/before D contribute 0 to value but still count.
+
+        Response: {"dates": ["YYYY-MM-DD", ...], "counts": [...],
+                   "tcg_values": [...], "ck_values": [...]}
+        """
+        import datetime as _dt
+        import itertools as _it
+        from collections import defaultdict
+
+        from mtg_collector.search import SearchError, compile_query, parse_query
+
+        q = params.get("q", [""])[0]
+        tz = params.get("tz", [""])[0] or None
+
+        where_sql = "1=1"
+        sql_params: list = []
+        compiled = None
+        if q:
+            try:
+                ast = parse_query(q)
+                compiled = compile_query(ast, tz=tz)
+                where_sql = compiled.where_sql
+                sql_params = list(compiled.params)
+            except SearchError as e:
+                self._send_json({"error": str(e), "position": e.position}, 400)
+                return
+
+        # is:unowned makes no sense for a growth chart — ignore.
+        if compiled and compiled.include_unowned:
+            self._send_json({"dates": [], "counts": [], "tcg_values": [], "ck_values": []})
+            return
+
+        # Match /api/collection's status default
+        has_status = compiled and compiled.has_status_filter
+        if not has_status:
+            if where_sql == "1=1":
+                where_sql = "c.status IN ('owned', 'ordered')"
+            else:
+                where_sql = f"c.status IN ('owned', 'ordered') AND ({where_sql})"
+
+        # Conditional joins (mirrors /api/collection's default template — the
+        # collection-anchored one, since growth is always about owned rows).
+        extra_joins = []
+        if compiled and compiled.needs_price_join:
+            extra_joins.append(
+                "LEFT JOIN latest_prices _lp ON _lp.set_code = p.set_code"
+                " AND _lp.collector_number = p.collector_number AND _lp.price_type = 'normal'"
+            )
+        if compiled and compiled.needs_wishlist_join:
+            extra_joins.append(
+                "LEFT JOIN wishlist _wl ON _wl.oracle_id = card.oracle_id AND _wl.fulfilled_at IS NULL"
+            )
+        extra_joins_sql = "\n            ".join(extra_joins)
+
+        conn = self._get_conn()
+        query = f"""
+            SELECT p.set_code, p.collector_number, c.finish,
+                   substr(c.acquired_at, 1, 10) AS acq_date
+            FROM collection c
+            JOIN printings p ON c.printing_id = p.printing_id
+            JOIN cards card ON p.oracle_id = card.oracle_id
+            JOIN sets s ON p.set_code = s.set_code
+            LEFT JOIN orders o ON c.order_id = o.id
+            LEFT JOIN deck_cards dc ON dc.collection_id = c.id
+            LEFT JOIN decks d ON dc.deck_id = d.id
+            LEFT JOIN binders b ON c.binder_id = b.id
+            {extra_joins_sql}
+            WHERE ({where_sql}) AND c.acquired_at IS NOT NULL
+            GROUP BY c.id
+        """
+        pop_rows = conn.execute(query, sql_params).fetchall()
+
+        if not pop_rows:
+            conn.close()
+            self._send_json({"dates": [], "counts": [], "tcg_values": [], "ck_values": []})
+            return
+
+        # Build the date axis: earliest acquisition → today (UTC).
+        # acquired_at is ISO 8601 UTC, so the first 10 chars are a UTC date.
+        min_acq = min(r["acq_date"] for r in pop_rows)
+        try:
+            start = _dt.date.fromisoformat(min_acq)
+        except (TypeError, ValueError):
+            conn.close()
+            self._send_json({"dates": [], "counts": [], "tcg_values": [], "ck_values": []})
+            return
+        end = _dt.datetime.utcnow().date()
+        if end < start:
+            end = start
+        num_days = (end - start).days + 1
+        date_list = [(start + _dt.timedelta(days=i)).isoformat() for i in range(num_days)]
+        date_idx = {d: i for i, d in enumerate(date_list)}
+
+        # Group population by (set_code, collector_number, finish). Each row in
+        # `collection` = 1 physical card.
+        groups: dict[tuple, list[int]] = defaultdict(list)
+        for r in pop_rows:
+            acq = r["acq_date"]
+            i = date_idx.get(acq)
+            if i is None:
+                # Acquired_at before start? Shouldn't happen — start = min(acq).
+                # Acquired_at after today (clock skew)? Clamp to last day.
+                i = num_days - 1
+            groups[(r["set_code"], r["collector_number"], r["finish"])].append(i)
+
+        # Fetch all relevant prices in one query, scoped to the population's
+        # distinct (set_code, collector_number) pairs and dates >= start.
+        key_pairs = list({(g[0], g[1]) for g in groups.keys()})
+        # SQLite has a default parameter limit (often 32766); chunk to be safe.
+        prices_by_key: dict[tuple, list[tuple[str, float]]] = defaultdict(list)
+        CHUNK = 500
+        for i in range(0, len(key_pairs), CHUNK):
+            chunk = key_pairs[i:i + CHUNK]
+            placeholders = ",".join(["(?, ?)"] * len(chunk))
+            chunk_params = [v for pair in chunk for v in pair]
+            chunk_params.append(min_acq)
+            price_rows = conn.execute(
+                f"""
+                SELECT set_code, collector_number, source, price_type, observed_at, price
+                FROM prices
+                WHERE (set_code, collector_number) IN ({placeholders})
+                  AND observed_at >= ?
+                ORDER BY observed_at
+                """,
+                chunk_params,
+            ).fetchall()
+            for pr in price_rows:
+                k = (pr["set_code"], pr["collector_number"], pr["source"], pr["price_type"])
+                prices_by_key[k].append((pr["observed_at"], pr["price"]))
+        conn.close()
+
+        # Also include any pre-window prices so the first days forward-fill
+        # correctly. Fetch the latest price <= start per (set,cn,source,type).
+        # (Skipped: prices before start are rare in practice; if a card has no
+        # price >= start, the chart shows 0 for it until a price appears, which
+        # is acceptable for a "growth" view.)
+
+        def _forward_fill(points: list[tuple[str, float]]) -> list[float]:
+            out = [0.0] * num_days
+            j = 0
+            current = 0.0
+            for i, d in enumerate(date_list):
+                while j < len(points) and points[j][0] <= d:
+                    current = points[j][1]
+                    j += 1
+                out[i] = current
+            return out
+
+        # Cumulative count series.
+        count_series = [0] * num_days
+        for indices in groups.values():
+            for ai in indices:
+                count_series[ai] += 1
+        count_series = list(_it.accumulate(count_series))
+
+        # Value series — per group, forward-fill prices and multiply by
+        # cumulative count within the group.
+        tcg_values = [0.0] * num_days
+        ck_values = [0.0] * num_days
+        for (set_code, cn, finish), indices in groups.items():
+            price_type = "foil" if finish in ("foil", "etched") else "normal"
+            tcg_prices = _forward_fill(prices_by_key.get((set_code, cn, "tcgplayer", price_type), []))
+            ck_prices = _forward_fill(prices_by_key.get((set_code, cn, "cardkingdom", price_type), []))
+            grp_cum = [0] * num_days
+            for ai in indices:
+                grp_cum[ai] += 1
+            grp_cum = list(_it.accumulate(grp_cum))
+            for i in range(num_days):
+                if grp_cum[i]:
+                    tcg_values[i] += grp_cum[i] * tcg_prices[i]
+                    ck_values[i] += grp_cum[i] * ck_prices[i]
+
+        # Round value series to cents to keep payload small.
+        tcg_values = [round(v, 2) for v in tcg_values]
+        ck_values = [round(v, 2) for v in ck_values]
+
+        self._send_json({
+            "dates": date_list,
+            "counts": count_series,
+            "tcg_values": tcg_values,
+            "ck_values": ck_values,
+        })
 
     def _api_price_history(self, set_code: str, collector_number: str):
         """Return full price time series for a card."""

--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -315,6 +315,11 @@ button.secondary.active { background: #0f3460; border-color: #e94560; }
   width: 100%;
   border-collapse: collapse;
   font-size: 0.85rem;
+  /* Fixed layout: column widths come from the first row's explicit widths
+     (set per-column via [data-col="X"] selectors below). Stops the Card
+     column from resizing as the virtual scroller swaps row ranges in/out,
+     and lets the skeleton match the eventual real-row layout. */
+  table-layout: fixed;
 }
 
 .collection-table th {
@@ -335,6 +340,8 @@ button.secondary.active { background: #0f3460; border-color: #e94560; }
   padding: 2px 12px;
   border-bottom: 1px solid #0f346033;
   vertical-align: middle;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .collection-table tr:hover { background: rgba(15, 52, 96, 0.2); }
@@ -351,8 +358,8 @@ button.secondary.active { background: #0f3460; border-color: #e94560; }
   animation: shimmer 1.5s infinite;
 }
 .skeleton-cell.thumb { width: 146px; height: 44px; display: inline-block; vertical-align: middle; margin-right: 10px; }
-.skeleton-cell.wide { width: 40%; display: inline-block; vertical-align: middle; }
-.skeleton-cell.narrow { width: 30%; }
+.skeleton-cell.wide { width: calc(100% - 156px); display: inline-block; vertical-align: middle; }
+.skeleton-cell.narrow { width: 100%; }
 @keyframes shimmer {
   0% { background-position: 200% 0; }
   100% { background-position: -200% 0; }
@@ -698,10 +705,14 @@ a.lineage-link {
   border-radius: 16px;
   box-shadow: 0 12px 40px rgba(0,0,0,0.8);
   padding: 24px;
-  width: 420px;
+  width: 500px;
   max-width: 92vw;
   max-height: 90vh;
   overflow-y: auto;
+}
+.growth-chart-wrap { height: 200px; position: relative; }
+.growth-empty {
+  color: #888; font-size: 0.8rem; padding: 24px 0; text-align: center;
 }
 .stats-modal h2 {
   font-size: 1.1rem;
@@ -769,7 +780,9 @@ a.lineage-link {
 }
 .col-config-dropdown.open { display: block; }
 
-/* Narrow Qty column: card quantities are almost always single digits */
+/* Per-column widths. Under table-layout:fixed the unsized column ("name")
+   absorbs the remaining viewport width, so these only need to match the
+   typical maximum content size — not the worst-case. */
 .collection-table th[data-col="qty"],
 .collection-table td[data-col="qty"] {
   width: 40px;
@@ -777,6 +790,29 @@ a.lineage-link {
   padding-left: 4px;
   padding-right: 4px;
 }
+.collection-table th[data-col="mana"],
+.collection-table td[data-col="mana"] { width: 90px; }
+.collection-table th[data-col="type"],
+.collection-table td[data-col="type"] { width: 170px; }
+.collection-table th[data-col="set"],
+.collection-table td[data-col="set"] { width: 90px; }
+.collection-table th[data-col="collector_number"],
+.collection-table td[data-col="collector_number"] { width: 55px; }
+.collection-table th[data-col="price"],
+.collection-table td[data-col="price"] { width: 160px; }
+.collection-table th[data-col="condition"],
+.collection-table td[data-col="condition"] { width: 50px; text-align: center; }
+.collection-table th[data-col="date_added"],
+.collection-table td[data-col="date_added"] { width: 100px; }
+.collection-table th[data-col="ck_price"],
+.collection-table td[data-col="ck_price"] { width: 90px; }
+.collection-table th[data-col="tcg_price"],
+.collection-table td[data-col="tcg_price"] { width: 90px; }
+/* Name column is intentionally unsized — table-layout:fixed gives it the
+   remaining width. Keep a sensible floor so the thumb doesn't overflow on
+   narrow viewports. */
+.collection-table th[data-col="name"],
+.collection-table td[data-col="name"] { min-width: 220px; }
 
 /* Sort arrow */
 .sort-arrow { font-size: 0.7rem; margin-left: 2px; }
@@ -1890,14 +1926,167 @@ function _renderRarityBlock(counts) {
     </div>`;
 }
 
+let _growthChart = null;
+function _destroyGrowthChart() {
+  if (_growthChart) { _growthChart.destroy(); _growthChart = null; }
+}
+
+async function renderGrowthChart(primarySource) {
+  _destroyGrowthChart();
+  const wrap = document.getElementById('growth-chart-wrap');
+  if (!wrap) return;
+
+  // Reuse the existing /api/collection query string so the chart respects
+  // the user's current search filter.
+  let data;
+  try {
+    const res = await fetch(`/api/collection/growth?${getFetchParams()}`);
+    if (!res.ok) throw new Error('fetch failed');
+    data = await res.json();
+  } catch {
+    wrap.innerHTML = '<div class="growth-empty">Failed to load growth history</div>';
+    return;
+  }
+
+  if (!data.dates || !data.dates.length) {
+    wrap.innerHTML = '<div class="growth-empty">No acquisition history for the current filter</div>';
+    return;
+  }
+
+  const valSeries = primarySource === 'ck' ? data.ck_values : data.tcg_values;
+  const valLabel = primarySource === 'ck' ? 'Card Kingdom value' : 'TCGplayer value';
+
+  const earliest = new Date(data.dates[0]).getTime();
+  const spanDays = (Date.now() - earliest) / 86400000;
+  const pills = document.querySelectorAll('#growth-range-pills .price-range-pill');
+  const ranges = [30, 90, 180, 365, 0];
+  pills.forEach((pill, i) => {
+    pill.classList.toggle('disabled', ranges[i] > 0 && spanDays < ranges[i]);
+  });
+
+  function filterData(rangeDays) {
+    if (!rangeDays) return { dates: data.dates, counts: data.counts, values: valSeries };
+    const cutoffMs = Date.now() - rangeDays * 86400000;
+    let idx0 = data.dates.findIndex(d => new Date(d).getTime() >= cutoffMs);
+    if (idx0 === -1) idx0 = data.dates.length - 1;
+    return {
+      dates: data.dates.slice(idx0),
+      counts: data.counts.slice(idx0),
+      values: valSeries.slice(idx0),
+    };
+  }
+
+  function buildDatasets(f) {
+    return [
+      {
+        label: 'Cards',
+        data: f.dates.map((d, i) => ({ x: d, y: f.counts[i] })),
+        borderColor: '#7ec8e3',
+        backgroundColor: 'transparent',
+        borderWidth: 1.5,
+        pointRadius: 0,
+        pointHoverRadius: 4,
+        tension: 0.25,
+        yAxisID: 'y',
+      },
+      {
+        label: valLabel,
+        data: f.dates.map((d, i) => ({ x: d, y: f.values[i] })),
+        borderColor: '#e94560',
+        backgroundColor: 'transparent',
+        borderWidth: 1.5,
+        pointRadius: 0,
+        pointHoverRadius: 4,
+        tension: 0.25,
+        yAxisID: 'y1',
+      },
+    ];
+  }
+
+  // Default range: ALL.
+  let activeRange = 0;
+  pills.forEach(p => p.classList.toggle('active', parseInt(p.dataset.range) === activeRange));
+
+  const canvas = document.getElementById('growth-chart-canvas');
+  const f = filterData(activeRange);
+  _growthChart = new Chart(canvas, {
+    type: 'line',
+    data: { datasets: buildDatasets(f) },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { mode: 'index', intersect: false },
+      scales: {
+        x: {
+          type: 'time',
+          time: { tooltipFormat: 'MMM d, yyyy' },
+          ticks: { color: '#666', maxTicksLimit: 5, font: { size: 10 } },
+          grid: { color: 'rgba(255,255,255,0.06)' },
+        },
+        y: {
+          position: 'left',
+          ticks: { color: '#7ec8e3', font: { size: 10 }, callback: v => v.toLocaleString() },
+          grid: { color: 'rgba(255,255,255,0.06)' },
+          beginAtZero: true,
+        },
+        y1: {
+          position: 'right',
+          ticks: { color: '#e94560', font: { size: 10 }, callback: v => formatPrice(v) },
+          grid: { drawOnChartArea: false },
+          beginAtZero: true,
+        },
+      },
+      plugins: {
+        legend: { position: 'top', labels: { color: '#888', font: { size: 10 }, boxWidth: 12 } },
+        tooltip: {
+          callbacks: {
+            label: ctx => {
+              if (ctx.dataset.yAxisID === 'y1') {
+                return `${ctx.dataset.label}: ${formatPrice(ctx.parsed.y)}`;
+              }
+              return `${ctx.dataset.label}: ${ctx.parsed.y.toLocaleString()}`;
+            }
+          },
+        },
+      },
+    },
+  });
+
+  pills.forEach(pill => {
+    pill.addEventListener('click', () => {
+      if (pill.classList.contains('disabled')) return;
+      pills.forEach(p => p.classList.remove('active'));
+      pill.classList.add('active');
+      const range = parseInt(pill.dataset.range);
+      const f = filterData(range);
+      _growthChart.data.datasets = buildDatasets(f);
+      _growthChart.update();
+    });
+  });
+}
+
 function openStatsModal() {
   if (!allCards.length) return;
   const s = computeResultStats(allCards);
   const sources = (_settings.price_sources || 'tcg,ck').split(',');
-  const primary = sources[0] === 'ck' ? 'Card Kingdom' : 'TCGplayer';
+  const primarySource = sources[0] === 'ck' ? 'ck' : 'tcg';
+  const primary = primarySource === 'ck' ? 'Card Kingdom' : 'TCGplayer';
   statsModalContent.innerHTML = `
     <h2>Result statistics</h2>
     <div class="stats-subtitle">Default price source: ${primary}</div>
+    <div class="modal-section">
+      <div class="modal-section-title">Growth over time</div>
+      <div class="price-range-pills" id="growth-range-pills">
+        <button class="price-range-pill" data-range="30">1M</button>
+        <button class="price-range-pill" data-range="90">3M</button>
+        <button class="price-range-pill" data-range="180">6M</button>
+        <button class="price-range-pill" data-range="365">1Y</button>
+        <button class="price-range-pill active" data-range="0">ALL</button>
+      </div>
+      <div class="growth-chart-wrap" id="growth-chart-wrap">
+        <canvas id="growth-chart-canvas"></canvas>
+      </div>
+    </div>
     <div class="modal-section">
       <div class="modal-section-title">Counts</div>
       <div class="stats-grid">
@@ -1912,9 +2101,13 @@ function openStatsModal() {
     ${_renderRarityBlock(s.rarityCounts)}
   `;
   statsModalOverlay.classList.add('active');
+  renderGrowthChart(primarySource);
 }
 
-function closeStatsModal() { statsModalOverlay.classList.remove('active'); }
+function closeStatsModal() {
+  _destroyGrowthChart();
+  statsModalOverlay.classList.remove('active');
+}
 
 statusEl.addEventListener('click', openStatsModal);
 statusEl.addEventListener('keydown', (e) => {
@@ -2987,13 +3180,13 @@ function updateStatusText() {
 function renderSkeleton() {
   const visCols = getVisibleColumns();
   let html = '<table class="collection-table"><thead><tr>';
-  for (const col of visCols) html += `<th>${col.label}</th>`;
+  for (const col of visCols) html += `<th data-col="${col.key}">${col.label}</th>`;
   html += '</tr></thead><tbody>';
   for (let i = 0; i < 20; i++) {
     html += '<tr class="skeleton-row">';
     for (const col of visCols) {
-      if (col.key === 'name') html += '<td><div class="skeleton-cell thumb"></div><div class="skeleton-cell wide"></div></td>';
-      else html += '<td><div class="skeleton-cell narrow"></div></td>';
+      if (col.key === 'name') html += `<td data-col="${col.key}"><div class="skeleton-cell thumb"></div><div class="skeleton-cell wide"></div></td>`;
+      else html += `<td data-col="${col.key}"><div class="skeleton-cell narrow"></div></td>`;
     }
     html += '</tr>';
   }


### PR DESCRIPTION
## Summary
- New **Growth-over-time** section at the top of the Result-statistics modal on `/collection`: dual-axis Chart.js line (cumulative cards on the left, value on the right in the user's primary price source) with 1M / 3M / 6M / 1Y / ALL range pills (ALL default; pills outside the data span auto-disable).
- New `GET /api/collection/growth?q=...&tz=...` endpoint. Reuses the search compiler so the chart respects the current filter, then walks day-by-day from the earliest acquisition through today. Value at time T uses forward-filled historical prices per `(set, cn, source, price_type)` — captures both acquisition growth **and** market drift.
- Collection table now uses `table-layout: fixed` with explicit widths per `[data-col="X"]`. Fixes two layout bugs: (1) the Card column no longer twitches as the virtual scroller swaps row ranges in/out, and (2) the loading skeleton no longer balloons the Qty column — the skeleton row was emitting bare `<th>`/`<td>` with no `data-col`, so the existing 40px qty rule never matched it.

## Test plan
- [x] `uv run ruff check mtg_collector/`
- [x] `uv run pytest tests/ --ignore=tests/ui --ignore=tests/integration` (full unit suite, exit 0)
- [x] `uv run pytest tests/test_search_compiler.py tests/test_search_corpus.py` (search compiler reuse)
- [x] Container validation: deployed to a test instance, seeded 540 days of synthetic acquisition + price history, verified:
  - [x] Unfiltered: 45 cards / $893 — both axes climb monotonically with realistic noise on the value series.
  - [x] Filtered `t:creature`: chart and surrounding stats both recompute to 27 cards / ~$600.
  - [x] Filtered `status:sold` (no rows): endpoint returns empty series; modal stays sane.
  - [x] Skeleton loading state: Qty column stays at 40px; Card column reserves its full width before data arrives.
  - [x] Virtual scroll: column widths stable as new row ranges page in/out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)