### PR TITLE
Allow editing a copy's finish from the card detail page and modal

### DIFF
--- a/mtg_collector/db/models.py
+++ b/mtg_collector/db/models.py
@@ -1004,7 +1004,8 @@ class CollectionRepository:
                 o.order_number, o.source AS order_source, o.seller_name,
                 o.order_date,
                 il.image_md5, il.image_path, il.card_index,
-                ii.id AS image_id
+                ii.id AS image_id,
+                p.finishes AS available_finishes
             FROM collection c
             LEFT JOIN orders o ON c.order_id = o.id
             LEFT JOIN deck_cards dc ON dc.collection_id = c.id
@@ -1012,6 +1013,7 @@ class CollectionRepository:
             LEFT JOIN binders b ON c.binder_id = b.id
             LEFT JOIN ingest_lineage il ON il.collection_id = c.id
             LEFT JOIN ingest_images ii ON il.image_md5 = ii.md5
+            LEFT JOIN printings p ON c.printing_id = p.printing_id
             WHERE c.printing_id = ?
         """
         params: List[Any] = [printing_id]

--- a/mtg_collector/static/card-detail.js
+++ b/mtg_collector/static/card-detail.js
@@ -322,6 +322,16 @@
         <div class="printing-picker" id="printing-picker-${copy.id}" style="display:none;"></div>`
       : '';
 
+    // Editable finish row — only when active and the printing supports >1 finish.
+    const availableFinishes = parseJsonField(card.finishes) || [];
+    const changeFinishHtml = isActive && availableFinishes.length > 1
+      ? `<div class="detail-row"><span class="label">Finish</span><span class="value">
+          <select class="change-finish-select" data-copy-id="${copy.id}" style="padding:2px 6px;font-size:0.8rem;background:#1a1a2e;color:#e0e0e0;border:1px solid #0f3460;border-radius:4px;">
+            ${availableFinishes.map(f => `<option value="${esc(f)}"${f === copy.finish ? ' selected' : ''}>${esc(f.charAt(0).toUpperCase() + f.slice(1))}</option>`).join('')}
+          </select>
+        </span></div>`
+      : '';
+
     // Deck/binder assignment row
     let assignHtml = '';
     if (isActive) {
@@ -390,7 +400,7 @@
         <span class="copy-id">#${copy.id}</span>
       </div>
       ${statusBadge ? `<div style="margin-bottom:6px;">${statusBadge}</div>` : ''}
-      ${orderHtml}${priceHtml}${lineageHtml}${changePrintingHtml}${assignHtml}
+      ${orderHtml}${priceHtml}${lineageHtml}${changePrintingHtml}${changeFinishHtml}${assignHtml}
       ${controlsHtml}
       <button class="history-toggle" data-copy-id="${copy.id}">History &#x25BE;</button>
       <div class="history-container" id="history-${copy.id}"></div>
@@ -665,6 +675,29 @@
         }
         btn.innerHTML = 'History &#x25B4;';
         loadHistory(copyId, histContainer);
+      });
+    });
+
+    // Change finish
+    container.querySelectorAll('.change-finish-select').forEach(sel => {
+      const original = sel.value;
+      sel.addEventListener('change', async () => {
+        const copyId = sel.dataset.copyId;
+        const newFinish = sel.value;
+        sel.disabled = true;
+        const r = await fetch(`/api/collection/${copyId}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ finish: newFinish }),
+        });
+        if (r.ok) {
+          window.location.reload();
+        } else {
+          const err = await r.json().catch(() => ({}));
+          alert(err.error || 'Change finish failed');
+          sel.value = original;
+          sel.disabled = false;
+        }
       });
     });
 

--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -2660,6 +2660,30 @@ async function loadModalCopies(card) {
       });
     });
 
+    // Change finish
+    container.querySelectorAll('.change-finish-select').forEach(sel => {
+      const original = sel.value;
+      sel.addEventListener('change', async () => {
+        const copyId = sel.dataset.copyId;
+        const newFinish = sel.value;
+        sel.disabled = true;
+        const r = await fetch(`/api/collection/${copyId}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ finish: newFinish }),
+        });
+        if (r.ok) {
+          await loadModalCopies(card);
+          fetchCollection();
+        } else {
+          const err = await r.json().catch(() => ({}));
+          alert(err.error || 'Change finish failed');
+          sel.value = original;
+          sel.disabled = false;
+        }
+      });
+    });
+
     // Change printing
     container.querySelectorAll('.change-printing-btn').forEach(btn => {
       btn.addEventListener('click', async () => {
@@ -2756,6 +2780,16 @@ function renderCopySection(copy) {
       <div class="printing-picker" id="printing-picker-${copy.id}" style="display:none;"></div>`
     : '';
 
+  // Editable finish row — only when active and the printing supports >1 finish.
+  const availableFinishes = parseJsonField(copy.available_finishes);
+  const changeFinishHtml = isActive && availableFinishes.length > 1
+    ? `<div class="modal-row"><span class="label">Finish</span><span class="value">
+        <select class="change-finish-select" data-copy-id="${copy.id}" style="padding:2px 6px;font-size:0.8rem;background:#1a1a2e;color:#e0e0e0;border:1px solid #0f3460;border-radius:4px;">
+          ${availableFinishes.map(f => `<option value="${f}"${f === copy.finish ? ' selected' : ''}>${f.charAt(0).toUpperCase() + f.slice(1)}</option>`).join('')}
+        </select>
+      </span></div>`
+    : '';
+
   // Deck/binder assignment row
   let assignHtml = '';
   if (isActive) {
@@ -2819,7 +2853,7 @@ function renderCopySection(copy) {
       <span class="copy-id">#${copy.id}</span>
     </div>
     ${statusBadge ? `<div style="margin-bottom:6px;">${statusBadge}</div>` : ''}
-    ${orderHtml}${priceHtml}${lineageHtml}${changePrintingHtml}${assignHtml}
+    ${orderHtml}${priceHtml}${lineageHtml}${changePrintingHtml}${changeFinishHtml}${assignHtml}
     ${controlsHtml}
   </div>`;
 }

--- a/tests/ui/hints/card_detail_change_finish.yaml
+++ b/tests/ui/hints/card_detail_change_finish.yaml
@@ -1,0 +1,23 @@
+start_page: /card/fdn/100
+involves:
+  - 'copy section (class .copy-section) inside the card detail page'
+  - 'copy header text starting "Nonfoil Near Mint —" before the change'
+  - 'inline finish select (class .change-finish-select)'
+  - 'after change the page reloads and the copy header text starts "Foil Near Mint —"'
+fixture_data:
+  card_name: "Beast-Kin Ranger"
+  set_code: "fdn"
+  collector_number: "100"
+  initial_finish: "nonfoil"
+  target_finish: "foil"
+  printing_finishes: ["nonfoil", "foil"]
+notes: >
+  1. Navigate to /card/fdn/100 (Beast-Kin Ranger, 1 owned copy id=3,
+     currently nonfoil; printing supports nonfoil + foil so the select
+     renders).
+  2. Wait for the copy section and assert the header shows
+     "Nonfoil Near Mint".
+  3. Change the .change-finish-select value to "foil" — this PUTs
+     /api/collection/3 and calls window.location.reload().
+  4. Wait for the page to render the new header "Foil Near Mint" and
+     verify the copy section is still present afterwards.

--- a/tests/ui/hints/collection_modal_change_finish.yaml
+++ b/tests/ui/hints/collection_modal_change_finish.yaml
@@ -1,0 +1,25 @@
+start_page: /collection
+involves:
+  - 'collection search input (placeholder "Search (e.g. t:creature c:r mv>=3)")'
+  - 'card modal overlay (id #card-modal-overlay) opened by clicking the card'
+  - 'copies container in modal (id #copies-container)'
+  - 'copy section (class .copy-section) inside the modal'
+  - 'inline finish select (class .change-finish-select) in the copy section'
+  - 'copy header text "Nonfoil Near Mint —" before the change, "Foil Near Mint —" after'
+fixture_data:
+  card_name: "Beast-Kin Ranger"
+  search_term: "Beast-Kin"
+  initial_finish: "nonfoil"
+  target_finish: "foil"
+notes: >
+  1. Navigate to /collection.
+  2. Search for "Beast-Kin" to filter down to a single card.
+  3. Click the card to open the modal. Wait for #card-modal-overlay
+     and the copies in #copies-container to render.
+  4. Assert the copy header shows "Nonfoil Near Mint".
+  5. Change .change-finish-select to "foil" — this PUTs
+     /api/collection/3, then re-runs loadModalCopies(card) AND
+     fetchCollection() to refresh both the modal and the grid behind.
+  6. Wait for the new "Foil Near Mint" header to appear inside the
+     still-open modal; assert the modal overlay is still visible
+     (no navigation happened).

--- a/tests/ui/implementations/card_detail_change_finish.py
+++ b/tests/ui/implementations/card_detail_change_finish.py
@@ -1,0 +1,26 @@
+"""
+Hand-written implementation for card_detail_change_finish.
+
+Switches a copy's recorded finish from nonfoil to foil via the inline
+select on the card detail page and verifies the page reload picks up
+the new finish in the copy header label.
+"""
+
+
+def steps(harness):
+    # start_page: /card/fdn/100 — Beast-Kin Ranger, one owned copy id=3,
+    # currently nonfoil. Printing supports ["nonfoil", "foil"] so the
+    # finish select is rendered.
+    harness.wait_for_text("Beast-Kin Ranger")
+    harness.wait_for_visible(".copy-section")
+    # The copy starts as nonfoil — verified via the header text.
+    harness.assert_text_present("Nonfoil Near Mint")
+    harness.screenshot("before_change")
+    # Flip finish to foil via the inline select. The handler PUTs
+    # /api/collection/3 with {finish: "foil"} and reloads the page.
+    harness.select_by_label(".change-finish-select", "Foil")
+    # After reload the copy header should now read "Foil Near Mint".
+    harness.wait_for_text("Foil Near Mint", timeout=5_000)
+    harness.assert_visible(".copy-section")
+    harness.assert_text_absent("Nonfoil Near Mint")
+    harness.screenshot("final_state")

--- a/tests/ui/implementations/collection_modal_change_finish.py
+++ b/tests/ui/implementations/collection_modal_change_finish.py
@@ -1,0 +1,31 @@
+"""
+Hand-written implementation for collection_modal_change_finish.
+
+Opens a card modal from the collection page, switches the copy's
+finish from nonfoil to foil via the inline select, and verifies the
+modal refreshes in place — the new finish appears in the copy header
+without navigating away.
+"""
+
+
+def steps(harness):
+    # start_page: /collection
+    harness.wait_for_visible(".card-cell", timeout=5_000)
+    # Filter down to the target card so click_by_text is unambiguous.
+    harness.fill_by_placeholder("Search (e.g. t:creature c:r mv>=3)", "Beast-Kin")
+    harness.press_key("Enter")
+    harness.wait_for_text("Beast-Kin Ranger", timeout=5_000)
+    harness.click_by_text("Beast-Kin Ranger")
+    # Modal opens and loads copies asynchronously.
+    harness.wait_for_visible("#card-modal-overlay")
+    harness.wait_for_visible("#copies-container .copy-section", timeout=5_000)
+    harness.assert_text_present("Nonfoil Near Mint")
+    harness.screenshot("modal_open_nonfoil")
+    # Flip finish to foil — handler PUTs /api/collection/3, then
+    # loadModalCopies(card) + fetchCollection() refresh in place.
+    harness.select_by_label(".change-finish-select", "Foil")
+    # The same modal should now show the updated copy header.
+    harness.wait_for_text("Foil Near Mint", timeout=5_000)
+    harness.assert_visible("#card-modal-overlay")
+    harness.assert_text_absent("Nonfoil Near Mint")
+    harness.screenshot("final_state")

--- a/tests/ui/intents/card_detail_change_finish.yaml
+++ b/tests/ui/intents/card_detail_change_finish.yaml
@@ -1,0 +1,12 @@
+# Scenario: Change a copy's finish from the card detail page
+#
+# Related:
+#   issues: []
+#   pull_requests: [261]
+
+description: >
+  From the card detail page I can use the inline finish select in an
+  owned copy's section to switch the copy between the finishes its
+  printing supports. After I choose a different finish the page
+  reloads and the copy's header label updates to reflect the new
+  finish.

--- a/tests/ui/intents/collection_modal_change_finish.yaml
+++ b/tests/ui/intents/collection_modal_change_finish.yaml
@@ -1,0 +1,13 @@
+# Scenario: Change a copy's finish from the collection card modal
+#
+# Related:
+#   issues: []
+#   pull_requests: [261]
+
+description: >
+  When viewing a card in the collection modal I can use the inline
+  finish select inside the owned copy's section to switch finishes.
+  The modal refreshes the copies list in place (no navigation), the
+  copy's header label updates to reflect the new finish, and the
+  collection grid behind the modal re-fetches so the foil treatment
+  tag on the row matches.


### PR DESCRIPTION
## Summary
- Adds an inline finish `<select>` next to the existing **Printing / Change** row on both the card detail page (`/card/:set/:cn`) and the collection card modal, so users can flip a copy between `nonfoil` / `foil` / `etched` without having to delete and re-ingest.
- The select is restricted to the finishes the printing actually supports (`printings.finishes` JSON list) and is hidden entirely when only one finish is available — nonfoil-only prints stay uncluttered.
- On change, the card detail page reloads; the collection modal refreshes copies in place and re-fetches the collection list so the new finish, foil tag, and finish-aware price all update.

## Why
`PUT /api/collection/:id` has accepted `{finish: ...}` for a while, but no UI ever surfaced it. The only finish-adjacent button (**Refinish**) only appears on image-ingested copies and *deletes* the entry to re-run OCR — useful for OCR re-do, useless for "I mis-clicked the finish at ingest time."

## Implementation notes
- `get_copies` now LEFT JOINs `printings` and returns `available_finishes` per copy, so the modal can render the dropdown without a separate per-copy fetch.
- Card detail uses the printing's `finishes` from the existing `/api/card/by-set-cn` response — no new endpoint or query path needed.

## Test plan
- [x] `uv run ruff check mtg_collector/`
- [x] `uv run pytest tests/ --ignore=tests/ui --ignore=tests/integration` (full unit suite, exit 0)
- [x] Container validation in an isolated instance:
  - [x] `GET /api/collection/copies?printing_id=...` returns `available_finishes` per copy
  - [x] `PUT /api/collection/3 {"finish":"foil"}` flips the row; DB reflects the change
  - [x] Card detail page renders the new select with current finish pre-selected
  - [x] Collection modal renders the new select inside the per-copy section, alongside the existing Printing/Change row
  - [x] Select is omitted for printings with only one available finish

🤖 Generated with [Claude Code](https://claude.com/claude-code)