### PR TITLE
Stabilise UI replay harness: bump 500ms timeouts, tolerate navigation race

### DIFF
--- a/tests/ui/implementations/binders_manage_from_card_modal.py
+++ b/tests/ui/implementations/binders_manage_from_card_modal.py
@@ -17,9 +17,9 @@ def steps(harness):
     # Click the card in grid view.
     harness.click_by_selector(".sheet-card[data-idx]")
     # Wait for modal to appear.
-    harness.wait_for_visible("#card-modal-overlay.active", timeout=500)
+    harness.wait_for_visible("#card-modal-overlay.active")
     # Wait for the binder dropdown to appear (copies section loads async).
-    harness.wait_for_visible("select.copy-add-to-binder", timeout=500)
+    harness.wait_for_visible("select.copy-add-to-binder")
     # Assign to Trade Binder using the dropdown.
     harness.select_by_label("select.copy-add-to-binder", "Trade Binder")
     harness.screenshot("final_state")

--- a/tests/ui/implementations/card_detail_add_copy.py
+++ b/tests/ui/implementations/card_detail_add_copy.py
@@ -19,5 +19,5 @@ def steps(harness):
     harness.click_by_selector("#add-confirm-btn")
     # Form should disappear and a new copy should appear.
     harness.wait_for_hidden(".add-collection-form")
-    harness.wait_for_visible(".copy-section", timeout=500)
+    harness.wait_for_visible(".copy-section")
     harness.screenshot("final_state")

--- a/tests/ui/implementations/card_detail_add_form_toggle.py
+++ b/tests/ui/implementations/card_detail_add_form_toggle.py
@@ -9,11 +9,11 @@ with pre-filled date, then closes it by clicking Add again.
 def steps(harness):
     # start_page: /card/lci/68 — auto-navigated by test runner.
     harness.wait_for_text("Orazca Puzzle-Door")
-    harness.wait_for_visible("#add-btn", timeout=500)
+    harness.wait_for_visible("#add-btn")
     # Click "Add" to open the form.
     harness.click_by_selector("#add-btn")
     # Verify the add form appears.
-    harness.wait_for_visible(".add-collection-form", timeout=500)
+    harness.wait_for_visible(".add-collection-form")
     # Verify date field is present.
     harness.assert_visible("#add-date")
     # Verify price and source fields are present.
@@ -22,5 +22,5 @@ def steps(harness):
     # Click "Add" again to close the form.
     harness.click_by_selector("#add-btn")
     # Verify the form disappears.
-    harness.wait_for_hidden(".add-collection-form", timeout=500)
+    harness.wait_for_hidden(".add-collection-form")
     harness.screenshot("final_state")

--- a/tests/ui/implementations/card_detail_binder_assign.py
+++ b/tests/ui/implementations/card_detail_binder_assign.py
@@ -10,13 +10,13 @@ def steps(harness):
     # start_page: /card/mkm/210 — auto-navigated by test runner.
     harness.wait_for_text("Judith, Carnage Connoisseur")
     # Wait for copies to load.
-    harness.wait_for_visible(".copy-section", timeout=500)
+    harness.wait_for_visible(".copy-section")
     # Verify the copy is currently unassigned.
     harness.assert_text_present("Unassigned")
     # Select "Trade Binder" from the "Add to Binder" dropdown.
     harness.select_by_label(".copy-add-to-binder", "Trade Binder")
     # The copies section reloads showing the binder name.
-    harness.wait_for_text("Trade Binder", timeout=500)
+    harness.wait_for_text("Trade Binder")
     harness.assert_text_present("Trade Binder")
     # A "Remove" link should appear.
     harness.assert_visible(".copy-remove-binder")

--- a/tests/ui/implementations/card_detail_change_printing_execute.py
+++ b/tests/ui/implementations/card_detail_change_printing_execute.py
@@ -16,7 +16,7 @@ def steps(harness):
     # Click the first non-current printing option
     harness.click_by_selector(".printing-option:not(.current)")
     # Page should navigate to the new printing's detail page
-    harness.wait_for_text("Curator of Destinies", timeout=500)
+    harness.wait_for_text("Curator of Destinies")
     # Verify the copy now exists on this page
-    harness.wait_for_visible(".copy-section", timeout=500)
+    harness.wait_for_visible(".copy-section")
     harness.screenshot("final_state")

--- a/tests/ui/implementations/card_detail_copy_history.py
+++ b/tests/ui/implementations/card_detail_copy_history.py
@@ -11,11 +11,11 @@ def steps(harness):
     # start_page: /card/blb/124 — auto-navigated by test runner.
     harness.wait_for_text("Artist's Talent")
     # Wait for copies to load.
-    harness.wait_for_visible(".copy-section", timeout=500)
+    harness.wait_for_visible(".copy-section")
     # Click the "History" toggle button.
     harness.click_by_selector(".history-toggle")
     # Timeline should appear.
-    harness.wait_for_visible(".history-timeline", timeout=500)
+    harness.wait_for_visible(".history-timeline")
     harness.assert_visible(".history-event")
     harness.screenshot("history_expanded")
     # Click again to collapse.

--- a/tests/ui/implementations/card_detail_deck_assign.py
+++ b/tests/ui/implementations/card_detail_deck_assign.py
@@ -11,13 +11,13 @@ def steps(harness):
     # start_page: /card/fdn/139 — auto-navigated by test runner.
     harness.wait_for_text("Cathar Commando")
     # Wait for copies to load.
-    harness.wait_for_visible(".copy-section", timeout=500)
+    harness.wait_for_visible(".copy-section")
     # Verify the copy is currently unassigned.
     harness.assert_text_present("Unassigned")
     # Select "Bolt Tribal" from the "Add to Deck" dropdown.
     harness.select_by_label(".copy-add-to-deck", "Bolt Tribal")
     # The copy section reloads showing the deck name.
-    harness.wait_for_text("Bolt Tribal", timeout=500)
+    harness.wait_for_text("Bolt Tribal")
     harness.assert_text_present("Bolt Tribal")
     # A "Remove" link should appear.
     harness.assert_visible(".copy-remove-deck")

--- a/tests/ui/implementations/card_detail_delete_copy.py
+++ b/tests/ui/implementations/card_detail_delete_copy.py
@@ -9,11 +9,11 @@ def steps(harness):
     # start_page: /card/lci/113 — auto-navigated by test runner.
     harness.wait_for_text("Preacher of the Schism")
     # Wait for copies to load.
-    harness.wait_for_visible(".copy-section", timeout=500)
+    harness.wait_for_visible(".copy-section")
     harness.screenshot("before_delete")
     # Click the Delete button. The confirm() dialog is auto-accepted by
     # the test runner's dialog handler.
     harness.click_by_selector(".delete-copy-btn")
     # The copy section should disappear after deletion.
-    harness.wait_for_hidden(".copy-section", timeout=500)
+    harness.wait_for_hidden(".copy-section")
     harness.screenshot("final_state")

--- a/tests/ui/implementations/card_detail_dispose_copy.py
+++ b/tests/ui/implementations/card_detail_dispose_copy.py
@@ -9,7 +9,7 @@ def steps(harness):
     # start_page: /card/woe/171 — auto-navigated by test runner.
     harness.wait_for_text("Graceful Takedown")
     # Wait for copies to load.
-    harness.wait_for_visible(".copy-section", timeout=500)
+    harness.wait_for_visible(".copy-section")
     # Select "Sold" from the dispose dropdown.
     harness.select_by_label(".dispose-select", "Sold")
     # Fill in sale price and note.
@@ -18,5 +18,5 @@ def steps(harness):
     # Click the Dispose button.
     harness.click_by_selector(".dispose-btn")
     # After disposal, the copy should show a disposition badge.
-    harness.wait_for_visible(".disposition-badge", timeout=500)
+    harness.wait_for_visible(".disposition-badge")
     harness.screenshot("final_state")

--- a/tests/ui/implementations/card_detail_dispose_listed_unlist.py
+++ b/tests/ui/implementations/card_detail_dispose_listed_unlist.py
@@ -10,7 +10,7 @@ def steps(harness):
     # start_page: /card/lci/113 — auto-navigated by test runner.
     harness.wait_for_text("Preacher of the Schism")
     # Wait for copies to load.
-    harness.wait_for_visible(".copy-section", timeout=500)
+    harness.wait_for_visible(".copy-section")
     # Select "Listed" from the dispose dropdown.
     harness.select_by_label(".dispose-select", "Listed")
     # Click Dispose.
@@ -18,13 +18,13 @@ def steps(harness):
     # After dispose, the copy status becomes "listed" which is still active,
     # so no .disposition-badge appears. Instead, the dispose-select now
     # shows "Unlist" instead of "Listed". Wait for the page to re-render.
-    harness.wait_for_visible(".dispose-select", timeout=500)
+    harness.wait_for_visible(".dispose-select")
     # Verify "Unlist" is now an option (status is "listed").
     harness.select_by_label(".dispose-select", "Unlist")
     # Click Dispose again to unlist (sets status back to "owned").
     harness.click_by_selector(".dispose-btn")
     # After unlisting, the copy is "owned" again. The dispose-select should
     # now show "Listed" as an option again.
-    harness.wait_for_visible(".dispose-select", timeout=500)
+    harness.wait_for_visible(".dispose-select")
     harness.assert_visible(".dispose-select")
     harness.screenshot("final_state")

--- a/tests/ui/implementations/card_detail_flip_non_dfc.py
+++ b/tests/ui/implementations/card_detail_flip_non_dfc.py
@@ -9,16 +9,16 @@ panel is unchanged, then flips back to the front face.
 def steps(harness):
     # start_page: /card/fdn/191 — auto-navigated by test runner.
     harness.wait_for_text("Brazen Scourge")
-    harness.wait_for_visible("#flip-btn", timeout=500)
+    harness.wait_for_visible("#flip-btn")
     # Click the flip button.
     harness.click_by_selector("#flip-btn")
     # Verify the card is flipped.
-    harness.wait_for_visible("#card-flip.flipped", timeout=500)
+    harness.wait_for_visible("#card-flip.flipped")
     # Details panel should still show the same card name.
     harness.assert_text_present("Brazen Scourge")
     # Click flip again to return to front.
     harness.click_by_selector("#flip-btn")
     # Verify the card is no longer flipped.
-    harness.wait_for_hidden("#card-flip.flipped", timeout=500)
+    harness.wait_for_hidden("#card-flip.flipped")
     harness.assert_text_present("Brazen Scourge")
     harness.screenshot("final_state")

--- a/tests/ui/implementations/card_detail_from_collection_modal.py
+++ b/tests/ui/implementations/card_detail_from_collection_modal.py
@@ -9,17 +9,17 @@ and verifies the card detail page loads.
 def steps(harness):
     # start_page: /collection — auto-navigated by test runner.
     # Wait for collection table to load.
-    harness.wait_for_visible("tr[data-idx]", timeout=500)
+    harness.wait_for_visible("tr[data-idx]")
     # Switch to grid view for direct card click.
     harness.click_by_selector("#view-grid-btn")
     # Click the first card in grid view to open the modal.
     harness.click_by_selector(".sheet-card[data-idx]")
     # Wait for modal to appear.
-    harness.wait_for_visible("#card-modal-overlay.active", timeout=500)
+    harness.wait_for_visible("#card-modal-overlay.active")
     # Click the "Full page" badge link in the modal.
     harness.click_by_text("Full page")
     # Should navigate to /card/:set/:cn.
-    harness.wait_for_visible(".card-detail-layout", timeout=500)
+    harness.wait_for_visible(".card-detail-layout")
     # Verify a card name heading is present.
     harness.assert_visible("h2")
     harness.screenshot("final_state")

--- a/tests/ui/implementations/card_detail_move_deck_to_binder.py
+++ b/tests/ui/implementations/card_detail_move_deck_to_binder.py
@@ -9,14 +9,14 @@ def steps(harness):
     # start_page: /card/fdn/100 — auto-navigated by test runner.
     harness.wait_for_text("Beast-Kin Ranger")
     # Wait for copies to load.
-    harness.wait_for_visible(".copy-section", timeout=500)
+    harness.wait_for_visible(".copy-section")
     # Verify the copy is currently in deck "Bolt Tribal".
     harness.assert_text_present("Bolt Tribal")
     harness.assert_visible(".copy-remove-deck")
     # Select "Foil Collection" from the "Move to Binder" dropdown.
     harness.select_by_label(".copy-move-to-binder", "Foil Collection")
     # The copies section reloads showing the binder name.
-    harness.wait_for_text("Foil Collection", timeout=500)
+    harness.wait_for_text("Foil Collection")
     harness.assert_text_present("Foil Collection")
     # A "Remove" link for the binder should appear.
     harness.assert_visible(".copy-remove-binder")

--- a/tests/ui/implementations/card_detail_receive_copy.py
+++ b/tests/ui/implementations/card_detail_receive_copy.py
@@ -9,7 +9,7 @@ def steps(harness):
     # start_page: /card/blb/188 — auto-navigated by test runner.
     harness.wait_for_text("Peerless Recycling")
     # Wait for copies to load.
-    harness.wait_for_visible(".copy-section", timeout=500)
+    harness.wait_for_visible(".copy-section")
     # Verify "Receive" button is present (ordered status).
     harness.assert_visible(".receive-btn")
     harness.screenshot("before_receive")
@@ -17,6 +17,6 @@ def steps(harness):
     harness.click_by_selector(".receive-btn")
     # After receiving, the copy section reloads. The Receive button disappears
     # and owned-status controls (dispose dropdown, deck/binder selects) appear.
-    harness.wait_for_hidden(".receive-btn", timeout=500)
-    harness.wait_for_visible(".dispose-select", timeout=500)
+    harness.wait_for_hidden(".receive-btn")
+    harness.wait_for_visible(".dispose-select")
     harness.screenshot("final_state")

--- a/tests/ui/implementations/collection_add_from_modal.py
+++ b/tests/ui/implementations/collection_add_from_modal.py
@@ -13,7 +13,7 @@ def steps(harness):
     # Click the first card in grid view to open the modal.
     harness.click_by_selector(".sheet-card[data-idx]")
     # Wait for modal to appear.
-    harness.wait_for_visible("#card-modal-overlay.active", timeout=500)
+    harness.wait_for_visible("#card-modal-overlay.active")
     # Click the "Add" button to show the add form.
     harness.click_by_selector("#modal-add-btn")
     # Fill in purchase details.

--- a/tests/ui/implementations/collection_add_second_card_no_refresh.py
+++ b/tests/ui/implementations/collection_add_second_card_no_refresh.py
@@ -16,7 +16,7 @@ def steps(harness):
     # Click the first card in grid view to open the modal.
     harness.click_by_selector(".sheet-card[data-idx]")
     # Wait for modal to appear.
-    harness.wait_for_visible("#card-modal-overlay.active", timeout=500)
+    harness.wait_for_visible("#card-modal-overlay.active")
     # Click the "Add" button to show the add form.
     harness.click_by_selector("#modal-add-btn")
     # Fill in purchase details for the first card.
@@ -30,7 +30,7 @@ def steps(harness):
     # Click the second card in grid view.
     harness.click_by_selector(".sheet-card[data-idx]:nth-child(2)")
     # Wait for the modal to reappear.
-    harness.wait_for_visible("#card-modal-overlay.active", timeout=500)
+    harness.wait_for_visible("#card-modal-overlay.active")
     # Click "Add" again — this is the regression check.
     harness.click_by_selector("#modal-add-btn")
     # The form must appear. Fill in details for the second card.

--- a/tests/ui/implementations/collection_inline_deck_creation.py
+++ b/tests/ui/implementations/collection_inline_deck_creation.py
@@ -17,11 +17,11 @@ def steps(harness):
     # Click the card in grid view.
     harness.click_by_selector(".sheet-card[data-idx]")
     # Wait for modal and copies to load.
-    harness.wait_for_visible("#card-modal-overlay.active", timeout=500)
-    harness.wait_for_visible("select.copy-add-to-deck", timeout=500)
+    harness.wait_for_visible("#card-modal-overlay.active")
+    harness.wait_for_visible("select.copy-add-to-deck")
     # Select "New Deck..." — the prompt auto-accepts with "Test View".
     harness.select_by_label("select.copy-add-to-deck", "New Deck...")
     # Wait for the assignment to complete — the copy section re-renders
     # showing a "Remove" link instead of the "Add to Deck" dropdown.
-    harness.wait_for_visible(".copy-remove-deck", timeout=500)
+    harness.wait_for_visible(".copy-remove-deck")
     harness.screenshot("final_state")

--- a/tests/ui/implementations/collection_modal_change_printing.py
+++ b/tests/ui/implementations/collection_modal_change_printing.py
@@ -9,16 +9,16 @@ fewer copy.
 
 def steps(harness):
     # start_page: /collection
-    harness.wait_for_visible(".card-cell", timeout=500)
+    harness.wait_for_visible(".card-cell")
     # Search for Unstoppable Slasher
     harness.fill_by_placeholder("Search (e.g. t:creature c:r mv>=3)", "Unstoppable")
     harness.press_key("Enter")
     # Wait for search results and click the card
-    harness.wait_for_text("Unstoppable Slasher", timeout=500)
+    harness.wait_for_text("Unstoppable Slasher")
     harness.click_by_text("Unstoppable Slasher")
     # Wait for the card modal to open with copies loaded
     harness.wait_for_visible("#card-modal-overlay")
-    harness.wait_for_visible(".copy-section", timeout=500)
+    harness.wait_for_visible(".copy-section")
     # Verify 2 copies are shown initially
     harness.assert_element_count(".copy-section", 2)
     harness.screenshot("modal_with_two_copies")
@@ -31,6 +31,6 @@ def steps(harness):
     # Click a different printing
     harness.click_by_selector(".printing-option:not(.current)")
     # After changing, the modal refreshes — only 1 copy remains
-    harness.wait_for_text("Copies (1)", timeout=500)
+    harness.wait_for_text("Copies (1)")
     harness.assert_element_count(".copy-section", 1)
     harness.screenshot("final_state")

--- a/tests/ui/implementations/collection_multiselect_new_deck.py
+++ b/tests/ui/implementations/collection_multiselect_new_deck.py
@@ -19,11 +19,11 @@ def steps(harness):
     # Click "Add to Deck" in the selection bar.
     harness.click_by_selector("#sel-deck-btn")
     # Wait for the assign overlay to appear.
-    harness.wait_for_visible("#assign-deck-overlay", timeout=500)
+    harness.wait_for_visible("#assign-deck-overlay")
     # Select "New Deck..." — the prompt auto-accepts with "Test View".
     harness.select_by_label("#assign-deck-select", "New Deck...")
     # Click the Add button to confirm.
     harness.click_by_text("Add", exact=True)
     # Wait for the overlay to close.
-    harness.wait_for_hidden("#assign-deck-overlay", timeout=500)
+    harness.wait_for_hidden("#assign-deck-overlay")
     harness.screenshot("final_state")

--- a/tests/ui/implementations/collection_multiselect_toggle.py
+++ b/tests/ui/implementations/collection_multiselect_toggle.py
@@ -9,7 +9,7 @@ toggle off. Also verifies the selection bar count updates.
 def steps(harness):
     # Navigate to Collection page
     harness.navigate("/collection")
-    harness.wait_for_visible(".collection-table", timeout=500)
+    harness.wait_for_visible(".collection-table")
 
     # Open more menu and enable multi-select
     harness.click_by_selector("#more-menu-btn")

--- a/tests/ui/implementations/collection_search_clear_button_clears_input.py
+++ b/tests/ui/implementations/collection_search_clear_button_clears_input.py
@@ -9,7 +9,7 @@ the input empties, the button hides, and the full collection comes back.
 def steps(harness):
     # Navigate to Collection page and wait for the table to render.
     harness.navigate("/collection")
-    harness.wait_for_visible(".collection-table", timeout=500)
+    harness.wait_for_visible(".collection-table")
 
     # Clear button should be hidden when the input starts empty.
     harness.assert_hidden("#search-clear")

--- a/tests/ui/implementations/collection_search_clear_button_visibility_toggle.py
+++ b/tests/ui/implementations/collection_search_clear_button_visibility_toggle.py
@@ -9,7 +9,7 @@ types, and hides again once the input is empty.
 def steps(harness):
     # Navigate to Collection page and wait for the table to render.
     harness.navigate("/collection")
-    harness.wait_for_visible(".collection-table", timeout=500)
+    harness.wait_for_visible(".collection-table")
 
     # Empty input → clear button hidden.
     harness.assert_hidden("#search-clear")

--- a/tests/ui/implementations/collection_search_debounced.py
+++ b/tests/ui/implementations/collection_search_debounced.py
@@ -9,7 +9,7 @@ to show only matching cards, then clears the search to restore the full view.
 def steps(harness):
     # Navigate to Collection page and wait for table to load
     harness.navigate("/collection")
-    harness.wait_for_visible(".collection-table", timeout=500)
+    harness.wait_for_visible(".collection-table")
 
     # Type a search term using Scryfall syntax (debounced server fetch after 300ms)
     harness.fill_by_placeholder("Search (e.g. t:creature c:r mv>=3)", "Scrawling")

--- a/tests/ui/implementations/collection_view_toggle.py
+++ b/tests/ui/implementations/collection_view_toggle.py
@@ -8,7 +8,7 @@ Toggles between table view (default) and grid view on the Collection page.
 def steps(harness):
     # Navigate to Collection page (default is table view)
     harness.navigate("/collection")
-    harness.wait_for_visible(".collection-table", timeout=500)
+    harness.wait_for_visible(".collection-table")
 
     # Switch to grid view
     harness.click_by_selector("#view-grid-btn")

--- a/tests/ui/implementations/collection_wishlist_panel.py
+++ b/tests/ui/implementations/collection_wishlist_panel.py
@@ -9,7 +9,7 @@ removes one entry, and closes the panel via the backdrop.
 def steps(harness):
     # Navigate to Collection page
     harness.navigate("/collection")
-    harness.wait_for_visible(".collection-table", timeout=500)
+    harness.wait_for_visible(".collection-table")
 
     # Open the more menu and click Wishlist
     harness.click_by_selector("#more-menu-btn")

--- a/tests/ui/implementations/corners_batch_browse.py
+++ b/tests/ui/implementations/corners_batch_browse.py
@@ -9,16 +9,16 @@ one to see its cards in the detail view.
 def steps(harness):
     # start_page: /batches — auto-navigated by test runner.
     # Wait for the batch list to load.
-    harness.wait_for_visible(".batch-card", timeout=500)
+    harness.wait_for_visible(".batch-card")
     # Click the "Corner" filter pill to filter to corner batches.
     harness.click_by_text("Corner", exact=True)
     # Verify corner batches are still visible.
-    harness.wait_for_visible(".batch-card", timeout=500)
+    harness.wait_for_visible(".batch-card")
     # Click the "New cards from LGS" batch to open detail view.
     harness.click_by_text("New cards from LGS")
     # Wait for detail view to appear with cards.
-    harness.wait_for_visible("#detail-view", timeout=500)
-    harness.wait_for_visible(".card-item", timeout=500)
+    harness.wait_for_visible("#detail-view")
+    harness.wait_for_visible(".card-item")
     # Verify batch metadata is shown.
     harness.assert_text_present("New cards from LGS")
     harness.assert_text_present("Corner")

--- a/tests/ui/implementations/corners_batch_retroactive_deck_assign.py
+++ b/tests/ui/implementations/corners_batch_retroactive_deck_assign.py
@@ -8,12 +8,12 @@ Verifies the assignment succeeds.
 
 def steps(harness):
     # start_page: /batches — auto-navigated by test runner.
-    harness.wait_for_visible(".batch-card", timeout=500)
+    harness.wait_for_visible(".batch-card")
     # Click the unassigned "New cards from LGS" batch.
     harness.click_by_text("New cards from LGS")
     # Wait for detail view with the assign section.
-    harness.wait_for_visible("#detail-view", timeout=500)
-    harness.wait_for_visible("#assign-deck-select", timeout=500)
+    harness.wait_for_visible("#detail-view")
+    harness.wait_for_visible("#assign-deck-select")
     # Select "Bolt Tribal" from the deck dropdown.
     harness.select_by_label("#assign-deck-select", "Bolt Tribal (modern)")
     # Select zone.
@@ -22,5 +22,5 @@ def steps(harness):
     harness.click_by_text("Assign", exact=True)
     # After assignment, batch_detail.html re-renders in place and the
     # assign-status div replaces the form with "Assigned to: X (zone)".
-    harness.wait_for_text("Assigned to: Bolt Tribal", timeout=500)
+    harness.wait_for_text("Assigned to: Bolt Tribal")
     harness.screenshot("final_state")

--- a/tests/ui/implementations/corners_ingest_deck_selector.py
+++ b/tests/ui/implementations/corners_ingest_deck_selector.py
@@ -20,7 +20,7 @@ def steps(harness):
         document.getElementById('deck-selector').style.display = 'block';
     """)
     # Wait for the deck selector to be visible.
-    harness.wait_for_visible("#deck-select", timeout=500)
+    harness.wait_for_visible("#deck-select")
     # Verify the "Create new deck" option exists.
     harness.assert_text_present("Create new deck")
     # Verify zone selector has expected options.

--- a/tests/ui/implementations/csv_import_assign_to_deck.py
+++ b/tests/ui/implementations/csv_import_assign_to_deck.py
@@ -18,13 +18,13 @@ def steps(harness):
 
     # Parse & Resolve
     harness.click_by_selector("#parse-btn")
-    harness.wait_for_text("Resolved", timeout=500)
+    harness.wait_for_text("Resolved")
 
     # Select a deck (assign targets load automatically after resolve)
     harness.select_by_label("#assign-target", "Bolt Tribal")
 
     # Commit
     harness.click_by_selector("#commit-btn")
-    harness.wait_for_text("Successfully added", timeout=500)
+    harness.wait_for_text("Successfully added")
 
     harness.screenshot("final_state")

--- a/tests/ui/implementations/csv_import_batch_metadata_in_commit.py
+++ b/tests/ui/implementations/csv_import_batch_metadata_in_commit.py
@@ -23,10 +23,10 @@ def steps(harness):
 
     # Parse & Resolve
     harness.click_by_selector("#parse-btn")
-    harness.wait_for_text("Resolved", timeout=500)
+    harness.wait_for_text("Resolved")
 
     # Commit
     harness.click_by_selector("#commit-btn")
-    harness.wait_for_text("Successfully added", timeout=500)
+    harness.wait_for_text("Successfully added")
 
     harness.screenshot("final_state")

--- a/tests/ui/implementations/csv_import_cancel_after_resolve.py
+++ b/tests/ui/implementations/csv_import_cancel_after_resolve.py
@@ -18,7 +18,7 @@ def steps(harness):
 
     # Parse & Resolve
     harness.click_by_selector("#parse-btn")
-    harness.wait_for_text("Resolved", timeout=500)
+    harness.wait_for_text("Resolved")
 
     # Cancel
     harness.click_by_selector("#cancel-btn")

--- a/tests/ui/implementations/csv_import_commit_to_collection.py
+++ b/tests/ui/implementations/csv_import_commit_to_collection.py
@@ -18,10 +18,10 @@ def steps(harness):
 
     # Parse & Resolve
     harness.click_by_selector("#parse-btn")
-    harness.wait_for_text("Resolved", timeout=500)
+    harness.wait_for_text("Resolved")
 
     # Commit
     harness.click_by_selector("#commit-btn")
-    harness.wait_for_text("Successfully added", timeout=500)
+    harness.wait_for_text("Successfully added")
 
     harness.screenshot("final_state")

--- a/tests/ui/implementations/csv_import_failed_cards_display.py
+++ b/tests/ui/implementations/csv_import_failed_cards_display.py
@@ -18,7 +18,7 @@ def steps(harness):
 
     # Parse & Resolve
     harness.click_by_selector("#parse-btn")
-    harness.wait_for_text("Failed", timeout=500)
+    harness.wait_for_text("Failed")
 
     # Verify failed count in summary bar
     harness.assert_text_present("Failed")

--- a/tests/ui/implementations/csv_import_parse_and_resolve_decklist.py
+++ b/tests/ui/implementations/csv_import_parse_and_resolve_decklist.py
@@ -20,7 +20,7 @@ def steps(harness):
     harness.click_by_selector("#parse-btn")
 
     # Wait for resolved results
-    harness.wait_for_text("Resolved", timeout=500)
+    harness.wait_for_text("Resolved")
 
     # Verify summary bar
     harness.assert_visible(".summary-bar")

--- a/tests/ui/implementations/deck_builder_add_and_remove_cards.py
+++ b/tests/ui/implementations/deck_builder_add_and_remove_cards.py
@@ -14,11 +14,11 @@ def steps(harness):
     harness.select_by_label("#deck-state", "Constructed")
     # Search for Judith as commander
     harness.fill_by_placeholder("Search your collection...", "Judith")
-    harness.wait_for_text("Judith, Carnage Connoisseur", timeout=500)
+    harness.wait_for_text("Judith, Carnage Connoisseur")
     harness.click_by_text("Judith, Carnage Connoisseur")
     # Create the deck
     harness.click_by_text("Create Deck")
-    harness.wait_for_text("+ Add Card", timeout=500)
+    harness.wait_for_text("+ Add Card")
     # Verify initial count
     harness.assert_text_present("0/100")
     # Open the Add Cards modal via the button
@@ -26,12 +26,12 @@ def steps(harness):
     harness.wait_for_visible("#add-cards-modal.active")
     # Search for an unassigned owned card
     harness.fill_by_placeholder("Search by name...", "Infernal Vessel")
-    harness.wait_for_text("Infernal Vessel", timeout=500)
+    harness.wait_for_text("Infernal Vessel")
     # Select the card
     harness.click_by_text("Infernal Vessel")
     # Add the card
     harness.click_by_text("Add Selected")
-    harness.wait_for_hidden("#add-cards-modal.active", timeout=500)
+    harness.wait_for_hidden("#add-cards-modal.active")
     # Verify the card count updated
     harness.assert_text_present("1/100")
     # Verify the card is in the deck

--- a/tests/ui/implementations/deck_builder_commander_autocomplete.py
+++ b/tests/ui/implementations/deck_builder_commander_autocomplete.py
@@ -13,7 +13,7 @@ def steps(harness):
     # Type a legendary creature name into the search
     harness.fill_by_placeholder("Search your collection...", "Glarb")
     # Wait for autocomplete dropdown to show results
-    harness.wait_for_text("Glarb, Calamity's Augur", timeout=500)
+    harness.wait_for_text("Glarb, Calamity's Augur")
     # Click the autocomplete result
     harness.click_by_text("Glarb, Calamity's Augur")
     # Verify the Create Deck button is now enabled (text still present)

--- a/tests/ui/implementations/deck_builder_create_and_view.py
+++ b/tests/ui/implementations/deck_builder_create_and_view.py
@@ -11,13 +11,13 @@ def steps(harness):
     harness.wait_for_text("New Commander Deck")
     # Search for a commander
     harness.fill_by_placeholder("Search your collection...", "Bonny")
-    harness.wait_for_text("Bonny Pall, Clearcutter", timeout=500)
+    harness.wait_for_text("Bonny Pall, Clearcutter")
     # Select the commander
     harness.click_by_text("Bonny Pall, Clearcutter")
     # Click Create Deck
     harness.click_by_text("Create Deck")
     # Wait for builder mode to render with commander name as deck title
-    harness.wait_for_text("Bonny Pall, Clearcutter", timeout=500)
+    harness.wait_for_text("Bonny Pall, Clearcutter")
     # Verify the card count badge
     harness.assert_text_present("0/100")
     # Verify the Commander section exists

--- a/tests/ui/implementations/deck_create_redirects_to_detail.py
+++ b/tests/ui/implementations/deck_create_redirects_to_detail.py
@@ -29,7 +29,7 @@ def steps(harness):
     harness.click_by_text("Save")
 
     # Wait for redirect to the unified deck page (renders deck header h2)
-    harness.wait_for_text("Test Redirect Deck", timeout=500)
+    harness.wait_for_text("Test Redirect Deck")
 
     # Verify zone tabs are present (confirms standalone page, not list)
     harness.assert_text_present("Mainboard")

--- a/tests/ui/implementations/deck_share_button_copies_url.py
+++ b/tests/ui/implementations/deck_share_button_copies_url.py
@@ -18,7 +18,7 @@ def steps(harness):
     harness.click_by_selector("#btn-share-deck")
 
     # Verify button text changes to "Copied!"
-    harness.wait_for_text("Copied!", timeout=500)
+    harness.wait_for_text("Copied!")
     harness.assert_text_present("Copied!")
 
     harness.screenshot("final_state")

--- a/tests/ui/implementations/decks_exclusivity_enforcement.py
+++ b/tests/ui/implementations/decks_exclusivity_enforcement.py
@@ -15,7 +15,7 @@ def steps(harness):
     # Click the card in grid view.
     harness.click_by_selector(".sheet-card[data-idx]")
     # Wait for modal and copies to load.
-    harness.wait_for_visible("#card-modal-overlay.active", timeout=500)
+    harness.wait_for_visible("#card-modal-overlay.active")
     harness.wait_for_text("Copies")
     # Assign the unassigned copy to Trade Binder.
     harness.select_by_label("select.copy-add-to-binder", "Trade Binder")

--- a/tests/ui/implementations/decks_import_expected_and_completeness.py
+++ b/tests/ui/implementations/decks_import_expected_and_completeness.py
@@ -12,10 +12,10 @@ def steps(harness):
     # Click "Bolt Tribal" deck link — navigates to /decks/1 standalone page.
     harness.click_by_text("Bolt Tribal")
     # Wait for the standalone deck detail page to load.
-    harness.wait_for_visible("#btn-import-expected", timeout=500)
+    harness.wait_for_visible("#btn-import-expected")
     # Click "Import Expected" to open the modal.
     harness.click_by_selector("#btn-import-expected")
-    harness.wait_for_visible("#expected-modal.active", timeout=500)
+    harness.wait_for_visible("#expected-modal.active")
     # Paste a decklist: Beast-Kin Ranger is in the deck, Cathar Commando is not.
     harness.fill_by_selector(
         "#f-expected-list",
@@ -24,8 +24,8 @@ def steps(harness):
     # Click "Import".
     harness.click_by_selector("#expected-modal button")
     # Wait for modal to close and completeness to load.
-    harness.wait_for_hidden("#expected-modal.active", timeout=500)
-    harness.wait_for_visible("#completeness-section", timeout=500)
+    harness.wait_for_hidden("#expected-modal.active")
+    harness.wait_for_visible("#completeness-section")
     # Verify the completeness section shows present and missing cards.
     harness.assert_text_present("Present")
     harness.assert_text_present("Beast-Kin Ranger")

--- a/tests/ui/implementations/decks_manage_from_card_modal.py
+++ b/tests/ui/implementations/decks_manage_from_card_modal.py
@@ -15,8 +15,8 @@ def steps(harness):
     # Click the card in grid view.
     harness.click_by_selector(".sheet-card[data-idx]")
     # Wait for modal and copies to load.
-    harness.wait_for_visible("#card-modal-overlay.active", timeout=500)
-    harness.wait_for_visible("select.copy-add-to-deck", timeout=500)
+    harness.wait_for_visible("#card-modal-overlay.active")
+    harness.wait_for_visible("select.copy-add-to-deck")
     # Assign to Bolt Tribal deck using the dropdown.
     harness.select_by_label("select.copy-add-to-deck", "Bolt Tribal")
     harness.screenshot("final_state")

--- a/tests/ui/implementations/decks_precon_origin_metadata.py
+++ b/tests/ui/implementations/decks_precon_origin_metadata.py
@@ -10,7 +10,7 @@ deck detail page (navigated to automatically after save).
 def steps(harness):
     # Click "New Deck" to open the creation modal.
     harness.click_by_text("New Deck")
-    harness.wait_for_visible("#deck-modal.active", timeout=500)
+    harness.wait_for_visible("#deck-modal.active")
     # Fill in deck name.
     harness.fill_by_placeholder("My Commander Deck", "Goblins JMP")
     # Check the "Preconstructed deck" checkbox to reveal origin fields.
@@ -25,7 +25,7 @@ def steps(harness):
     # Save the deck — saveDeck() auto-navigates to /decks/:id standalone page.
     harness.click_by_text("Save")
     # Wait for the standalone deck detail page to load (deck name appears).
-    harness.wait_for_text("Goblins JMP", timeout=500)
+    harness.wait_for_text("Goblins JMP")
     harness.assert_text_present("Preconstructed")
     harness.assert_text_present("JMP")
     harness.assert_text_present("Goblins")

--- a/tests/ui/implementations/decks_reassemble_unassigned_cards.py
+++ b/tests/ui/implementations/decks_reassemble_unassigned_cards.py
@@ -12,14 +12,14 @@ def steps(harness):
     # Click "Bolt Tribal" deck link — navigates to /decks/1 standalone page.
     harness.click_by_text("Bolt Tribal")
     # Wait for the standalone deck detail page to load.
-    harness.wait_for_visible("#btn-import-expected", timeout=500)
+    harness.wait_for_visible("#btn-import-expected")
     # Import expected list with only Cathar Commando (unassigned in collection).
     harness.click_by_selector("#btn-import-expected")
-    harness.wait_for_visible("#expected-modal.active", timeout=500)
+    harness.wait_for_visible("#expected-modal.active")
     harness.fill_by_selector("#f-expected-list", "1 Cathar Commando (FDN) 139")
     harness.click_by_selector("#expected-modal button")
-    harness.wait_for_hidden("#expected-modal.active", timeout=500)
-    harness.wait_for_visible("#completeness-section", timeout=500)
+    harness.wait_for_hidden("#expected-modal.active")
+    harness.wait_for_visible("#completeness-section")
     # Verify Cathar Commando is missing with Unassigned tag.
     harness.assert_text_present("Missing")
     harness.assert_text_present("Cathar Commando")
@@ -27,7 +27,7 @@ def steps(harness):
     # Click the "Reassemble 1 Unassigned Card" button.
     harness.click_by_text("Reassemble 1 Unassigned Card")
     # Wait for completeness to refresh — Cathar Commando should now be Present.
-    harness.wait_for_text("Present", timeout=500)
+    harness.wait_for_text("Present")
     harness.assert_text_present("Cathar Commando")
     harness.assert_text_absent("Unassigned")
     harness.screenshot("final_state")

--- a/tests/ui/implementations/edit_order_inline_edit_card.py
+++ b/tests/ui/implementations/edit_order_inline_edit_card.py
@@ -8,7 +8,7 @@ the auto-save persisted both values.
 
 def steps(harness):
     # start_page: /orders/1 — auto-navigated by test runner.
-    harness.wait_for_visible(".card-row", timeout=500)
+    harness.wait_for_visible(".card-row")
     # Change condition on the first card to "Lightly Played".
     harness.select_by_label("select[data-field='condition']", "Lightly Played")
     # Change finish on the same card to "foil".
@@ -16,5 +16,5 @@ def steps(harness):
     # Wait for auto-save to complete.
     # Reload and verify persistence.
     harness.navigate("/orders/1")
-    harness.wait_for_visible(".card-row", timeout=500)
+    harness.wait_for_visible(".card-row")
     harness.screenshot("final_state")

--- a/tests/ui/implementations/edit_order_load_and_view.py
+++ b/tests/ui/implementations/edit_order_load_and_view.py
@@ -8,7 +8,7 @@ and card row elements are present.
 
 def steps(harness):
     # start_page: /orders/1 — auto-navigated by test runner.
-    harness.wait_for_visible("#save-meta-btn", timeout=500)
+    harness.wait_for_visible("#save-meta-btn")
     # Verify seller name is pre-filled.
     harness.assert_visible("#meta-seller")
     # Verify order number field.
@@ -25,7 +25,7 @@ def steps(harness):
     # Verify Save Order Details button.
     harness.assert_text_present("Save Order Details")
     # Verify summary bar with card count.
-    harness.wait_for_visible(".summary-bar", timeout=500)
+    harness.wait_for_visible(".summary-bar")
     harness.assert_text_present("5 cards")
     # Verify Add Card button.
     harness.assert_visible("#add-card-btn")

--- a/tests/ui/implementations/edit_order_remove_card.py
+++ b/tests/ui/implementations/edit_order_remove_card.py
@@ -8,13 +8,13 @@ Browser confirm() dialogs are auto-accepted.
 
 def steps(harness):
     # start_page: /orders/1 — auto-navigated by test runner.
-    harness.wait_for_visible(".summary-bar", timeout=500)
-    harness.wait_for_visible(".card-row", timeout=500)
+    harness.wait_for_visible(".summary-bar")
+    harness.wait_for_visible(".card-row")
     # Verify initial card count.
     harness.assert_text_present("5 cards")
     # Click the remove button on the first card row.
     harness.click_by_selector(".btn-icon.danger")
     # Confirm dialog is auto-accepted.
     # Wait for the card list to refresh.
-    harness.wait_for_text("4 cards", timeout=500)
+    harness.wait_for_text("4 cards")
     harness.screenshot("final_state")

--- a/tests/ui/implementations/edit_order_replace_card.py
+++ b/tests/ui/implementations/edit_order_replace_card.py
@@ -8,7 +8,7 @@ a result, and verifies the original card is replaced.
 
 def steps(harness):
     # start_page: /orders/1 — auto-navigated by test runner.
-    harness.wait_for_visible(".card-row", timeout=500)
+    harness.wait_for_visible(".card-row")
     # Note the original card name in the last row.
     harness.assert_text_present("Witness Protection")
     # Click the replace button on the last card row.
@@ -18,16 +18,16 @@ def steps(harness):
     replace_buttons = harness.page.locator(".btn-icon[title='Replace card']")
     replace_buttons.last.click()
     # Wait for the search overlay to open.
-    harness.wait_for_visible("#search-overlay.active", timeout=500)
+    harness.wait_for_visible("#search-overlay.active")
     # Type a search query (must be a card in the fixture DB) and wait for debounce + API
     harness.fill_by_selector("#search-input", "Beast-Kin Ranger")
     # Wait for search results.
-    harness.wait_for_visible(".search-candidate", timeout=500)
+    harness.wait_for_visible(".search-candidate")
     # Click the first search result.
     harness.click_by_selector(".search-candidate")
     # Overlay closes and card list refreshes.
-    harness.wait_for_hidden("#search-overlay.active", timeout=500)
-    harness.wait_for_visible(".card-row", timeout=500)
+    harness.wait_for_hidden("#search-overlay.active")
+    harness.wait_for_visible(".card-row")
     # Verify original card is gone.
     harness.assert_text_absent("Witness Protection")
     harness.screenshot("final_state")

--- a/tests/ui/implementations/edit_order_save_metadata.py
+++ b/tests/ui/implementations/edit_order_save_metadata.py
@@ -8,7 +8,7 @@ persistence.
 
 def steps(harness):
     # start_page: /orders/1 — auto-navigated by test runner.
-    harness.wait_for_visible("#save-meta-btn", timeout=500)
+    harness.wait_for_visible("#save-meta-btn")
     # Change seller name.
     harness.fill_by_selector("#meta-seller", "Test Seller")
     # Change source to Card Kingdom.
@@ -18,13 +18,13 @@ def steps(harness):
     # Click Save Order Details.
     harness.click_by_selector("#save-meta-btn")
     # Wait for green "Saved" confirmation.
-    harness.wait_for_visible(".status-msg.success", timeout=500)
+    harness.wait_for_visible(".status-msg.success")
     harness.assert_text_present("Saved")
     # Reload and verify persistence.
     harness.navigate("/orders/1")
-    harness.wait_for_visible("#save-meta-btn", timeout=500)
+    harness.wait_for_visible("#save-meta-btn")
     # Seller name is inside an <input> element, so we verify via input_value
     # rather than wait_for_text (which only finds visible text content).
-    value = harness.page.input_value("#meta-seller", timeout=500)
+    value = harness.page.input_value("#meta-seller")
     assert value == "Test Seller", f"Expected 'Test Seller', got '{value}'"
     harness.screenshot("final_state")

--- a/tests/ui/implementations/jumpstart_by_origin_api_existing_deck.py
+++ b/tests/ui/implementations/jumpstart_by_origin_api_existing_deck.py
@@ -9,11 +9,11 @@ to confirm the deck persists with correct metadata.
 
 def steps(harness):
     # start_page is /decks (auto-navigated by harness)
-    harness.wait_for_text("New Deck", timeout=500)
+    harness.wait_for_text("New Deck")
 
     # Open deck creation modal
     harness.click_by_text("New Deck")
-    harness.wait_for_visible("#deck-modal.active", timeout=500)
+    harness.wait_for_visible("#deck-modal.active")
 
     # Fill deck name
     harness.fill_by_placeholder("My Commander Deck", "Elves JMP")
@@ -28,7 +28,7 @@ def steps(harness):
 
     # Save — auto-navigates to deck detail page
     harness.click_by_text("Save")
-    harness.wait_for_text("Elves JMP", timeout=500)
+    harness.wait_for_text("Elves JMP")
 
     # Verify origin metadata on detail page
     harness.assert_text_present("Preconstructed")
@@ -37,7 +37,7 @@ def steps(harness):
 
     # Navigate back to deck list to confirm persistence
     harness.navigate("/decks")
-    harness.wait_for_text("Elves JMP", timeout=500)
+    harness.wait_for_text("Elves JMP")
     harness.assert_text_present("Elves JMP")
 
     harness.screenshot("final_state")

--- a/tests/ui/implementations/jumpstart_deck_auto_creation.py
+++ b/tests/ui/implementations/jumpstart_deck_auto_creation.py
@@ -9,11 +9,11 @@ deck list to confirm the deck persists.
 
 def steps(harness):
     # start_page is /decks (auto-navigated by harness)
-    harness.wait_for_text("New Deck", timeout=500)
+    harness.wait_for_text("New Deck")
 
     # Open deck creation modal
     harness.click_by_text("New Deck")
-    harness.wait_for_visible("#deck-modal.active", timeout=500)
+    harness.wait_for_visible("#deck-modal.active")
 
     # Fill deck name
     harness.fill_by_placeholder("My Commander Deck", "Goblins JMP Test")
@@ -28,7 +28,7 @@ def steps(harness):
 
     # Save — auto-navigates to deck detail page
     harness.click_by_text("Save")
-    harness.wait_for_text("Goblins JMP Test", timeout=500)
+    harness.wait_for_text("Goblins JMP Test")
 
     # Verify origin metadata on detail page
     harness.assert_text_present("Preconstructed")
@@ -37,7 +37,7 @@ def steps(harness):
 
     # Navigate back to deck list
     harness.navigate("/decks")
-    harness.wait_for_text("Goblins JMP Test", timeout=500)
+    harness.wait_for_text("Goblins JMP Test")
 
     # Verify the deck appears in the list
     harness.assert_text_present("Goblins JMP Test")

--- a/tests/ui/implementations/manual_id_add_and_resolve.py
+++ b/tests/ui/implementations/manual_id_add_and_resolve.py
@@ -30,6 +30,6 @@ def steps(harness):
     harness.click_by_selector("#resolve-btn")
 
     # Wait for resolved card to appear
-    harness.wait_for_text("Beast-Kin Ranger", timeout=500)
+    harness.wait_for_text("Beast-Kin Ranger")
 
     harness.screenshot("final_state")

--- a/tests/ui/implementations/manual_id_cancel_after_resolve.py
+++ b/tests/ui/implementations/manual_id_cancel_after_resolve.py
@@ -16,7 +16,7 @@ def steps(harness):
 
     # Resolve
     harness.click_by_selector("#resolve-btn")
-    harness.wait_for_text("Beast-Kin Ranger", timeout=500)
+    harness.wait_for_text("Beast-Kin Ranger")
 
     # Click Cancel
     harness.click_by_selector("#cancel-btn")

--- a/tests/ui/implementations/manual_id_failed_resolution.py
+++ b/tests/ui/implementations/manual_id_failed_resolution.py
@@ -19,7 +19,7 @@ def steps(harness):
     harness.click_by_selector("#resolve-btn")
 
     # Wait for failed results
-    harness.wait_for_text("Failed", timeout=500)
+    harness.wait_for_text("Failed")
 
     # Verify failed section appears
     harness.assert_visible(".failed-section")

--- a/tests/ui/implementations/manual_id_foil_toggle_in_results.py
+++ b/tests/ui/implementations/manual_id_foil_toggle_in_results.py
@@ -16,7 +16,7 @@ def steps(harness):
 
     # Resolve
     harness.click_by_selector("#resolve-btn")
-    harness.wait_for_text("Beast-Kin Ranger", timeout=500)
+    harness.wait_for_text("Beast-Kin Ranger")
 
     # Toggle foil on (click the inactive "--" toggle)
     harness.click_by_selector(".foil-toggle")

--- a/tests/ui/implementations/manual_id_rarity_mismatch.py
+++ b/tests/ui/implementations/manual_id_rarity_mismatch.py
@@ -27,7 +27,7 @@ def steps(harness):
     harness.click_by_selector("#resolve-btn")
 
     # Wait for resolved card
-    harness.wait_for_text("Beast-Kin Ranger", timeout=500)
+    harness.wait_for_text("Beast-Kin Ranger")
 
     # Verify rarity mismatch warning
     harness.assert_text_present("Expected")

--- a/tests/ui/implementations/manual_id_resolve_and_commit.py
+++ b/tests/ui/implementations/manual_id_resolve_and_commit.py
@@ -18,7 +18,7 @@ def steps(harness):
 
     # Click Resolve
     harness.click_by_selector("#resolve-btn")
-    harness.wait_for_text("Beast-Kin Ranger", timeout=500)
+    harness.wait_for_text("Beast-Kin Ranger")
 
     # Verify resolved table appears
     harness.assert_visible(".resolved-table")
@@ -28,6 +28,6 @@ def steps(harness):
 
     # Commit to collection
     harness.click_by_selector("#commit-btn")
-    harness.wait_for_text("Added", timeout=500)
+    harness.wait_for_text("Added")
 
     harness.screenshot("final_state")

--- a/tests/ui/implementations/order_assign_to_deck.py
+++ b/tests/ui/implementations/order_assign_to_deck.py
@@ -18,13 +18,13 @@ def steps(harness):
 
     # Parse (auto-resolves after parsing)
     harness.click_by_selector("#parse-btn")
-    harness.wait_for_text("Resolved", timeout=500)
+    harness.wait_for_text("Resolved")
 
     # Select a deck (assign targets load automatically after resolve)
     harness.select_by_label("#assign-target", "Bolt Tribal")
 
     # Commit
     harness.click_by_selector("#commit-btn")
-    harness.wait_for_text("Added", timeout=500)
+    harness.wait_for_text("Added")
 
     harness.screenshot("final_state")

--- a/tests/ui/implementations/order_cancel_after_resolve.py
+++ b/tests/ui/implementations/order_cancel_after_resolve.py
@@ -17,7 +17,7 @@ def steps(harness):
 
     # Parse
     harness.click_by_selector("#parse-btn")
-    harness.wait_for_text("Resolved", timeout=500)
+    harness.wait_for_text("Resolved")
 
     # Cancel
     harness.click_by_selector("#cancel-btn")

--- a/tests/ui/implementations/order_commit_ordered_guidance.py
+++ b/tests/ui/implementations/order_commit_ordered_guidance.py
@@ -21,11 +21,11 @@ def steps(harness):
 
     # Parse and wait for results
     harness.click_by_selector("#parse-btn")
-    harness.wait_for_text("Resolved", timeout=500)
+    harness.wait_for_text("Resolved")
 
     # Commit
     harness.click_by_selector("#commit-btn")
-    harness.wait_for_text("Added", timeout=500)
+    harness.wait_for_text("Added")
 
     # Verify guidance message about Ordered status
     harness.assert_text_present("Ordered")

--- a/tests/ui/implementations/order_import_parse_and_review.py
+++ b/tests/ui/implementations/order_import_parse_and_review.py
@@ -21,7 +21,7 @@ def steps(harness):
     harness.click_by_selector("#parse-btn")
 
     # Wait for resolved results to appear
-    harness.wait_for_text("Resolved", timeout=500)
+    harness.wait_for_text("Resolved")
 
     # Verify order group appears with card entries
     harness.assert_visible(".order-group")

--- a/tests/ui/implementations/order_import_unresolved_cards.py
+++ b/tests/ui/implementations/order_import_unresolved_cards.py
@@ -21,7 +21,7 @@ def steps(harness):
     harness.click_by_selector("#parse-btn")
 
     # Wait for results with failed resolution
-    harness.wait_for_text("Failed", timeout=500)
+    harness.wait_for_text("Failed")
 
     # Verify unresolved card styling appears
     harness.assert_visible(".unresolved")

--- a/tests/ui/implementations/order_no_orders_found.py
+++ b/tests/ui/implementations/order_no_orders_found.py
@@ -20,6 +20,6 @@ def steps(harness):
     harness.click_by_selector("#parse-btn")
 
     # Wait for error
-    harness.wait_for_text("No orders found in input.", timeout=500)
+    harness.wait_for_text("No orders found in input.")
 
     harness.screenshot("final_state")

--- a/tests/ui/implementations/order_parse_and_commit.py
+++ b/tests/ui/implementations/order_parse_and_commit.py
@@ -20,11 +20,11 @@ def steps(harness):
     harness.click_by_selector("#parse-btn")
 
     # Wait for resolved results
-    harness.wait_for_text("Resolved", timeout=500)
+    harness.wait_for_text("Resolved")
     harness.assert_visible(".order-group")
 
     # Commit to collection
     harness.click_by_selector("#commit-btn")
-    harness.wait_for_text("Added", timeout=500)
+    harness.wait_for_text("Added")
 
     harness.screenshot("final_state")

--- a/tests/ui/implementations/recents/brimstone_mage_ingest.py
+++ b/tests/ui/implementations/recents/brimstone_mage_ingest.py
@@ -16,7 +16,7 @@ def steps(harness):
     # Brimstone Mage was inserted as READY_FOR_OCR by --demo.
     # Server processes it on startup. Wait for cards to appear.
     harness.navigate("/recent")
-    harness.wait_for_visible(".img-card", timeout=500)
+    harness.wait_for_visible(".img-card")
 
     # After the unicode artist fix, _resolve_candidates finds the ROE
     # printing. With 1 candidate, auto-disambiguation selects it.

--- a/tests/ui/implementations/recents/single_card_ingest.py
+++ b/tests/ui/implementations/recents/single_card_ingest.py
@@ -11,14 +11,14 @@ Requires demo ingest images (4 images from --test fixture: 2 DONE, 2 ERROR).
 
 def steps(harness):
     # Wait for demo ingest cards to appear in the grid.
-    harness.wait_for_visible(".img-card", timeout=500)
+    harness.wait_for_visible(".img-card")
 
     # All 4 demo images should be present (2 DONE, 2 ERROR).
     harness.assert_element_count(".img-card", 4)
 
     # Click the first card to open the accordion sidebar.
     harness.click_by_selector(".img-card")
-    harness.wait_for_visible(".acc-sidebar", timeout=500)
+    harness.wait_for_visible(".acc-sidebar")
 
     # The "Add to Collection" button should be visible for a confirmed card.
     harness.assert_text_present("Add to Collection")
@@ -30,7 +30,7 @@ def steps(harness):
 
     # After ingest, the card should be removed from the grid.
     # Wait for grid to shrink to 3 cards.
-    harness.wait_for_hidden(".accordion-panel.open", timeout=500)
+    harness.wait_for_hidden(".accordion-panel.open")
     harness.assert_element_count(".img-card", 3)
 
     harness.screenshot("after_single_ingest")

--- a/tests/ui/implementations/sealed_add_and_table_view.py
+++ b/tests/ui/implementations/sealed_add_and_table_view.py
@@ -19,7 +19,7 @@ def steps(harness):
     # Confirm.
     harness.click_by_selector("#confirm-add-btn")
     # Close the modal overlay if still visible.
-    harness.wait_for_hidden("#add-modal-overlay.active", timeout=500)
+    harness.wait_for_hidden("#add-modal-overlay.active")
     # Switch to table view.
     harness.click_by_selector("#view-table-btn")
     # Verify the product appears in the table.

--- a/tests/ui/implementations/sealed_delete_entry.py
+++ b/tests/ui/implementations/sealed_delete_entry.py
@@ -23,7 +23,7 @@ def steps(harness):
     harness.click_by_selector(".entry-delete-btn")
 
     # Modal closes and collection re-fetches
-    harness.wait_for_hidden("#detail-modal-overlay.active", timeout=500)
+    harness.wait_for_hidden("#detail-modal-overlay.active")
 
     # Verify the product is gone (its UUID should no longer be in the DOM)
     harness.assert_hidden('[data-uuid="989edd8e-fba0-5102-9dad-178755d59c74"]')

--- a/tests/ui/implementations/sealed_multi_order_aggregation.py
+++ b/tests/ui/implementations/sealed_multi_order_aggregation.py
@@ -15,7 +15,7 @@ def steps(harness):
     harness.fill_by_selector("#add-qty", "2")
     harness.fill_by_selector("#add-price", "10.00")
     harness.click_by_selector("#confirm-add-btn")
-    harness.wait_for_hidden("#add-modal-overlay.active", timeout=500)
+    harness.wait_for_hidden("#add-modal-overlay.active")
 
     # Add the same product again (second time with different qty/price).
     harness.click_by_selector("#add-btn")
@@ -25,7 +25,7 @@ def steps(harness):
     harness.fill_by_selector("#add-qty", "3")
     harness.fill_by_selector("#add-price", "15.00")
     harness.click_by_selector("#confirm-add-btn")
-    harness.wait_for_hidden("#add-modal-overlay.active", timeout=500)
+    harness.wait_for_hidden("#add-modal-overlay.active")
 
     # Verify aggregated display shows the product.
     harness.wait_for_text("Lorwyn")

--- a/tests/ui/implementations/sealed_open_product.py
+++ b/tests/ui/implementations/sealed_open_product.py
@@ -37,7 +37,7 @@ def steps(harness):
     harness.click_by_selector("#open-confirm-btn")
 
     # Wait for modal to close and status to update
-    harness.wait_for_hidden("#open-modal-overlay.active", timeout=500)
+    harness.wait_for_hidden("#open-modal-overlay.active")
     harness.wait_for_text("Added")
 
     # Final state: sealed page with status showing added cards

--- a/tests/ui/implementations/sealed_open_second_product_no_refresh.py
+++ b/tests/ui/implementations/sealed_open_second_product_no_refresh.py
@@ -16,16 +16,16 @@ def steps(harness):
     harness.wait_for_visible("#open-modal-overlay.active")
     # Search for the first product.
     harness.fill_by_selector("#open-search-input", "Foundations Beginner")
-    harness.wait_for_visible("#open-product-results li", timeout=500)
+    harness.wait_for_visible("#open-product-results li")
     # Click the Beginner Box result.
     harness.click_by_text("Foundations Beginner Box")
     # Wait for the preview with confirm button.
-    harness.wait_for_visible("#open-confirm-btn", timeout=500)
+    harness.wait_for_visible("#open-confirm-btn")
     harness.screenshot("first_product_preview")
     # Open the product.
     harness.click_by_selector("#open-confirm-btn")
     # Wait for modal to close and success feedback.
-    harness.wait_for_hidden("#open-modal-overlay.active", timeout=500)
+    harness.wait_for_hidden("#open-modal-overlay.active")
     harness.wait_for_text("Added")
     harness.screenshot("first_product_opened")
     # Reopen the modal — this is the regression check.
@@ -35,8 +35,8 @@ def steps(harness):
     harness.assert_visible("#open-search-input")
     # Search for a second product to verify full functionality.
     harness.fill_by_selector("#open-search-input", "Foundations Starter")
-    harness.wait_for_visible("#open-product-results li", timeout=500)
+    harness.wait_for_visible("#open-product-results li")
     # Click the Starter Collection result.
     harness.click_by_text("Foundations Starter Collection")
-    harness.wait_for_visible("#open-confirm-btn", timeout=500)
+    harness.wait_for_visible("#open-confirm-btn")
     harness.screenshot("second_product_preview")

--- a/tests/ui/implementations/set_value_remove_set_pill.py
+++ b/tests/ui/implementations/set_value_remove_set_pill.py
@@ -12,13 +12,13 @@ def steps(harness):
 
     # Select first set: Bloomburrow
     harness.fill_by_selector("#set-search", "Bloom")
-    harness.wait_for_visible("#set-dropdown.open li", timeout=500)
+    harness.wait_for_visible("#set-dropdown.open li")
     harness.click_by_selector("#set-dropdown li")
     harness.wait_for_visible(".selected-pill")
 
     # Clear search and select second set: Foundations
     harness.fill_by_selector("#set-search", "Foundations")
-    harness.wait_for_visible("#set-dropdown.open li", timeout=500)
+    harness.wait_for_visible("#set-dropdown.open li")
     harness.click_by_selector("#set-dropdown li")
 
     # Verify two pills are present

--- a/tests/ui/implementations/sheets_card_zoom_overlay.py
+++ b/tests/ui/implementations/sheets_card_zoom_overlay.py
@@ -10,26 +10,26 @@ def steps(harness):
     # start_page: /sheets — auto-navigated by test runner.
 
     # Wait for the set input to be ready
-    harness.wait_for_visible("#set-input:not([disabled])", timeout=500)
+    harness.wait_for_visible("#set-input:not([disabled])")
 
     # Select BLB set
     harness.fill_by_selector("#set-input", "Bloom")
-    harness.wait_for_visible("#set-dropdown li", timeout=500)
+    harness.wait_for_visible("#set-dropdown li")
     harness.click_by_selector("#set-dropdown li")
 
     # Wait for products to load
-    harness.wait_for_visible("#product-radios label", timeout=500)
+    harness.wait_for_visible("#product-radios label")
 
     # Select play product
     harness.click_by_text("play", exact=True)
 
     # Wait for sheet sections to render
-    harness.wait_for_visible(".section-header", timeout=500)
+    harness.wait_for_visible(".section-header")
 
     # Expand the "Common" section to reveal cards (exact match)
     harness.click_by_text("Common", exact=True)
     # Use .section.open selector to target cards in expanded section only.
-    harness.wait_for_visible(".section.open .sheet-card", timeout=500)
+    harness.wait_for_visible(".section.open .sheet-card")
 
     # Click the first visible card to open zoom overlay
     harness.click_by_selector(".section.open .sheet-card")

--- a/tests/ui/implementations/sheets_deep_link_url_hash.py
+++ b/tests/ui/implementations/sheets_deep_link_url_hash.py
@@ -10,10 +10,13 @@ def steps(harness):
     # start_page: /sheets#set=blb&product=play — auto-navigated by test runner.
 
     # Wait for the status text to settle on the final sheet count.
-    # explore_sheets.html updates #status only after the section-render
-    # loop completes, so waiting on .section-header alone races the
-    # status update on slower runners.
-    harness.wait_for_text("8 sheets", timeout=5_000)
+    # explore_sheets.html updates #status only after the per-variant
+    # DOM render loop completes, which is genuinely slow on contended
+    # CI runners (fetches /api/sheets, then loops through every sheet
+    # and variant). The 5s default isn't always enough — give this
+    # specific assertion more headroom rather than bumping the global
+    # default for everyone.
+    harness.wait_for_text("8 sheets", timeout=10_000)
 
     # Verify the set input auto-filled with Bloomburrow (input value, not text)
     val = harness.page.input_value("#set-input")

--- a/tests/ui/implementations/sheets_foil_sheet_indicators.py
+++ b/tests/ui/implementations/sheets_foil_sheet_indicators.py
@@ -10,7 +10,7 @@ def steps(harness):
     # start_page: /sheets#set=blb&product=play — auto-navigated by test runner.
 
     # Wait for sections to render
-    harness.wait_for_visible(".section-header", timeout=500)
+    harness.wait_for_visible(".section-header")
 
     # Verify foil tags exist in section header meta (foil sheets)
     harness.assert_visible(".foil-tag")
@@ -22,7 +22,7 @@ def steps(harness):
     # Use Playwright locator for exact h2 text match (not "Foil Land")
     harness.page.locator(".section-header").filter(has_text="Foil").first.click()
     # Verify foil card wrappers are visible in the expanded section
-    harness.wait_for_visible(".section.open .sheet-card-img-wrap.foil", timeout=500)
+    harness.wait_for_visible(".section.open .sheet-card-img-wrap.foil")
 
     # Verify card wrappers have the foil class
     harness.assert_visible(".sheet-card-img-wrap.foil")

--- a/tests/ui/implementations/sheets_section_collapse_expand_with_cards.py
+++ b/tests/ui/implementations/sheets_section_collapse_expand_with_cards.py
@@ -10,21 +10,21 @@ def steps(harness):
     # start_page: /sheets — auto-navigated by test runner.
 
     # Wait for the set input to be ready
-    harness.wait_for_visible("#set-input:not([disabled])", timeout=500)
+    harness.wait_for_visible("#set-input:not([disabled])")
 
     # Select BLB set
     harness.fill_by_selector("#set-input", "Bloom")
-    harness.wait_for_visible("#set-dropdown li", timeout=500)
+    harness.wait_for_visible("#set-dropdown li")
     harness.click_by_selector("#set-dropdown li")
 
     # Wait for products to load
-    harness.wait_for_visible("#product-radios label", timeout=500)
+    harness.wait_for_visible("#product-radios label")
 
     # Select play product
     harness.click_by_text("play", exact=True)
 
     # Wait for sheet sections to render
-    harness.wait_for_visible(".section-header", timeout=500)
+    harness.wait_for_visible(".section-header")
 
     # Variants section should be expanded by default (first section)
     harness.assert_visible(".section.open")
@@ -34,7 +34,7 @@ def steps(harness):
 
     # Card images should now be visible inside the expanded Common section.
     # Use section-specific selector since collapsed sections also have .sheet-card elements.
-    harness.wait_for_visible(".section.open .section-body .sheet-card", timeout=500)
+    harness.wait_for_visible(".section.open .section-body .sheet-card")
 
     # Pull-rate badges should be visible below cards
     harness.assert_visible(".section.open .badge.pull-rate")

--- a/tests/ui/implementations/sheets_variants_table_content.py
+++ b/tests/ui/implementations/sheets_variants_table_content.py
@@ -22,7 +22,10 @@ def steps(harness):
     # Verify probability percentages are shown (table has % values)
     harness.assert_text_present("%")
 
-    # Verify status text shows sheet count
-    harness.assert_text_present("8 sheets")
+    # Verify status text shows sheet count. Use wait_for_text not
+    # assert_text_present — the "N sheets" status is set by JS only
+    # after the per-variant render loop finishes, which is slow on a
+    # contended CI runner.
+    harness.wait_for_text("8 sheets", timeout=10_000)
 
     harness.screenshot("final_state")

--- a/tests/ui/replay.py
+++ b/tests/ui/replay.py
@@ -15,6 +15,14 @@ from .harness import EXTRACT_ELEMENTS_JS
 
 log = logging.getLogger(__name__)
 
+# Per-action Playwright timeout. Generous enough to absorb the latency a
+# self-hosted CI runner sees when the full UI suite is hammering the test
+# container in parallel (the harness used to default to 500 ms, which was
+# fine on an idle dev box but flaked the deck/jumpstart/sheets tests under
+# load — the Playwright assertion returns as soon as the condition is met,
+# so raising the cap is free for passing tests).
+DEFAULT_TIMEOUT_MS = 5_000
+
 
 @dataclass
 class ReplayStep:
@@ -70,31 +78,31 @@ class ReplayHarness:
 
     def click_by_text(self, text: str, *, exact: bool = False):
         self._record("click_by_text", text)
-        self.page.get_by_text(text, exact=exact).first.click(timeout=500)
+        self.page.get_by_text(text, exact=exact).first.click(timeout=DEFAULT_TIMEOUT_MS)
         self._settle()
         self._snap()
 
     def click_by_selector(self, selector: str):
         self._record("click_by_selector", selector)
-        self.page.click(selector, timeout=500)
+        self.page.click(selector, timeout=DEFAULT_TIMEOUT_MS)
         self._settle()
         self._snap()
 
     def click_by_test_id(self, test_id: str):
         self._record("click_by_test_id", test_id)
-        self.page.get_by_test_id(test_id).click(timeout=500)
+        self.page.get_by_test_id(test_id).click(timeout=DEFAULT_TIMEOUT_MS)
         self._settle()
         self._snap()
 
     def fill_by_placeholder(self, placeholder: str, value: str):
         self._record("fill_by_placeholder", f"{placeholder}={value}")
-        self.page.get_by_placeholder(placeholder).fill(value, timeout=500)
+        self.page.get_by_placeholder(placeholder).fill(value, timeout=DEFAULT_TIMEOUT_MS)
         self._settle()
         self._snap()
 
     def fill_by_selector(self, selector: str, value: str):
         self._record("fill_by_selector", f"{selector}={value}")
-        self.page.fill(selector, value, timeout=500)
+        self.page.fill(selector, value, timeout=DEFAULT_TIMEOUT_MS)
         self._settle()
         self._snap()
 
@@ -103,7 +111,7 @@ class ReplayHarness:
         target = selector or "active element"
         self._record("press_key", f"{key} on {target}")
         if selector:
-            self.page.press(selector, key, timeout=500)
+            self.page.press(selector, key, timeout=DEFAULT_TIMEOUT_MS)
         else:
             self.page.keyboard.press(key)
         self._settle()
@@ -111,13 +119,13 @@ class ReplayHarness:
 
     def set_input_files(self, selector: str, file_path: str):
         self._record("set_input_files", f"{selector} <- {file_path}")
-        self.page.set_input_files(selector, file_path, timeout=500)
+        self.page.set_input_files(selector, file_path, timeout=DEFAULT_TIMEOUT_MS)
         self._settle()
         self._snap()
 
     def select_by_label(self, selector: str, label: str):
         self._record("select_by_label", f"{selector}={label}")
-        self.page.select_option(selector, label=label, timeout=500)
+        self.page.select_option(selector, label=label, timeout=DEFAULT_TIMEOUT_MS)
         self._settle()
         self._snap()
 
@@ -130,17 +138,17 @@ class ReplayHarness:
 
     # ── Waiting ────────────────────────────────────────────────────────
 
-    def wait_for_visible(self, selector: str, timeout: int = 500):
+    def wait_for_visible(self, selector: str, timeout: int = DEFAULT_TIMEOUT_MS):
         self._record("wait_for_visible", selector)
         self.page.wait_for_selector(selector, state="visible", timeout=timeout)
         self._snap()
 
-    def wait_for_hidden(self, selector: str, timeout: int = 500):
+    def wait_for_hidden(self, selector: str, timeout: int = DEFAULT_TIMEOUT_MS):
         self._record("wait_for_hidden", selector)
         self.page.wait_for_selector(selector, state="hidden", timeout=timeout)
         self._snap()
 
-    def wait_for_text(self, text: str, timeout: int = 500):
+    def wait_for_text(self, text: str, timeout: int = DEFAULT_TIMEOUT_MS):
         self._record("wait_for_text", text)
         self.page.get_by_text(text).first.wait_for(state="visible", timeout=timeout)
         self._snap()
@@ -149,14 +157,14 @@ class ReplayHarness:
 
     def assert_visible(self, selector: str):
         self._record("assert_visible", selector)
-        visible = self.page.is_visible(selector, timeout=500)
+        visible = self.page.is_visible(selector, timeout=DEFAULT_TIMEOUT_MS)
         if not visible:
             self._fail(f"Expected visible: {selector}")
         self._snap()
 
     def assert_hidden(self, selector: str):
         self._record("assert_hidden", selector)
-        hidden = self.page.is_hidden(selector, timeout=500)
+        hidden = self.page.is_hidden(selector, timeout=DEFAULT_TIMEOUT_MS)
         if not hidden:
             self._fail(f"Expected hidden: {selector}")
         self._snap()
@@ -225,18 +233,38 @@ class ReplayHarness:
         )
 
     def _snap(self):
-        """Auto-snapshot after every action."""
+        """Auto-snapshot after every action.
+
+        The DOM snapshot can hit "Execution context was destroyed" when the
+        preceding interaction triggered a navigation that is still in
+        flight. That's the classic Playwright race and it shouldn't fail
+        the test — the screenshot is the evidence that matters; the DOM
+        dump is best-effort. Swallow the error and leave dom_snapshot None
+        for that step.
+        """
         step = self._steps[-1]
         name = f"{self.scenario_name}_{self._step:02d}_{step.action}.png"
         path = self.screenshot_dir / name
         self.page.screenshot(path=str(path))
         step.screenshot = str(path)
 
-        elements = self.page.evaluate(EXTRACT_ELEMENTS_JS)
-        step.dom_snapshot = elements
+        try:
+            step.dom_snapshot = self.page.evaluate(EXTRACT_ELEMENTS_JS)
+        except Exception as e:
+            log.debug(
+                "[%s] DOM snapshot skipped after step %d (%s): %s",
+                self.scenario_name, self._step, step.action, e,
+            )
+            step.dom_snapshot = None
 
     def _settle(self):
-        """Wait for async page updates: one animation frame + networkidle."""
+        """Wait for async page updates: one animation frame + networkidle.
+
+        The networkidle wait is best-effort — some pages (SSE, long-poll)
+        never reach idle. Keep this short so we don't add seconds to every
+        interaction on those pages; the per-call timeouts on the next
+        action will still cover any genuine slow load.
+        """
         self.page.wait_for_timeout(50)
         try:
             self.page.wait_for_load_state("networkidle", timeout=500)


### PR DESCRIPTION
## Summary
Fixes two harness-level bugs that surface as flaky CI failures on PRs that didn't touch the affected code paths (currently blocking #259 and #260):

1. **Every per-action timeout was hardcoded to 500 ms.** All `wait_*`, `assert_*`, `click_*`, `fill_*`, `select_*`, `press_*` calls in `tests/ui/replay.py` defaulted to a 500 ms Playwright timeout. Under full-suite CI load the test container is contended enough that legitimate page renders miss that window. Routed through a single `DEFAULT_TIMEOUT_MS = 5_000`. Passing tests don't slow down — Playwright returns as soon as the condition is met; only genuinely-failing assertions take longer to fail.

2. **`_snap()` evaluated DOM JS after every interaction, including navigations.** When a click triggered navigation (e.g. `jumpstart_by_origin_api_existing_deck`'s `click_by_text("Save")` redirects to the new deck page), `page.evaluate(EXTRACT_ELEMENTS_JS)` raced with the context teardown and crashed with `Execution context was destroyed, most likely because of a navigation`. The DOM dump is best-effort evidence; wrapped in try/except so the screenshot still lands.

`_settle()`'s internal `networkidle` wait stays at 500 ms on purpose — it's already best-effort (already wrapped in try/except) and bumping it would add seconds to every interaction on SSE / long-poll pages that never hit networkidle.

## Why now
PR #260 (collection growth chart) and PR #259 (README sweep) both went red on CI with these failures — none in code those PRs modified:
- `deck_edit_nominate_commander` — modal-hide 500 ms miss
- `decks_create_and_add_cards` — `.deck-header h2` 500 ms miss
- `jumpstart_by_origin_api_existing_deck` — navigation race
- `sheets_variants_table_content` — `"8 sheets"` 500 ms miss

All four pass locally in ~19 s.

## Test plan
- [x] `uv run ruff check tests/ui/replay.py`
- [x] The four previously-failing tests pass: `uv run pytest tests/ui/ --instance flake-debug -k "deck_edit_nominate_commander or decks_create_and_add_cards or jumpstart_by_origin_api_existing_deck or sheets_variants_table_content"`
- [ ] Full UI suite (running in background) — expecting no regressions; the change is strictly more tolerant
- [ ] Rebase #259 and #260 once this lands; expect CI green

Closes efj-mtgc-ckq

🤖 Generated with [Claude Code](https://claude.com/claude-code)