### PR TITLE
Fix order import hijacking pre-existing owned cards

### DIFF
--- a/mtg_collector/cli/ingest_order.py
+++ b/mtg_collector/cli/ingest_order.py
@@ -162,6 +162,5 @@ def run(args):
     print("\nDone!")
     print(f"  Orders created: {summary['orders_created']}")
     print(f"  Cards added: {summary['cards_added']}")
-    print(f"  Cards linked to existing: {summary['cards_linked']}")
     if summary["errors"]:
         print(f"  Errors: {len(summary['errors'])}")

--- a/mtg_collector/services/order_resolver.py
+++ b/mtg_collector/services/order_resolver.py
@@ -230,7 +230,6 @@ def commit_orders(
         "orders_created": 0,
         "orders_skipped": 0,
         "cards_added": 0,
-        "cards_linked": 0,
         "cards_skipped": 0,
         "errors": [],
         "collection_ids": [],
@@ -289,39 +288,30 @@ def commit_orders(
                 continue
 
             for _ in range(item.parsed.quantity):
-                # Check for existing unlinked ordered card with same printing_id
-                existing = _find_existing_unlinked(
-                    conn, item.printing_id, status
+                # One physical card per ordered quantity → one new collection row.
+                # Never reuse a pre-existing entry: an order is a distinct
+                # acquisition, and copies you already own (from Moxfield import,
+                # corner ingest, other orders, …) are different physical cards.
+                # Order-level idempotency above already blocks re-importing the
+                # same order, so this never double-adds.
+                finish = normalize_finish("foil" if item.parsed.foil else "nonfoil")
+                condition = normalize_condition(item.parsed.condition)
+                entry = CollectionEntry(
+                    id=None,
+                    printing_id=item.printing_id,
+                    finish=finish,
+                    condition=condition,
+                    purchase_price=item.parsed.price,
+                    source=source,
+                    status=status,
+                    order_id=order_id,
+                    acquired_at=ts,
+                    batch_id=batch_id,
                 )
-
-                if existing:
-                    # Link existing entry to this order
-                    conn.execute(
-                        "UPDATE collection SET order_id = ?, batch_id = ? WHERE id = ?",
-                        (order_id, batch_id, existing),
-                    )
-                    summary["cards_linked"] += 1
-                    batch_card_count += 1
-                else:
-                    # Create new collection entry
-                    finish = normalize_finish("foil" if item.parsed.foil else "nonfoil")
-                    condition = normalize_condition(item.parsed.condition)
-                    entry = CollectionEntry(
-                        id=None,
-                        printing_id=item.printing_id,
-                        finish=finish,
-                        condition=condition,
-                        purchase_price=item.parsed.price,
-                        source=source,
-                        status=status,
-                        order_id=order_id,
-                        acquired_at=ts,
-                        batch_id=batch_id,
-                    )
-                    new_id = collection_repo.add(entry)
-                    summary["cards_added"] += 1
-                    summary["collection_ids"].append(new_id)
-                    batch_card_count += 1
+                new_id = collection_repo.add(entry)
+                summary["cards_added"] += 1
+                summary["collection_ids"].append(new_id)
+                batch_card_count += 1
 
         # Update batch card count
         if batch_repo and batch_id and batch_card_count:
@@ -329,15 +319,3 @@ def commit_orders(
 
     conn.commit()
     return summary
-
-
-def _find_existing_unlinked(
-    conn, printing_id: str, status: str
-) -> Optional[int]:
-    """Find an existing collection entry with matching printing_id, status, and no order_id."""
-    cursor = conn.execute(
-        "SELECT id FROM collection WHERE printing_id = ? AND status = ? AND order_id IS NULL LIMIT 1",
-        (printing_id, status),
-    )
-    row = cursor.fetchone()
-    return row["id"] if row else None

--- a/mtg_collector/static/ingest_order.html
+++ b/mtg_collector/static/ingest_order.html
@@ -526,7 +526,6 @@ async function commitOrders() {
     const summary = await res.json();
 
     let msg = `Added ${summary.cards_added} card(s)`;
-    if (summary.cards_linked > 0) msg += `, linked ${summary.cards_linked} existing`;
     msg += ` across ${summary.orders_created} order(s).`;
     if (summary.errors && summary.errors.length > 0) msg += ` ${summary.errors.length} error(s).`;
 

--- a/tests/test_order_resolver.py
+++ b/tests/test_order_resolver.py
@@ -211,35 +211,59 @@ class TestCommitOrders:
 
         assert summary["orders_created"] == 1
         assert summary["cards_added"] == 1
-        assert summary["cards_linked"] == 0
 
-    def test_commit_links_existing_unlinked(self, repos):
+    def test_commit_never_absorbs_existing_owned_copies(self, repos):
+        """Regression: importing an order must NOT reassign pre-existing copies.
+
+        A copy you already own (from Moxfield import, corner ingest, an earlier
+        order, …) is a different physical card from a copy in a new order.
+        Importing an order with the same printing must create new rows and leave
+        the existing copies' order_id untouched — not silently absorb them.
+        """
         order_repo = repos["order_repo"]
         collection_repo = repos["collection_repo"]
         conn = repos["conn"]
 
         sid = _TEST_PRINTING["printing_id"]
 
-        # Create an existing unlinked ordered card
-        collection_repo.add(CollectionEntry(
-            id=None, printing_id=sid, finish="nonfoil",
-            status="ordered", order_id=None,
-        ))
+        # Two copies already owned via unrelated channels, no order attached.
+        existing_ids = [
+            collection_repo.add(CollectionEntry(
+                id=None, printing_id=sid, finish="nonfoil",
+                status="owned", order_id=None, source="moxfield_import",
+            )),
+            collection_repo.add(CollectionEntry(
+                id=None, printing_id=sid, finish="nonfoil",
+                status="owned", order_id=None, source="corner_ingest",
+            )),
+        ]
         conn.commit()
 
-        # Now commit an order with the same card
-        parsed = ParsedOrder(order_number="LINK-1", source="tcgplayer", seller_name="Seller")
-        item = ParsedOrderItem(card_name="Card", condition="Near Mint", quantity=1)
+        # Import an order of 3 of the same printing, also as owned.
+        parsed = ParsedOrder(order_number="LINK-1", source="cardkingdom", seller_name="Card Kingdom")
+        item = ParsedOrderItem(card_name="Card", condition="Near Mint", quantity=3)
         resolved_item = ResolvedItem(parsed=item, printing_id=sid, card_name="Card")
         resolved_order = ResolvedOrder(parsed=parsed, items=[resolved_item])
 
         summary = commit_orders(
             [resolved_order], order_repo, collection_repo, conn,
-            status="ordered", source="order_import",
+            status="owned", source="order_import",
         )
 
-        assert summary["cards_linked"] == 1
-        assert summary["cards_added"] == 0
+        # All 3 ordered copies are brand-new rows.
+        assert summary["cards_added"] == 3
+        # The pre-existing owned copies are untouched — still no order attached.
+        for cid in existing_ids:
+            row = conn.execute(
+                "SELECT order_id, source FROM collection WHERE id = ?", (cid,)
+            ).fetchone()
+            assert row["order_id"] is None
+            assert row["source"] in ("moxfield_import", "corner_ingest")
+        # Net: 2 pre-existing + 3 ordered = 5 total copies of this printing.
+        total = conn.execute(
+            "SELECT COUNT(*) FROM collection WHERE printing_id = ?", (sid,)
+        ).fetchone()[0]
+        assert total == 5
 
     def test_commit_skips_unresolved(self, repos):
         order_repo = repos["order_repo"]


### PR DESCRIPTION
## Problem

`commit_orders()` in `order_resolver.py` ran `_find_existing_unlinked()` for every ordered card slot: it found any existing collection row with the same `printing_id` + `status` + `order_id IS NULL` and **reassigned that row to the new order** instead of creating a new copy.

When an order is imported as status **owned** (a vendor order that already arrived) and you already own matching copies, the import absorbs those copies — acquired through unrelated channels (Moxfield import, corner ingest, earlier orders) — into the new order. The collection **shrinks** instead of growing, violating the "one row per physical card" model.

### Real incident
CardKingdom order `163874028` on prod absorbed **10 pre-existing owned cards** (7 `moxfield_import` + 3 `corner_ingest`) across 5 printings (Dragoon's Lance FIN 17, Samurai's Katana FIN 154, White Mage's Staff FIN 42, Fate of the Sun-Cryst FIN 19, Machinist's Arsenal FIN 23). Ten copies the order actually contained were never created. (Prod data has been restored separately; this PR fixes the code so it can't recur.)

## Fix

Order import now **always creates new rows**. Order-level idempotency on `(order_number, seller_name)` already blocks re-importing the same order, so this never double-adds. Removed `_find_existing_unlinked()` and the `cards_linked` summary field; updated the CLI and `ingest_order.html` readouts.

## Test

Replaced `test_commit_links_existing_unlinked` (which encoded the buggy behavior as desired) with a regression test asserting that re-importing a printing never absorbs pre-existing owned copies — it fails on the old code and passes on the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)