### PR TITLE
Fix collection price showing non-foil price for foil copies

### DIFF
--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -2216,9 +2216,12 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                 if compiled and "b.name" in (compiled.where_sql or ""):
                     joins.append("LEFT JOIN binders b ON c.binder_id = b.id")
             if needs_price_join:
+                # price_type follows the copy's actual finish so foil copies sort
+                # by their foil price, not the nonfoil price. Etched uses foil.
                 joins.append(
                     "LEFT JOIN latest_prices _lp ON _lp.set_code = p.set_code"
-                    " AND _lp.collector_number = p.collector_number AND _lp.price_type = 'normal'"
+                    " AND _lp.collector_number = p.collector_number"
+                    " AND _lp.price_type = CASE WHEN c.finish IN ('foil', 'etched') THEN 'foil' ELSE 'normal' END"
                 )
             if needs_wishlist_join:
                 joins.append(
@@ -2405,8 +2408,11 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         if results:
             price_keys = []
             for card in results:
-                finishes = json.loads(card["finishes"]) if card["finishes"] else []
-                price_type = "normal" if "nonfoil" in finishes else "foil"
+                # Use the physical copy's actual finish (c.finish), not the
+                # printing's available finishes (p.finishes) — otherwise a foil
+                # copy of a printing that also exists in nonfoil shows the
+                # nonfoil price. Etched copies use foil pricing.
+                price_type = "foil" if card["finish"] in ("foil", "etched") else "normal"
                 sc = card["set_code"].lower()
                 cn = card["collector_number"]
                 price_keys.append((sc, cn, price_type))

--- a/tests/ui/hints/collection_foil_nonfoil_distinct_prices.yaml
+++ b/tests/ui/hints/collection_foil_nonfoil_distinct_prices.yaml
@@ -1,0 +1,33 @@
+start_page: /collection
+involves:
+  - 'search input (#search-input, placeholder "Search (e.g. t:creature c:r mv>=3)")'
+  - 'collection table rows (tr[data-idx]) in the default table view'
+  - 'Price column badges built by buildPriceBadges (SF <tcg> / CK <ck>)'
+  - 'foil row carries an "F" finish badge next to the card name'
+fixture_data:
+  card_name: "Scrawling Crawler"
+  set_code: "fdn"
+  collector_number: "132"
+  owned_finishes: ["nonfoil", "foil"]
+  nonfoil_tcg_price: "3.00"
+  foil_tcg_price: "99.00"
+  nonfoil_ck_price: "3.30"
+  foil_ck_price: "110.00"
+notes: >
+  The --test fixture owns fdn/132 (Scrawling Crawler) as two nonfoil
+  copies (ids 1, 34) plus one foil copy (id 2), but has no price rows.
+  latest_prices lives in the shared reference DB (/data/shared.sqlite),
+  not /data/collection.sqlite — the implementation must seed it there.
+
+  1. Seed /data/shared.sqlite latest_prices via podman exec: for fdn/132
+     insert tcgplayer normal=3.00 / foil=99.00 and cardkingdom
+     normal=3.30 / foil=110.00.
+  2. The runner auto-navigates to /collection. Type "Scrawling Crawler"
+     into #search-input; the page debounces and fetches /api/collection.
+  3. The default table view groups by finish, so two rows render: a
+     foil row (qty 1) and a nonfoil row (qty 2).
+  4. Assert "$99.00" is present (the foil price) — this is the
+     regression guard. Before the fix both rows showed the non-foil
+     "$3.00" and "$99.00" never appeared.
+  5. Assert "$3.00" is present (the non-foil price) and that exactly two
+     rows render.

--- a/tests/ui/implementations/collection_foil_nonfoil_distinct_prices.py
+++ b/tests/ui/implementations/collection_foil_nonfoil_distinct_prices.py
@@ -1,0 +1,76 @@
+"""
+Hand-written implementation for collection_foil_nonfoil_distinct_prices.
+
+Seeds distinct foil vs non-foil prices for fdn/132 (Scrawling Crawler, owned in
+both finishes) into the shared reference DB, searches for the card in the
+collection, and verifies the foil row shows the foil price while the non-foil
+row shows the non-foil price.
+
+Regression guard: before the fix, price_type was derived from the printing's
+available finishes (p.finishes) instead of the copy's actual finish (c.finish),
+so both rows showed the non-foil price and the foil "$99.00" never appeared.
+"""
+
+import subprocess
+
+
+def _find_container(base_url):
+    """Find the container serving the given base_url by matching its port."""
+    try:
+        port = base_url.rstrip("/").rsplit(":", 1)[-1]
+        result = subprocess.run(
+            ["podman", "ps", "--format", "{{.Names}}"],
+            capture_output=True, text=True,
+        )
+        for name in result.stdout.strip().split("\n"):
+            if not name:
+                continue
+            port_result = subprocess.run(
+                ["podman", "port", name, "8081/tcp"],
+                capture_output=True, text=True,
+            )
+            if port in port_result.stdout:
+                return name
+    except Exception:
+        pass
+    return None
+
+
+def steps(harness):
+    # Seed distinct foil/non-foil prices into the SHARED reference DB.
+    # latest_prices is a shared table (/data/shared.sqlite), not collection.sqlite.
+    container = _find_container(harness.base_url)
+    if container:
+        seed_script = (
+            "import sqlite3\n"
+            "s = sqlite3.connect('/data/shared.sqlite')\n"
+            "s.execute(\"DELETE FROM latest_prices WHERE set_code='fdn' AND collector_number='132'\")\n"
+            "for src, ptype, price in [\n"
+            "    ('tcgplayer','normal','3.00'), ('tcgplayer','foil','99.00'),\n"
+            "    ('cardkingdom','normal','3.30'), ('cardkingdom','foil','110.00')]:\n"
+            "    s.execute(\n"
+            "        'INSERT INTO latest_prices (set_code, collector_number, source, price_type, price, observed_at) '\n"
+            "        \"VALUES (?,?,?,?,?, '2026-06-01T00:00:00Z')\", ('fdn','132',src,ptype,price))\n"
+            "s.commit(); s.close()\n"
+        )
+        subprocess.run(
+            ["podman", "exec", container, "python3", "-c", seed_script],
+            capture_output=True, text=True,
+        )
+
+    # start_page: /collection — auto-navigated by the test runner.
+    # Search for the card owned in both finishes.
+    harness.fill_by_placeholder("Search (e.g. t:creature c:r mv>=3)", "Scrawling Crawler")
+    # Default table view groups by finish: a foil row and a non-foil row.
+    harness.wait_for_visible("tr[data-idx]", timeout=15_000)
+
+    # Regression guard: the foil price must appear. Before the fix both rows
+    # showed the non-foil price ($3.00) and $99.00 never rendered. Waiting on
+    # the foil price also gates on the debounced filtered result settling.
+    harness.wait_for_text("$99.00", timeout=10_000)
+    harness.assert_text_present("$99.00")
+    # The non-foil row still shows the non-foil price.
+    harness.assert_text_present("$3.00")
+    # Exactly two rows (foil + non-foil grouping).
+    harness.assert_element_count("tr[data-idx]", 2)
+    harness.screenshot("final_state")

--- a/tests/ui/intents/collection_foil_nonfoil_distinct_prices.yaml
+++ b/tests/ui/intents/collection_foil_nonfoil_distinct_prices.yaml
@@ -1,0 +1,21 @@
+# Scenario: Foil and non-foil copies show their own finish's price
+#
+# Related:
+#   issues: []
+#   pull_requests: []
+#
+# Prerequisites:
+#   The test instance must have a printing that is owned in BOTH a foil and a
+#   non-foil copy, and have distinct foil vs non-foil prices in the shared
+#   latest_prices table. The default --test fixture owns fdn/132 (Scrawling
+#   Crawler) in both finishes but has no price rows, so the implementation
+#   seeds latest_prices via podman exec before searching.
+
+description: >
+  When I own both a foil and a non-foil copy of the same printing, the
+  collection view shows each copy its own market price. The foil copy
+  displays the (higher) foil price and the non-foil copy displays the
+  (lower) non-foil price — they are NOT both shown at the non-foil
+  price. Searching for the card surfaces two rows, and the foil row's
+  Price column shows the foil number while the non-foil row shows the
+  non-foil number.


### PR DESCRIPTION
## Problem

When you own a foil and a non-foil copy of the same printing, the collection view showed **the same (non-foil) price for both**. Reported on a collection search like `/collection?q=akroma's+will&sort=price&sort_dir=desc`.

## Root cause

In `_api_collection` (`crack_pack_server.py`) the price-type was derived from the wrong field:

```python
finishes = json.loads(card["finishes"])      # p.finishes — what the printing is AVAILABLE in
price_type = "normal" if "nonfoil" in finishes else "foil"
```

`card["finishes"]` is `p.finishes` (the finishes a printing is *available* in, e.g. `["nonfoil","foil"]`), not the finish of the physical copy. Any printing available in both finishes always resolved to `price_type="normal"`, so foil copies displayed the non-foil price. The correct field, `card["finish"]` (`c.finish`), was already used a few lines below for `ck_url`.

The `sort=price` join had the same hardcoded `price_type = 'normal'`, so foils also sorted by their non-foil price.

## Fix

- Display: derive `price_type` from the copy's actual finish — `"foil" if card["finish"] in ("foil","etched") else "normal"`, matching the existing `ck_url` logic.
- Sort: make the `latest_prices` join finish-aware via a `CASE` expression.

## Verification

Reproduced and fixed end-to-end in an isolated container. With a printing owned in both finishes and distinct prices (normal `$3.00`, foil `$99.00`):

| | Old code | Fixed |
|---|---|---|
| non-foil row | $3.00 | $3.00 |
| foil row | **$3.00** ❌ | **$99.00** ✅ |

`sort=price desc` now correctly orders the foil above the non-foil.

## Tests

Adds a UI scenario regression test (`collection_foil_nonfoil_distinct_prices`) via `/qa-finish`: seeds distinct foil/non-foil prices for a dual-finish printing and asserts each copy shows its own price. Passes against the fix; times out against the bug (foil price never renders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)