### PR TITLE
Stream per-test progress for the UI suite in CI

### DIFF
--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -15,6 +15,8 @@ Or pass an existing instance via --instance:
 import logging
 import ssl
 import subprocess
+import sys
+import time
 import urllib.request
 from datetime import datetime
 from pathlib import Path
@@ -109,6 +111,51 @@ def pytest_addoption(parser):
             parser.addoption(*opt_args, **opt_kwargs)
         except ValueError:
             pass
+
+
+# ── Live progress for the long-running UI suite ──────────────────────────────
+# The UI suite runs for minutes with one parametrized item per intent. Under CI
+# stdout is a pipe (not a TTY), so pytest block-buffers its output and nothing
+# surfaces until the run ends — and a hung test is invisible. These hooks emit a
+# flushed line per test to the *original* stderr. sys.__stderr__ bypasses
+# pytest's per-test output capture, and flush=True defeats block buffering, so
+# progress streams to GitHub Actions in real time. Scoped to UI nodeids so a
+# combined `pytest tests/` run doesn't narrate the unit suite too.
+
+_progress = {"total": 0, "done": 0}
+
+
+def _is_ui(nodeid: str) -> bool:
+    return nodeid.startswith("tests/ui/") or "/ui/" in nodeid
+
+
+def _emit(msg: str) -> None:
+    print(msg, file=sys.__stderr__, flush=True)
+
+
+def pytest_collection_modifyitems(session, config, items):
+    _progress["total"] = sum(1 for it in items if _is_ui(it.nodeid))
+
+
+def pytest_runtest_logstart(nodeid, location):
+    if not _is_ui(nodeid):
+        return
+    _progress["done"] += 1
+    _emit(
+        f"▶ [{_progress['done']}/{_progress['total']}] "
+        f"{time.strftime('%H:%M:%S')} START {nodeid}"
+    )
+
+
+def pytest_runtest_logreport(report):
+    # Report on the call phase (pass/fail of the test body) plus setup
+    # skips/errors, which never reach the call phase.
+    if not _is_ui(report.nodeid):
+        return
+    if report.when != "call" and not (report.when == "setup" and report.outcome != "passed"):
+        return
+    icon = {"passed": "✓", "failed": "✗", "skipped": "○"}.get(report.outcome, "?")
+    _emit(f"  {icon} {report.outcome.upper()} {report.nodeid} ({report.duration:.1f}s)")
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Problem

The `Run UI scenario tests` CI step runs `pytest tests/ui/ -q` for ~15–20 min (one parametrized item per intent). Because CI stdout is a pipe (not a TTY), pytest **block-buffers** its output — so the step shows nothing for the entire run and only dumps results at the very end. If a test hangs, there's no way to see which one.

## Fix

Add `pytest_runtest_logstart` / `pytest_runtest_logreport` hooks in `tests/ui/conftest.py` that emit a flushed line per test to `sys.__stderr__`:

```
▶ [42/222] 17:46:57 START tests/ui/test_scenarios.py::test_scenario[collection_view_toggle]
  ✓ PASSED tests/ui/test_scenarios.py::test_scenario[collection_view_toggle] (4.3s)
```

- `sys.__stderr__` bypasses pytest's per-test output capture; `flush=True` defeats block buffering → lines stream to GitHub Actions in **real time**.
- Each test shows a `START` line (with `[n/total]` and a timestamp) and a result line (outcome + duration). A hung test stalls visibly on its `START` line.
- Scoped to UI nodeids, so a combined `pytest tests/` run doesn't narrate the unit suite.

No workflow change required — the existing `-q` step now streams progress.

## Verification

Ran a subset against a live container with output piped (non-TTY, same as CI) and prefixed each line with its arrival time — lines arrived interleaved with execution, not at the end:

```
[17:46:57] ▶ [1/222] 17:46:57 START ...[binders_list_view_populated]
[17:47:00]   ✓ PASSED ...[binders_list_view_populated] (2.3s)
[17:47:01] ▶ [2/222] 17:47:01 START ...[collection_foil_nonfoil_distinct_prices]
[17:47:03]   ✓ PASSED ...[collection_foil_nonfoil_distinct_prices] (2.3s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)