### PR TITLE
perf: halve rows scanned by /api/collection/growth

### DIFF
--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -2731,31 +2731,52 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                 i = num_days - 1
             groups[(r["set_code"], r["collector_number"], r["finish"])].append(i)
 
-        # Fetch all relevant prices in one query, scoped to the population's
-        # distinct (set_code, collector_number) pairs and dates >= start.
-        key_pairs = list({(g[0], g[1]) for g in groups.keys()})
+        # Fetch price history for the population, scoped to dates >= start.
+        #
+        # Only the series this chart actually consumes are read: the two retail
+        # sources, and per card the single price_type its finish maps to. That
+        # skips the `buylist_*` series entirely and roughly halves the rows
+        # pulled out of SQLite (prod: 2.14M -> 1.13M). Pinning `price_type` to a
+        # constant also lets SQLite seek the full
+        # (set_code, collector_number, source, price_type, observed_at) unique
+        # index instead of the shorter idx_prices_card.
+        #
+        # There is deliberately no `ORDER BY observed_at` — it forced a temp
+        # B-tree sort over the whole result. `_forward_fill` needs ascending
+        # observations, so the (small) per-key lists are sorted below instead.
+        pairs_by_type: dict[str, set] = defaultdict(set)
+        for set_code, cn, finish in groups:
+            pairs_by_type["foil" if finish in ("foil", "etched") else "normal"].add((set_code, cn))
+
         # SQLite has a default parameter limit (often 32766); chunk to be safe.
         prices_by_key: dict[tuple, list[tuple[str, float]]] = defaultdict(list)
         CHUNK = 500
-        for i in range(0, len(key_pairs), CHUNK):
-            chunk = key_pairs[i:i + CHUNK]
-            placeholders = ",".join(["(?, ?)"] * len(chunk))
-            chunk_params = [v for pair in chunk for v in pair]
-            chunk_params.append(min_acq)
-            price_rows = conn.execute(
-                f"""
-                SELECT set_code, collector_number, source, price_type, observed_at, price
-                FROM prices
-                WHERE (set_code, collector_number) IN ({placeholders})
-                  AND observed_at >= ?
-                ORDER BY observed_at
-                """,
-                chunk_params,
-            ).fetchall()
-            for pr in price_rows:
-                k = (pr["set_code"], pr["collector_number"], pr["source"], pr["price_type"])
-                prices_by_key[k].append((pr["observed_at"], pr["price"]))
+        for price_type, pairs in pairs_by_type.items():
+            pair_list = sorted(pairs)
+            for i in range(0, len(pair_list), CHUNK):
+                chunk = pair_list[i:i + CHUNK]
+                placeholders = ",".join(["(?, ?)"] * len(chunk))
+                chunk_params = [v for pair in chunk for v in pair]
+                chunk_params.append(price_type)
+                chunk_params.append(min_acq)
+                price_rows = conn.execute(
+                    f"""
+                    SELECT set_code, collector_number, source, observed_at, price
+                    FROM prices
+                    WHERE (set_code, collector_number) IN ({placeholders})
+                      AND source IN ('tcgplayer', 'cardkingdom')
+                      AND price_type = ?
+                      AND observed_at >= ?
+                    """,
+                    chunk_params,
+                ).fetchall()
+                for pr in price_rows:
+                    k = (pr["set_code"], pr["collector_number"], pr["source"], price_type)
+                    prices_by_key[k].append((pr["observed_at"], pr["price"]))
         conn.close()
+
+        for points in prices_by_key.values():
+            points.sort()
 
         # Also include any pre-window prices so the first days forward-fill
         # correctly. Fetch the latest price <= start per (set,cn,source,type).

--- a/tests/ui/hints/collection_stats_growth_chart_renders.yaml
+++ b/tests/ui/hints/collection_stats_growth_chart_renders.yaml
@@ -1,0 +1,34 @@
+start_page: /collection
+involves:
+  - "result count text in header (#status), e.g. '45 cards, $10.46'"
+  - "stats modal overlay #stats-modal-overlay (gains .active when open)"
+  - "'Growth over time' section title inside #stats-modal-content"
+  - "growth chart wrapper #growth-chart-wrap"
+  - "Chart.js canvas #growth-chart-canvas"
+  - ".growth-empty placeholder shown when the series is empty"
+fixture_data:
+  demo_cards: 45
+  seeded_span_days: 120
+  seeded_price_pairs: 42
+notes: >
+  The chart is driven by GET /api/collection/growth, which returns
+  {dates, counts, tcg_values, ck_values}. It is fetched lazily by
+  renderGrowthChart() when the modal opens, so seeding before opening the
+  modal is sufficient.
+
+  Seed first, via podman exec. Prices MUST go into /data/shared.sqlite:
+  MTGC_SHARED_DB is set in the test container and attach_shared() creates
+  temp views that shadow the main-schema tables, so rows written to
+  /data/collection.sqlite's `prices` table are invisible to the server.
+  Acquisition dates are a genuine collection column and do go into
+  /data/collection.sqlite. Spread acquired_at over the last 120 days and
+  write price rows every 5th day (deliberate gaps, so the server-side
+  forward-fill is exercised) for both tcgplayer and cardkingdom, in both
+  normal and foil price_type, plus some cardkingdom buylist_normal rows
+  that the endpoint must ignore.
+
+  Then navigate to /collection, wait for .collection-table, click #status
+  to open the modal, wait for #stats-modal-overlay.active, and confirm
+  "Growth over time" is present, #growth-chart-canvas is visible, and the
+  text "No acquisition history for the current filter" is absent.
+  With this seed the series is 121 days, counts 1 -> 45, TCG 7.00 -> 837.00.

--- a/tests/ui/hints/collection_stats_growth_empty_state.yaml
+++ b/tests/ui/hints/collection_stats_growth_empty_state.yaml
@@ -1,0 +1,25 @@
+start_page: /collection
+involves:
+  - "search input, placeholder 'Search (e.g. t:creature c:r mv>=3)'"
+  - "result count text in header (#status)"
+  - "stats modal overlay #stats-modal-overlay"
+  - ".growth-empty placeholder div inside #growth-chart-wrap"
+fixture_data:
+  unowned_results: 7603
+notes: >
+  No seeding needed — this is the unseeded fixture's natural state for this
+  filter. The server short-circuits is:unowned in _api_collection_growth and
+  returns {"dates": [], "counts": [], "tcg_values": [], "ck_values": []}.
+  renderGrowthChart() sees an empty dates array and replaces the wrapper's
+  contents with
+  '<div class="growth-empty">No acquisition history for the current filter</div>'
+  so no canvas is created.
+
+  Type "is:unowned" into the search box (300ms debounce). Unowned rows carry
+  qty 0, so updateStatusText() falls back to counting rows and switches the
+  noun: the status reads "7,603 results", NOT "7,603 cards". Assert on the
+  noun rather than the number so the test survives fixture regeneration.
+  Click #status, wait for #stats-modal-overlay.active, then assert
+  .growth-empty is visible, the message text is present, and
+  #growth-chart-canvas is NOT attached. The Counts section still renders, so
+  "Entries (rows)" remains present — the empty state is scoped to the chart.

--- a/tests/ui/hints/collection_stats_growth_range_pills.yaml
+++ b/tests/ui/hints/collection_stats_growth_range_pills.yaml
@@ -1,0 +1,26 @@
+start_page: /collection
+involves:
+  - "result count text in header (#status)"
+  - "stats modal overlay #stats-modal-overlay"
+  - "range pill container #growth-range-pills"
+  - "pill buttons .price-range-pill with data-range 30/90/180/365/0"
+  - "'.active' marks the selected pill, '.disabled' marks unavailable ranges"
+fixture_data:
+  seeded_span_days: 120
+  enabled_pills: 3
+  disabled_pills: 2
+notes: >
+  Pills are 1M(data-range=30), 3M(90), 6M(180), 1Y(365), ALL(0). ALL carries
+  .active in the initial markup. renderGrowthChart() computes
+  spanDays = (Date.now() - dates[0]) / 86400000 and then toggles .disabled on
+  each pill where ranges[i] > 0 && spanDays < ranges[i]. ALL is never disabled.
+
+  Seeding 120 days of acquisition history (see
+  collection_stats_growth_chart_renders for the required two-database seed)
+  gives spanDays ~= 120, so 1M and 3M stay enabled while 6M and 1Y are
+  disabled — exactly 2 disabled pills and 3 enabled ones.
+
+  Clicking a disabled pill is a no-op (the handler returns early). Clicking
+  3M removes .active from every pill, adds it to 3M, and re-slices the chart
+  datasets client-side without a refetch. Assert on
+  "#growth-range-pills .price-range-pill.active[data-range='90']" afterwards.

--- a/tests/ui/implementations/collection_stats_growth_chart_renders.py
+++ b/tests/ui/implementations/collection_stats_growth_chart_renders.py
@@ -1,0 +1,124 @@
+"""
+Hand-written implementation for collection_stats_growth_chart_renders.
+
+Seeds acquisition history and price history via podman exec, then opens the
+result-stats modal and verifies the "Growth over time" chart actually renders
+instead of falling back to the empty-state placeholder.
+"""
+
+import subprocess
+
+# Spread acquired_at over the last 120 days and write price rows every 5th day
+# (deliberate gaps, so the server-side forward-fill is exercised) for both
+# sources in both price_types, plus buylist rows the endpoint must ignore.
+#
+# Prices go into /data/shared.sqlite, NOT /data/collection.sqlite: the test
+# container sets MTGC_SHARED_DB and attach_shared() creates temp views that
+# shadow the main-schema tables, so rows written to collection.sqlite's
+# `prices` table are invisible to the server.
+_SEED = """
+import sqlite3, datetime as dt
+col = sqlite3.connect('/data/collection.sqlite')
+sh = sqlite3.connect('/data/shared.sqlite')
+today = dt.date.today()
+ids = [r[0] for r in col.execute("SELECT id FROM collection ORDER BY id")]
+for n, cid in enumerate(ids):
+    d = today - dt.timedelta(days=120 - (n * 120 // max(len(ids), 1)))
+    col.execute("UPDATE collection SET acquired_at=? WHERE id=?",
+                (d.isoformat() + "T12:00:00.000Z", cid))
+col.commit()
+pids = [r[0] for r in col.execute("SELECT DISTINCT printing_id FROM collection")]
+q = ",".join("?" * len(pids))
+pairs = [tuple(r) for r in sh.execute(
+    "SELECT DISTINCT set_code, collector_number FROM printings "
+    "WHERE printing_id IN (%s)" % q, pids)]
+rows = []
+for i, (sc, cn) in enumerate(pairs):
+    base = 2.0 + (i % 20)
+    for k in range(0, 121, 5):
+        d = (today - dt.timedelta(days=120 - k)).isoformat()
+        grow = 1.0 + k / 240.0
+        for src, pt, mult in (('tcgplayer', 'normal', 1.0),
+                              ('cardkingdom', 'normal', 0.92),
+                              ('tcgplayer', 'foil', 2.4),
+                              ('cardkingdom', 'foil', 2.2),
+                              ('cardkingdom', 'buylist_normal', 0.4)):
+            rows.append((sc, cn, src, pt, round(base * grow * mult, 2), d))
+sh.executemany("INSERT OR REPLACE INTO prices "
+               "(set_code,collector_number,source,price_type,price,observed_at) "
+               "VALUES (?,?,?,?,?,?)", rows)
+sh.commit()
+"""
+
+
+def _find_container(base_url):
+    """Find the container serving the given base_url by matching its port."""
+    port = base_url.rstrip("/").rsplit(":", 1)[-1]
+    result = subprocess.run(
+        ["podman", "ps", "--format", "{{.Names}}"], capture_output=True, text=True
+    )
+    for name in result.stdout.strip().split("\n"):
+        if not name:
+            continue
+        port_result = subprocess.run(
+            ["podman", "port", name, "8081/tcp"], capture_output=True, text=True
+        )
+        if port in port_result.stdout:
+            return name
+    raise AssertionError(f"no container found serving {base_url}")
+
+
+def steps(harness):
+    # The --test fixture has no acquisition spread and almost no prices, so
+    # the chart would otherwise be a single point at $0.
+    container = _find_container(harness.base_url)
+    subprocess.run(
+        ["podman", "exec", container, "python3", "-c", _SEED],
+        capture_output=True, text=True, check=True,
+    )
+
+    # Reload so the collection list is served from the seeded DB.
+    harness.navigate("/collection")
+    harness.wait_for_visible(".collection-table", timeout=15_000)
+    harness.wait_for_text("45 cards", timeout=15_000)
+
+    # Open the result-stats modal from the inline result count.
+    harness.click_by_selector("#status")
+    harness.wait_for_visible("#stats-modal-overlay.active", timeout=10_000)
+
+    # The growth section is the first section in the modal.
+    harness.assert_text_present("Growth over time")
+
+    # The chart is fetched lazily when the modal opens, so wait for the canvas.
+    harness.wait_for_visible("#growth-chart-canvas", timeout=15_000)
+    harness.assert_visible("#growth-range-pills")
+
+    # Neither the empty state nor the fetch-failure state may be showing.
+    harness.assert_text_absent("No acquisition history for the current filter")
+    harness.assert_text_absent("Failed to load growth history")
+
+    # The canvas element exists in the markup even if Chart.js never drew, so
+    # assert against the live Chart instance. Datasets are arrays of {x, y}
+    # points (there is no labels array): dataset 0 is the card count, dataset 1
+    # is the value series.
+    chart = harness.page.evaluate(
+        "(() => {"
+        "  const c = Chart.getChart('growth-chart-canvas');"
+        "  if (!c) return null;"
+        "  const ys = i => c.data.datasets[i].data.map(p => Number(p.y));"
+        "  return {datasets: c.data.datasets.length,"
+        "          points: c.data.datasets[0].data.length,"
+        "          firstCount: ys(0)[0], lastCount: ys(0).slice(-1)[0],"
+        "          maxValue: Math.max(...ys(1))};"
+        "})()"
+    )
+    assert chart is not None, "Chart.js never instantiated the growth chart"
+    assert chart["datasets"] == 2, f"expected count + value datasets, got {chart['datasets']}"
+    assert chart["points"] > 100, f"expected the full ~121-day series, got {chart['points']}"
+    # The collection grows over the window, and the value series is not flat zero.
+    assert chart["lastCount"] > chart["firstCount"], (
+        f"count series did not grow: {chart['firstCount']} -> {chart['lastCount']}"
+    )
+    assert chart["maxValue"] > 0, "value series is flat zero — prices did not resolve"
+
+    harness.screenshot("final_state")

--- a/tests/ui/implementations/collection_stats_growth_empty_state.py
+++ b/tests/ui/implementations/collection_stats_growth_empty_state.py
@@ -1,0 +1,37 @@
+"""
+Hand-written implementation for collection_stats_growth_empty_state.
+
+Filters to is:unowned — which the growth endpoint short-circuits to an empty
+series — and verifies the chart area degrades to its placeholder message while
+the rest of the stats modal still renders. No seeding required.
+"""
+
+
+def steps(harness):
+    harness.navigate("/collection")
+    harness.wait_for_visible(".collection-table", timeout=15_000)
+    harness.wait_for_text("45 cards", timeout=15_000)
+
+    # is:unowned flips the query to a LEFT JOIN against printings. Unowned rows
+    # carry qty 0, so updateStatusText() switches the noun from "cards" to
+    # "results" — asserting on the noun keeps this independent of the fixture's
+    # exact printing count.
+    harness.fill_by_placeholder("Search (e.g. t:creature c:r mv>=3)", "is:unowned")
+    harness.wait_for_text("results", timeout=15_000)
+    harness.assert_text_absent("45 cards")
+    harness.screenshot("unowned_filter")
+
+    harness.click_by_selector("#status")
+    harness.wait_for_visible("#stats-modal-overlay.active", timeout=10_000)
+
+    # The growth section renders its placeholder rather than a chart.
+    harness.assert_text_present("Growth over time")
+    harness.wait_for_visible("#growth-chart-wrap .growth-empty", timeout=10_000)
+    harness.assert_text_present("No acquisition history for the current filter")
+    harness.assert_hidden("#growth-chart-canvas")
+
+    # The empty state is scoped to the chart — the rest of the modal is intact.
+    harness.assert_text_present("Entries (rows)")
+    harness.assert_text_present("Distinct printings")
+
+    harness.screenshot("final_state")

--- a/tests/ui/implementations/collection_stats_growth_range_pills.py
+++ b/tests/ui/implementations/collection_stats_growth_range_pills.py
@@ -1,0 +1,111 @@
+"""
+Hand-written implementation for collection_stats_growth_range_pills.
+
+Seeds ~120 days of history so the 1M/3M ranges are covered but 6M/1Y are not,
+then verifies the pills grey out accordingly and that clicking 3M moves the
+active selection.
+"""
+
+import subprocess
+
+# Spread acquired_at over the last 120 days and write price rows every 5th day
+# (deliberate gaps, so the server-side forward-fill is exercised) for both
+# sources in both price_types, plus buylist rows the endpoint must ignore.
+#
+# Prices go into /data/shared.sqlite, NOT /data/collection.sqlite: the test
+# container sets MTGC_SHARED_DB and attach_shared() creates temp views that
+# shadow the main-schema tables, so rows written to collection.sqlite's
+# `prices` table are invisible to the server.
+_SEED = """
+import sqlite3, datetime as dt
+col = sqlite3.connect('/data/collection.sqlite')
+sh = sqlite3.connect('/data/shared.sqlite')
+today = dt.date.today()
+ids = [r[0] for r in col.execute("SELECT id FROM collection ORDER BY id")]
+for n, cid in enumerate(ids):
+    d = today - dt.timedelta(days=120 - (n * 120 // max(len(ids), 1)))
+    col.execute("UPDATE collection SET acquired_at=? WHERE id=?",
+                (d.isoformat() + "T12:00:00.000Z", cid))
+col.commit()
+pids = [r[0] for r in col.execute("SELECT DISTINCT printing_id FROM collection")]
+q = ",".join("?" * len(pids))
+pairs = [tuple(r) for r in sh.execute(
+    "SELECT DISTINCT set_code, collector_number FROM printings "
+    "WHERE printing_id IN (%s)" % q, pids)]
+rows = []
+for i, (sc, cn) in enumerate(pairs):
+    base = 2.0 + (i % 20)
+    for k in range(0, 121, 5):
+        d = (today - dt.timedelta(days=120 - k)).isoformat()
+        grow = 1.0 + k / 240.0
+        for src, pt, mult in (('tcgplayer', 'normal', 1.0),
+                              ('cardkingdom', 'normal', 0.92),
+                              ('tcgplayer', 'foil', 2.4),
+                              ('cardkingdom', 'foil', 2.2),
+                              ('cardkingdom', 'buylist_normal', 0.4)):
+            rows.append((sc, cn, src, pt, round(base * grow * mult, 2), d))
+sh.executemany("INSERT OR REPLACE INTO prices "
+               "(set_code,collector_number,source,price_type,price,observed_at) "
+               "VALUES (?,?,?,?,?,?)", rows)
+sh.commit()
+"""
+
+
+def _find_container(base_url):
+    """Find the container serving the given base_url by matching its port."""
+    port = base_url.rstrip("/").rsplit(":", 1)[-1]
+    result = subprocess.run(
+        ["podman", "ps", "--format", "{{.Names}}"], capture_output=True, text=True
+    )
+    for name in result.stdout.strip().split("\n"):
+        if not name:
+            continue
+        port_result = subprocess.run(
+            ["podman", "port", name, "8081/tcp"], capture_output=True, text=True
+        )
+        if port in port_result.stdout:
+            return name
+    raise AssertionError(f"no container found serving {base_url}")
+
+
+def steps(harness):
+    # 120 days of history: long enough for 1M (30) and 3M (90), short enough
+    # that 6M (180) and 1Y (365) must be disabled.
+    container = _find_container(harness.base_url)
+    subprocess.run(
+        ["podman", "exec", container, "python3", "-c", _SEED],
+        capture_output=True, text=True, check=True,
+    )
+
+    harness.navigate("/collection")
+    harness.wait_for_visible(".collection-table", timeout=15_000)
+    harness.wait_for_text("45 cards", timeout=15_000)
+
+    harness.click_by_selector("#status")
+    harness.wait_for_visible("#stats-modal-overlay.active", timeout=10_000)
+    harness.wait_for_visible("#growth-chart-canvas", timeout=15_000)
+
+    # All five pills exist; ALL starts selected.
+    harness.assert_element_count("#growth-range-pills .price-range-pill", 5)
+    harness.assert_visible("#growth-range-pills .price-range-pill.active[data-range='0']")
+
+    # 6M and 1Y exceed the seeded span, so exactly those two are disabled.
+    harness.assert_element_count("#growth-range-pills .price-range-pill.disabled", 2)
+    harness.assert_visible("#growth-range-pills .price-range-pill.disabled[data-range='180']")
+    harness.assert_visible("#growth-range-pills .price-range-pill.disabled[data-range='365']")
+
+    # 1M, 3M and ALL remain selectable.
+    harness.assert_element_count("#growth-range-pills .price-range-pill:not(.disabled)", 3)
+    harness.screenshot("pills_initial")
+
+    # Selecting 3M re-slices the chart and moves the active marker.
+    harness.click_by_selector("#growth-range-pills .price-range-pill[data-range='90']")
+    harness.wait_for_visible(
+        "#growth-range-pills .price-range-pill.active[data-range='90']", timeout=5_000
+    )
+    harness.assert_element_count("#growth-range-pills .price-range-pill.active", 1)
+
+    # The chart is still rendered after the update.
+    harness.assert_visible("#growth-chart-canvas")
+
+    harness.screenshot("final_state")

--- a/tests/ui/intents/collection_stats_growth_chart_renders.yaml
+++ b/tests/ui/intents/collection_stats_growth_chart_renders.yaml
@@ -1,0 +1,22 @@
+# Scenario: Growth-over-time chart renders in the result-stats modal
+#
+# Related:
+#   issues: [efj-mtgc-655]
+#   pull_requests: []
+#
+# Prerequisites:
+#   The chart needs both acquisition history and price history. The --test
+#   fixture has neither: it ships 0 collection rows (the ~45 cards come from
+#   --demo at setup time, all acquired "today") and only 5 price rows. The
+#   implementation therefore seeds both via podman exec before opening the
+#   modal — backdated acquired_at into /data/collection.sqlite and price rows
+#   into /data/shared.sqlite (prices resolve through the ATTACHed shared DB,
+#   so seeding collection.sqlite has no effect).
+
+description: >
+  When I open the "Result statistics" modal from the collection page,
+  the first section is "Growth over time": a line chart plotting how my
+  collection's card count and total value have changed since my earliest
+  acquisition. With acquisition and price history present I see an actual
+  rendered chart, not the "No acquisition history for the current filter"
+  placeholder.

--- a/tests/ui/intents/collection_stats_growth_empty_state.yaml
+++ b/tests/ui/intents/collection_stats_growth_empty_state.yaml
@@ -1,0 +1,12 @@
+# Scenario: Growth chart shows an empty state for filters with no history
+#
+# Related:
+#   issues: [efj-mtgc-655]
+#   pull_requests: []
+
+description: >
+  When I search "is:unowned" the collection page shows cards I don't own,
+  which by definition have no acquisition history. Opening the result-stats
+  modal still works and still shows my counts, but the growth section shows
+  "No acquisition history for the current filter" instead of a chart —
+  rather than an empty chart, an error, or a hang.

--- a/tests/ui/intents/collection_stats_growth_range_pills.yaml
+++ b/tests/ui/intents/collection_stats_growth_range_pills.yaml
@@ -1,0 +1,17 @@
+# Scenario: Growth chart time-range pills reflect the available data span
+#
+# Related:
+#   issues: [efj-mtgc-655]
+#   pull_requests: []
+#
+# Prerequisites:
+#   Same seeding as collection_stats_growth_chart_renders, with the earliest
+#   acquisition pinned ~120 days back so that the 1M/3M ranges are covered by
+#   the data but 6M/1Y are not. See that intent for why seeding is required.
+
+description: >
+  Above the growth chart there are time-range pills (1M, 3M, 6M, 1Y, ALL)
+  with ALL selected by default. Ranges longer than my actual history are
+  greyed out — with about four months of history, 1M and 3M are available
+  but 6M and 1Y are not. Clicking 3M narrows the chart to the last three
+  months and makes 3M the selected pill.


### PR DESCRIPTION
## Problem

`/api/collection/growth` backs the "Growth over time" chart in the Result statistics modal on `/collection`. On prod it takes **18.3s** to return a 6KB payload of 162 points. Nothing is materialised — it recomputes per request, and the cost scales with `groups x days` while the day axis grows daily.

The endpoint pulled **every raw price observation** for each collected `(set_code, collector_number)` pair, across all sources and all `price_type`s, sorted by `observed_at`: 2.14M rows to produce 162 points.

## What changed

`prices` holds six `(source, price_type)` combinations, two of which are Card Kingdom `buylist_normal` / `buylist_foil` — series this chart never reads. And each group needs exactly **one** `price_type` (`foil` for foil/etched finishes, `normal` otherwise). The old query fetched all six per pair.

The endpoint now partitions the collection's pairs by their required `price_type` and issues one query per type with `source IN ('tcgplayer', 'cardkingdom') AND price_type = ?`. Prod rows hauled into Python: **2,139,150 → 1,128,983**.

Pinning `price_type` to a constant also changes the plan. Before:

```
SEARCH prices USING INDEX idx_prices_card (set_code=? AND collector_number=?)
USE TEMP B-TREE FOR ORDER BY
```

After — a 5-column seek on the UNIQUE index, including the `observed_at` range, and no sort:

```
SEARCH prices USING INDEX sqlite_autoindex_prices_1
  (set_code=? AND collector_number=? AND source=? AND price_type=? AND observed_at>?)
```

`ORDER BY observed_at` is dropped (it forced the temp B-tree). `_forward_fill` still requires ascending observations, so the small per-key lists are sorted in Python instead. `_forward_fill` itself is unchanged — its contract is preserved.

## Measurements

Against the real prod dataset (7,297 collection rows / 4,461 groups / 4,177 distinct pairs / 162 days / 47.1M `prices` rows), read-only via `mode=ro`:

| filter | rows old → new | time old → new |
|---|---|---|
| unfiltered | 2,139,150 → 1,128,983 | **12.68s → 6.80s** |
| `status:owned` | 2,139,150 → 1,128,983 | 12.72s → 7.08s |
| `is:decked` | 541,075 → 310,035 | 2.74s → 1.78s |
| `t:creature c:r` | 219,308 → 118,099 | 1.09s → 0.67s |
| `r:mythic` | 106,971 → 49,884 | 1.10s → 0.42s |

~1.85x on the query portion.

### Measurement caveat — please read

**These are warm-cache numbers.** I did not cleanly isolate cold-cache timing; my one cold attempt was confounded because running the old path first warmed the page cache for the new path. The original **18.3s end-to-end figure improving by this ratio is inference, not measurement.** The row-count reduction (2.14M → 1.13M) is directly measured; the end-to-end wall-clock improvement on a cold prod cache is not.

## Why not the obvious `GROUP BY` daily reduction?

The natural fix — `substr(observed_at,1,10) AS d ... GROUP BY 1,2,3,4,5` — was implemented, measured, and **rejected as a regression**. It collapses nothing on this data:

- All 47,153,627 `observed_at` values are date-only `'YYYY-MM-DD'` (verified: zero rows with `length != 10`).
- `UNIQUE(set_code, collector_number, source, price_type, observed_at)` already permits at most one row per key per day.

On one 500-pair chunk, at **identical row counts** (283,585):

| variant | time |
|---|---|
| original | 0.95s |
| with daily `GROUP BY` | 1.46s |

It returns the same rows and adds `USE TEMP B-TREE FOR GROUP BY`. Noting this so a reviewer doesn't wonder why the obvious approach wasn't used.

## Equivalence evidence

Output is byte-identical — verified, not assumed.

1. **Prod, read-only.** Old and new fetch paths run in one process feeding the same downstream builder. `dates` / `counts` / `tcg_values` / `ck_values` and the serialised JSON payload are identical for all five non-empty filters in the table above.
2. **Container.** Seeded 8,355 price rows over 42 pairs, including **2,800 buylist rows** (which must be ignored), **25% random daily gaps** (so forward-fill is load-bearing), and a foil/etched/nonfoil finish mix. The live patched endpoint was diffed against the pre-patch algorithm: all four arrays identical, unfiltered and `status:owned`. `is:unowned` still early-returns empty.

Preserved: the search filter via `parse_query`/`compile_query`, the `status IN ('owned','ordered')` default, the `is:unowned` early return, the foil/etched → `price_type 'foil'` mapping, and the cents rounding.

## Why the remaining cost is irreducible here

1.13M rows ≈ 4,177 pairs x 2 sources x 138 observed days — the minimum needed to forward-fill a per-card daily series.

Forward-fill genuinely matters: **12.67% of `(key, day)` cells inside each key's observed span have no price row**. A naive SQL join that skipped forward-fill would change values materially, so summing in SQL would need a day-spine cross join plus window-function forward-fill (the same ~1.15M internal rows) and risks cent-level float divergence.

## Tests

- 1,078 passed / 195 skipped, `uv run pytest tests/ --ignore=tests/ui --ignore=tests/integration`
- `uv run ruff check mtg_collector/ tests/ui/` clean
- 3 new UI scenarios from `/qa-finish`, all passing against a container

The `--test` fixture cannot produce a meaningful chart unaided (0 collection rows; the ~45 cards come from `--demo` all acquired "today", plus 5 price rows), so the two chart scenarios seed 120 days of history via `podman exec`, following the `collection_price_chart` precedent. Note prices must be seeded into `/data/shared.sqlite`, not `/data/collection.sqlite` — the container sets `MTGC_SHARED_DB` and `attach_shared()` creates temp views that shadow the main-schema tables.

## Related

`efj-mtgc-arl` — materialising `collection_value_history` from the `mtgc-prices` timer would make the unfiltered case O(days). Deliberately **not** attempted here; it only helps the unfiltered path, since this endpoint honours the active search filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
