### PR TITLE
Fix: keyword:>value silently returned zero results

### DIFF
--- a/mtg_collector/search/grammar.py
+++ b/mtg_collector/search/grammar.py
@@ -76,7 +76,8 @@ def tokenize(query: str) -> list[tuple[str, str, str, int]]:
                     keyword = m.group(1)
                     op = m.group(2) if name == "NEG_KEYWORD_COMPARE" else ":"
                     val_pos = m.end()
-                    val, val_end = _read_value(query, val_pos)
+                    val, val_end, quoted = _read_value(query, val_pos)
+                    op, val, val_pos = _fold_colon_operator(op, val, val_pos, quoted)
                     tokens.append(("KEYWORD_EXPR", keyword, op, pos + 1))
                     tokens.append(("VALUE", val, "", val_pos))
                     pos = val_end
@@ -87,7 +88,7 @@ def tokenize(query: str) -> list[tuple[str, str, str, int]]:
                     op = m.group(2)
                     # Now read the value
                     val_pos = m.end()
-                    val, val_end = _read_value(query, val_pos)
+                    val, val_end, _quoted = _read_value(query, val_pos)
                     tokens.append(("KEYWORD_EXPR", keyword, op, pos))
                     tokens.append(("VALUE", val, "", val_pos))
                     pos = val_end
@@ -97,8 +98,9 @@ def tokenize(query: str) -> list[tuple[str, str, str, int]]:
                     keyword = m.group(1)
                     # Now read the value
                     val_pos = m.end()
-                    val, val_end = _read_value(query, val_pos)
-                    tokens.append(("KEYWORD_EXPR", keyword, ":", pos))
+                    val, val_end, quoted = _read_value(query, val_pos)
+                    op, val, val_pos = _fold_colon_operator(":", val, val_pos, quoted)
+                    tokens.append(("KEYWORD_EXPR", keyword, op, pos))
                     tokens.append(("VALUE", val, "", val_pos))
                     pos = val_end
                     matched = True
@@ -121,23 +123,54 @@ def tokenize(query: str) -> list[tuple[str, str, str, int]]:
     return tokens
 
 
-def _read_value(query: str, pos: int) -> tuple[str, int]:
-    """Read a value starting at pos. Handles quoted strings and unquoted tokens."""
+# Comparison operators that may follow a `:`, longest-first so that `>=`
+# is preferred over `>` and `!=` over a bare `=`.
+_COLON_FOLDABLE_OPS = ("!=", "<=", ">=", "<", ">", "=")
+
+
+def _fold_colon_operator(
+    op: str, val: str, val_pos: int, quoted: bool
+) -> tuple[str, str, int]:
+    """Fold a comparison operator written after a colon into the operator slot.
+
+    Scryfall-style queries accept both ``mv>5`` and ``mv:>5``. The tokenizer
+    matches ``mv:`` first, leaving ``>5`` as the value; without this fold the
+    compiler receives operator ``:`` and the literal value ``">5"``, which is
+    not a number and previously compiled to a match-nothing ``1=0`` clause.
+
+    Only unquoted values are folded, so ``o:">"`` still searches for a literal
+    ``>`` character.
+    """
+    if op != ":" or quoted:
+        return (op, val, val_pos)
+
+    for candidate in _COLON_FOLDABLE_OPS:
+        if val.startswith(candidate):
+            return (candidate, val[len(candidate) :], val_pos + len(candidate))
+
+    return (op, val, val_pos)
+
+
+def _read_value(query: str, pos: int) -> tuple[str, int, bool]:
+    """Read a value starting at pos. Handles quoted strings and unquoted tokens.
+
+    Returns ``(value, end_position, was_quoted)``.
+    """
     if pos >= len(query):
-        return ("", pos)
+        return ("", pos, False)
 
     if query[pos] == '"':
         # Quoted value
         end = query.find('"', pos + 1)
         if end == -1:
             raise SearchError("Unterminated quoted string", position=pos)
-        return (query[pos + 1 : end], end + 1)
+        return (query[pos + 1 : end], end + 1, True)
     else:
         # Unquoted value: read until whitespace or ) or end
         end = pos
         while end < len(query) and query[end] not in (" ", "\t", "\n", "\r", ")"):
             end += 1
-        return (query[pos:end], end)
+        return (query[pos:end], end, False)
 
 
 def parse_query(query: str):

--- a/tests/test_search_compiler.py
+++ b/tests/test_search_compiler.py
@@ -13,6 +13,90 @@ def _compile(q: str) -> CompiledQuery:
     return compile_query(parse_query(q))
 
 
+# Every keyword that accepts a comparison operator, with a representative value.
+_OPERATOR_KEYWORDS = [
+    ("mv", "3"),
+    ("cmc", "3"),
+    ("manavalue", "3"),
+    ("year", "2020"),
+    ("price", "10"),
+    ("added", "2024-01-01"),
+    ("pow", "2"),
+    ("power", "2"),
+    ("tou", "2"),
+    ("toughness", "2"),
+    ("loy", "3"),
+    ("loyalty", "3"),
+    ("pt", "4"),
+    ("cn", "100"),
+    ("number", "100"),
+    ("r", "rare"),
+    ("rarity", "rare"),
+    ("c", "rg"),
+    ("id", "wu"),
+    ("status", "owned"),
+]
+
+_COMPARISON_OPERATORS = ["=", "!=", ">", ">=", "<", "<="]
+
+
+class TestColonOperatorParity:
+    """`keyword:>value` must behave identically to `keyword>value`.
+
+    Regression: the tokenizer used to treat `:` as the operator and hand the
+    whole `>value` string to the compiler as a literal value, which fell
+    through to a `1=0` match-nothing clause — silently returning zero rows
+    instead of raising.
+    """
+
+    @pytest.mark.parametrize("keyword,value", _OPERATOR_KEYWORDS)
+    @pytest.mark.parametrize("op", _COMPARISON_OPERATORS)
+    def test_colon_prefixed_operator_matches_bare_operator(self, keyword, value, op):
+        colon_form = _compile(f"{keyword}:{op}{value}")
+        bare_form = _compile(f"{keyword}{op}{value}")
+        assert colon_form.where_sql == bare_form.where_sql
+        assert colon_form.params == bare_form.params
+
+    @pytest.mark.parametrize("keyword,value", _OPERATOR_KEYWORDS)
+    @pytest.mark.parametrize("op", _COMPARISON_OPERATORS)
+    def test_colon_prefixed_operator_is_not_match_nothing(self, keyword, value, op):
+        c = _compile(f"{keyword}:{op}{value}")
+        assert "1=0" not in c.where_sql
+
+    @pytest.mark.parametrize("keyword,value", _OPERATOR_KEYWORDS)
+    @pytest.mark.parametrize("op", _COMPARISON_OPERATORS)
+    def test_negated_colon_prefixed_operator_matches_bare(self, keyword, value, op):
+        colon_form = _compile(f"-{keyword}:{op}{value}")
+        bare_form = _compile(f"-{keyword}{op}{value}")
+        assert colon_form.where_sql == bare_form.where_sql
+        assert colon_form.params == bare_form.params
+
+    @pytest.mark.parametrize("keyword,value", _OPERATOR_KEYWORDS)
+    def test_plain_colon_still_works(self, keyword, value):
+        """Control: bare `keyword:value` must be unaffected by the fix."""
+        c = _compile(f"{keyword}:{value}")
+        assert "1=0" not in c.where_sql
+
+    def test_quoted_value_starting_with_operator_is_literal(self):
+        """A quoted value keeps a leading operator character as literal text."""
+        c = _compile('o:">"')
+        assert "1=0" not in c.where_sql
+        assert any(">" in str(p) for p in c.params)
+
+    @pytest.mark.parametrize("query", [
+        "mv:>5",
+        "price:>10",
+        "year:>2020",
+        "added:>2026-05-01",
+        "added:>=2026-05-01",
+    ])
+    def test_reported_bug_queries_compile_to_real_predicates(self, query):
+        """The exact queries from the bug report must not compile to `1=0`."""
+        c = _compile(query)
+        assert "1=0" not in c.where_sql
+        assert c.params
+
+
 class TestColorCompilation:
     def test_color_contains(self):
         c = _compile("c:r")


### PR DESCRIPTION
Fixes efj-mtgc-1h8 (P1).

Any search combining a colon and a comparison operator — `mv:>5`, `price:>10`, `added:>=2026-05-01` — silently returned an **empty result set**. The bare form (`mv>5`) worked correctly. No error was raised: the API returned HTTP 200 with a zero-length list, so users saw "no results" instead of a syntax error.

## Root cause — this was NOT a parse failure

The natural assumption is that the parser chokes on `>5`. It doesn't. **Parsing succeeds cleanly.** The silent-empty comes from the compiler:

```
tokenize('mv:>5') -> [('KEYWORD_EXPR', 'mv', ':', 0), ('VALUE', '>5', '', 3)]
build_ast         -> ComparisonNode(keyword='mana_value', operator=':', value='>5')
_compile_numeric  -> float('>5') raises ValueError
                     ...which is CAUGHT, returning "1=0 /* invalid number */"
```

The `KEYWORD_COLON` pattern matches `mv:` first, and `_read_value` swallows `>5` as a literal value. The AST is well-formed — it just carries a value that is not a number. `compiler.py::_compile_numeric` (and `_compile_added` for dates) then catches the `ValueError` and substitutes a match-nothing clause.

That `except ValueError: return "1=0"` is a textbook violation of CLAUDE.md's **"NEVER add fallback logic. Errors should propagate. No fallback content, no silent defaults, no swallowed exceptions. Let it crash visibly."** The exception was swallowed and a silent default took its place, which is precisely why the failure was invisible — a broken query was indistinguishable from an empty collection.

## The fix, and why it lives in the tokeniser

`mtg_collector/search/grammar.py` only (+51/−9). New `_fold_colon_operator()` folds a leading comparison operator into the operator slot at tokenise time, so `mv:>5` tokenises **identically** to `mv>5`.

This makes the query *valid* rather than making the compiler *lenient*. The alternative — teaching `_compile_numeric` to cope with `">5"` — would spread operator parsing into the compiler and soften the very error path that should stay strict. By fixing it in the tokeniser, `keyword:>value` simply never reaches the `1=0` branch, and that branch keeps its current strictness for genuinely malformed input.

Guardrails:

- **Only unquoted values fold.** `o:">"` still searches for a literal `>` character. `_read_value` now reports whether the value was quoted.
- **Longest-match ordering** (`!=`, `<=`, `>=` before `<`, `>`, `=`) so `>=` isn't mis-split into `>` + `=`.
- **`-` is not a foldable operator**, so `mv:-1` (negative number) and `t:legendary-creature` (hyphenated value) are unaffected.

## Test evidence

New `tests/test_search_compiler.py::TestColonOperatorParity` — 386 parametrized cases covering 20 operator-taking keywords × 6 comparison operators, plus negated forms (`-mv:>5`), a plain-colon control, a quoted-literal case, and the 5 exact queries from the bug report.

Per CLAUDE.md, a bug-demonstrating test must fail while the bug exists. Verified in both directions:

| | result |
|---|---|
| Before fix | `337 failed, 49 passed, 97 deselected in 2.64s` |
| After fix | `386 passed, 97 deselected in 0.62s` |

- Fast search loop: **1,030 passed**
- Full unit suite: **1,464 passed, 195 skipped**
- `uv run ruff check mtg_collector/`: **All checks passed**

## Container validation

Measured against instance `coloparity` (`deploy/setup.sh coloparity --test`, torn down with `--purge`). All HTTP 200:

| colon form | n | bare form | n |
|---|---|---|---|
| `mv:>5` | 5 | `mv>5` | 5 |
| `price:>10` | 1 | `price>10` | 1 |
| `year:>2020` | 43 | `year>2020` | 43 |
| `added:>2020-01-01` | 43 | `added>2020-01-01` | 43 |
| `added:>=2020-01-01` | 43 | `added>=2020-01-01` | 43 |
| `cn:>100` | 32 | `cn>100` | 32 |
| `pow:>=3` | 14 | `pow>=3` | 14 |
| `tou:<=2` | 11 | `tou<=2` | 11 |
| `r:>rare` | 5 | `r>rare` | 5 |

Counts are **fixture-scale** (45 collection entries), not prod-scale — the point is the parity, not the magnitudes. Controls `r:mythic` (5) and `mv:5` (4) unchanged.

Re-confirmed against prod's live API (read-only, still running the old code), reproducing the originally reported numbers exactly:

```
mv:>5      -> 0     mv>5      -> 335
price:>10  -> 0     price>10  ->  73
```

## Deliberate divergence from Scryfall — please read before flagging

A reviewer who knows Scryfall may object that we're now doing something Scryfall doesn't. That's correct, and it was a conscious decision rather than an oversight.

Measured against the live Scryfall API:

```
set:fin             -> 313
cmc>5 set:fin       ->  36
cmc:>5 set:fin      -> 313   <-- identical to `set:fin` alone
cmc:>>5 set:fin     -> 313
cmc:banana set:fin  -> 313
```

Real Scryfall does **not** treat `cmc:>5` as `cmc>5`. It **silently drops** the unparseable clause, matching *everything*. So all three behaviours are on the table:

| | behaviour on `cmc:>5` |
|---|---|
| Scryfall | silently drops the clause → matches everything |
| deckdumpster (old) | silent `1=0` → matches nothing |
| deckdumpster (this PR) | treats it as `cmc>5` → matches what the user meant |

Scryfall's silent clause-drop is arguably the same class of silent-default bug, just in the opposite direction. CLAUDE.md documents both `:` and `>` as accepted operators on numeric/date keywords, and `price:>10` is the syntax users naturally type. We've chosen to honour the obvious intent rather than replicate Scryfall's silent-ignore.

## Related, not fixed here

**efj-mtgc-ube (P1)** — six further `1=0` sites in `compiler.py` still silently return empty for malformed values: `mv:abc`, `mv>`, `mv:>`, `price:xyz`, `cn:abc`, `pow:abc`, `status:bogus`, `added:lolwut`, `r>bogus`, `is:nonsense`, `has:nonsense`.

Left deliberately out of scope. `tests/test_search_compiler.py::test_status_unknown` and `::test_added_invalid_value` currently **assert that `1=0` is present**, so converting those paths to raise `SearchError` is a real behaviour change that needs its own review and corpus audit — not a drive-by rider on a P1 fix.

## Not verified

`uv run pytest tests/test_search_scryfall.py --scryfall` **never completed** — cold cache, network rate-limited past a 10-minute timeout, and I killed it. It was not empirically run.

It is safe by construction: that test fails only in the "we reject but Scryfall accepts" direction, and this change only makes *more* queries parse — it introduces no new rejections. But that is an argument, not a measurement, and shouldn't be read as a green run.

## No /qa-finish

Waived deliberately. CLAUDE.md mandates `/qa-finish` after any feature with UI changes; this change is parser-internal (`grammar.py` plus tests) with no UI surface to walk, so there is no scenario to capture. Flagging explicitly so reviewers don't have to wonder why a repo that mandates it has a PR without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
