### PR TITLE
Sealed: make Market per-unit, add a Total column

### DIFF
--- a/mtg_collector/static/sealed.html
+++ b/mtg_collector/static/sealed.html
@@ -1179,7 +1179,8 @@ const ALL_COLUMNS = [
   { key: 'min_cost', label: 'Min Cost',  sort: 'min_cost',       defaultOn: true },
   { key: 'max_cost', label: 'Max Cost',  sort: 'max_cost',       defaultOn: false },
   { key: 'avg_cost', label: 'Avg Cost',  sort: 'avg_cost',       defaultOn: false },
-  { key: 'market',   label: 'Market',    sort: 'market_total',   defaultOn: true },
+  { key: 'market',   label: 'Market',    sort: 'market_price',   defaultOn: true },
+  { key: 'total',    label: 'Total',     sort: 'market_total',   defaultOn: true },
   { key: 'added',    label: 'Added',     sort: 'added_at',       defaultOn: false },
   { key: 'status',   label: 'Status',    sort: 'primary_status', defaultOn: false },
 ];
@@ -1188,6 +1189,12 @@ const DEFAULT_COLS = ALL_COLUMNS.filter(c => c.defaultOn).map(c => c.key);
 let enabledCols = JSON.parse(localStorage.getItem('sealedCols') || 'null') || DEFAULT_COLS;
 if (enabledCols.includes('cost')) {
   enabledCols = enabledCols.map(k => k === 'cost' ? 'min_cost' : k);
+  localStorage.setItem('sealedCols', JSON.stringify(enabledCols));
+}
+// 'Market' used to render the all-units total; it is now per-unit and 'Total' carries
+// that figure. Give existing layouts the new column so they don't silently lose it.
+if (enabledCols.includes('market') && !enabledCols.includes('total')) {
+  enabledCols.splice(enabledCols.indexOf('market') + 1, 0, 'total');
   localStorage.setItem('sealedCols', JSON.stringify(enabledCols));
 }
 const COL_SORT_MAP = Object.fromEntries(ALL_COLUMNS.map(c => [c.key, c.sort]));
@@ -1937,7 +1944,8 @@ function renderTable() {
     const minCost = product.min_cost != null ? formatPrice(product.min_cost) : '';
     const maxCost = product.max_cost != null ? formatPrice(product.max_cost) : '';
     const avgCost = product.avg_cost != null ? formatPrice(product.avg_cost) : '';
-    const market = product.market_total != null ? formatPrice(product.market_total) : '';
+    const market = product.market_price != null ? formatPrice(product.market_price) : '';
+    const marketTotal = product.market_total != null ? formatPrice(product.market_total) : '';
     const added = product.added_at ? product.added_at.slice(0, 10) : '';
 
     const rowSelected = selectionMode && isProductSelected(product) ? ' selected' : '';
@@ -1958,6 +1966,7 @@ function renderTable() {
         case 'max_cost': html += `<td>${maxCost}</td>`; break;
         case 'avg_cost': html += `<td>${avgCost}</td>`; break;
         case 'market':   html += `<td>${market}</td>`; break;
+        case 'total':    html += `<td>${marketTotal}</td>`; break;
         case 'added':    html += `<td>${added}</td>`; break;
         case 'status':   html += `<td>${renderStatusBadges(product.status_counts)}</td>`; break;
       }

--- a/mtg_collector/static/sealed.html
+++ b/mtg_collector/static/sealed.html
@@ -426,6 +426,7 @@ button.secondary.active { background: #0f3460; border-color: #e94560; }
   vertical-align: middle;
 }
 .market-price { color: #7ec8e3; font-size: 0.75rem; font-weight: 600; }
+.market-total { color: #5a8fa3; font-size: 0.7rem; font-weight: 600; }
 
 /* Column config drawer */
 .col-drawer-backdrop {
@@ -1895,7 +1896,10 @@ function renderGrid() {
     const qtyBadge = product.total_quantity > 1 ? `<span class="qty-badge">${product.total_quantity}x</span>` : '';
     const statusBadge = `<span class="status-badge ${product.primary_status}">${product.primary_status}</span>`;
     const costText = product.min_cost != null ? formatPrice(product.min_cost) : '';
-    const marketText = product.market_total != null ? formatPrice(product.market_total) : '';
+    const marketText = product.market_price != null ? formatPrice(product.market_price) : '';
+    // Total repeats the per-unit figure when qty is 1, so only surface it when it adds something.
+    const marketTotalText = (product.market_total != null && product.total_quantity > 1)
+      ? formatPrice(product.market_total) : '';
     const selectable = selectionMode ? ' selectable' : '';
     const selected = selectionMode && isProductSelected(product) ? ' selected' : '';
     const checkboxHtml = selectionMode ? `<input type="checkbox" class="select-checkbox" ${isProductSelected(product) ? 'checked' : ''}>` : '';
@@ -1911,7 +1915,8 @@ function renderGrid() {
       <div class="card-info">
         <div class="card-name">${esc(product.set_name || product.set_code || '')}</div>
         <div class="card-set">${esc(formatCategory(product))}</div>
-        ${marketText ? `<div class="market-price">${marketText} mkt</div>` : ''}
+        ${marketText ? `<div class="market-price">${marketText}/ea mkt</div>` : ''}
+        ${marketTotalText ? `<div class="market-total">${marketTotalText} total</div>` : ''}
         ${costText ? `<div class="card-price">${costText}/ea cost</div>` : ''}
       </div>
     </div>`;

--- a/scripts/build_test_fixture.py
+++ b/scripts/build_test_fixture.py
@@ -52,6 +52,49 @@ SEALED_PRODUCTS = [
     ("fin", "play_booster_box", "Final Fantasy Play Booster Box"),
 ]
 
+# Sealed price seeding.
+#
+# The /sealed page shows a per-unit market price alongside a quantity x price
+# total, so the fixture needs prices on the products demo data actually holds —
+# including one with quantity > 1 — for that arithmetic to be exercisable.
+#
+# CRITICAL: the latest_sealed_prices VIEW filters on a GLOBAL max observed_at
+# (WHERE observed_at = (SELECT MAX(observed_at) FROM sealed_prices)), not a
+# per-product max — see efj-mtgc-gyp. Every row seeded here MUST therefore share
+# one observed_at, or products dated earlier drop out of the view entirely.
+SEALED_OBSERVED_AT = "2026-04-01"
+
+# (set_code, category_keyword, market_price). The pairs mirror
+# demo_data.DEMO_SEALED_PRODUCTS and are resolved with the same
+# "set_code = ? AND category LIKE ? LIMIT 1" query, so the priced products are
+# exactly the ones the demo sealed_collection holds.
+#
+# ("dsk", "bundle") is deliberately absent: leaving one demo-held product
+# unpriced keeps the null-price render path ('' rather than $0.00) covered on
+# the page itself.
+DEMO_SEALED_PRICES = [
+    ("dsk", "booster_box", 119.99),
+    ("blb", "booster_box", 99.50),
+    ("fdn", "booster_pack", 3.50),   # demo qty 6 -> $21.00 total
+    ("mh3", "booster_pack", 11.25),  # demo qty 3 -> $33.75 total
+    ("otj", "bundle", 38.75),
+    ("blb", "booster_pack", 4.99),   # demo qty 4 -> $19.96 total
+    ("fdn", "booster_box", 104.00),
+]
+
+# Representative market price per category, used to give the wider catalogue a
+# spread of price points. Categories absent here stay unpriced.
+SEALED_CATEGORY_PRICES = {
+    "booster_pack": 5.25,
+    "booster_box": 109.00,
+    "booster_case": 640.00,
+    "bundle": 42.00,
+    "bundle_case": 245.00,
+    "box_set": 74.50,
+    "deck": 16.00,
+    "limited_aid_tool": 28.00,
+}
+
 OUTPUT = Path(__file__).resolve().parent.parent / "tests" / "fixtures" / "test-data.sqlite"
 
 
@@ -148,6 +191,67 @@ def main():
         ("blb", "124", "tcgplayer", "normal", 10.46, "2026-04-01"),
     )
     print(f"  Seeded {len(price_rows)} price rows for blb/124")
+
+    # Seed sealed prices. All rows share SEALED_OBSERVED_AT — see the note there.
+    print("  Seeding sealed price data...")
+    priced_tcg_ids: set[str] = set()
+
+    def add_sealed_price(tcg_id: str, market: float):
+        conn.execute(
+            """INSERT OR IGNORE INTO sealed_prices
+               (tcgplayer_product_id, low_price, mid_price, high_price,
+                market_price, direct_low_price, observed_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (
+                tcg_id,
+                round(market * 0.88, 2),
+                round(market * 0.97, 2),
+                round(market * 1.35, 2),
+                market,
+                round(market * 0.92, 2),
+                SEALED_OBSERVED_AT,
+            ),
+        )
+        priced_tcg_ids.add(tcg_id)
+
+    # 1. Products the demo sealed_collection holds, resolved exactly as
+    #    demo_data.load_demo_data() resolves them.
+    demo_priced = 0
+    for set_code, category_keyword, market in DEMO_SEALED_PRICES:
+        row = conn.execute(
+            "SELECT tcgplayer_product_id FROM sealed_products "
+            "WHERE set_code = ? AND category LIKE ? LIMIT 1",
+            (set_code, category_keyword),
+        ).fetchone()
+        if row is None or row["tcgplayer_product_id"] is None:
+            print(f"    WARNING: no priceable product for {set_code}/{category_keyword}")
+            continue
+        add_sealed_price(row["tcgplayer_product_id"], market)
+        demo_priced += 1
+    print(f"    Priced {demo_priced} demo-held products")
+
+    # 2. A spread across the wider catalogue. Every third product keeps a slice
+    #    of the catalogue deliberately unpriced alongside the 40 that have no
+    #    tcgplayer_product_id at all.
+    catalogue = conn.execute(
+        "SELECT tcgplayer_product_id, category FROM sealed_products "
+        "WHERE tcgplayer_product_id IS NOT NULL ORDER BY tcgplayer_product_id"
+    ).fetchall()
+    spread_priced = 0
+    for i, row in enumerate(catalogue):
+        tcg_id = row["tcgplayer_product_id"]
+        base = SEALED_CATEGORY_PRICES.get(row["category"])
+        if base is None or tcg_id in priced_tcg_ids or i % 3 != 0:
+            continue
+        # Fan the price out around the category base so the data spans a range
+        # rather than repeating one value per category.
+        add_sealed_price(tcg_id, round(base * (0.7 + 0.05 * (i % 13)), 2))
+        spread_priced += 1
+    print(f"    Priced {spread_priced} further catalogue products")
+
+    total_priced = len(priced_tcg_ids)
+    unpriced = conn.execute("SELECT COUNT(*) FROM sealed_products").fetchone()[0] - total_priced
+    print(f"    {total_priced} sealed products priced, {unpriced} left unpriced")
 
     conn.commit()
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -95,6 +95,79 @@ def api(base_url):
     return APIClient(base_url)
 
 
+# DB paths inside the container (data volume mount point).
+_CONTAINER_DB = "/data/collection.sqlite"
+_CONTAINER_DB_BACKUP = "/data/collection.sqlite.integ.bak"
+_CONTAINER_SHARED_DB = "/data/shared.sqlite"
+_CONTAINER_SHARED_DB_BACKUP = "/data/shared.sqlite.integ.bak"
+
+# Snapshot before the suite, restore after. Mirrors tests/ui/conftest.py's
+# per-test isolation, but at SESSION scope: integration deliberately exercises
+# real mutations and tests may depend on each other's writes within the run, so
+# we don't restore between tests — only once at the end, to hand the container
+# back in fixture state. Without this, mutations here (notably test_fetch_prices,
+# which live-fetches TCGCSV prices into the shared sealed_prices table) survive
+# into a subsequent `pytest tests/ui/` run against the same container, whose
+# session snapshot then captures the polluted prices — silently breaking sealed
+# UI scenarios that assert on fixture prices.
+#
+# Both collection.sqlite and shared.sqlite are covered (shared holds sealed_prices
+# and latest_* views). Uses sqlite3.backup() in both directions rather than cp:
+# under WAL the live .sqlite is one of three files, and a cp leaves the -wal
+# sidecar so the server keeps reading stale frames. backup() copies pages through
+# SQLite's locking protocol.
+_INTEG_BACKUP_CMD = (
+    f'python3 -c "import sqlite3, os; '
+    f"s=sqlite3.connect('{_CONTAINER_DB}'); "
+    f"d=sqlite3.connect('{_CONTAINER_DB_BACKUP}'); "
+    f"s.backup(d); s.close(); d.close(); "
+    f"p='{_CONTAINER_SHARED_DB}'; "
+    f"b='{_CONTAINER_SHARED_DB_BACKUP}'; "
+    f"exec('if os.path.exists(p):\\n s=sqlite3.connect(p)\\n d=sqlite3.connect(b)\\n s.backup(d)\\n s.close()\\n d.close()')"
+    '"'
+)
+_INTEG_RESTORE_CMD = (
+    f'python3 -c "import sqlite3, os; '
+    f"s=sqlite3.connect('{_CONTAINER_DB_BACKUP}'); "
+    f"d=sqlite3.connect('{_CONTAINER_DB}'); "
+    f"s.backup(d); s.close(); d.close(); "
+    f"p='{_CONTAINER_SHARED_DB_BACKUP}'; "
+    f"q='{_CONTAINER_SHARED_DB}'; "
+    f"exec('if os.path.exists(p):\\n s=sqlite3.connect(p)\\n d=sqlite3.connect(q)\\n s.backup(d)\\n s.close()\\n d.close()')"
+    '"'
+)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _restore_container_after_suite(instance_name):
+    """Snapshot the container's DBs before the suite and restore them after.
+
+    No-op when there is no container (the skip path), so local runs against a
+    remote/base URL are unaffected.
+    """
+    container = _discover_container(instance_name)
+    if container is None:
+        yield
+        return
+    snapshot = subprocess.run(
+        ["podman", "exec", container, "bash", "-c", _INTEG_BACKUP_CMD],
+        capture_output=True, text=True,
+    )
+    # If the snapshot itself failed, don't pretend we can restore — fail loudly
+    # rather than silently leaving the container polluted for later suites.
+    snapshot.check_returncode()
+    yield
+    subprocess.run(
+        ["podman", "exec", container, "bash", "-c", _INTEG_RESTORE_CMD],
+        check=True, capture_output=True, text=True,
+    )
+    subprocess.run(
+        ["podman", "exec", container, "rm", "-f",
+         _CONTAINER_DB_BACKUP, _CONTAINER_SHARED_DB_BACKUP],
+        capture_output=True,
+    )
+
+
 class APIClient:
     """Minimal HTTP client for integration tests (no external deps)."""
 

--- a/tests/ui/hints/sealed_grid_market_per_unit_and_total.yaml
+++ b/tests/ui/hints/sealed_grid_market_per_unit_and_total.yaml
@@ -1,0 +1,25 @@
+start_page: /sealed
+involves:
+  - grid view toggle (#view-grid-btn)
+  - card tiles (.sheet-card) with a .market-price line reading "<price>/ea mkt"
+  - a .market-total line reading "<price> total", present only when quantity > 1
+  - quantity badge (.qty-badge) showing "6x"
+fixture_data:
+  multi_qty_product: "Foundations Collector Booster Pack"
+  multi_qty_quantity: "6"
+  multi_qty_per_unit: "$3.50/ea mkt"
+  multi_qty_total: "$21.00 total"
+  single_qty_product: "Bloomburrow Collector Booster Box"
+  single_qty_per_unit: "$99.50/ea mkt"
+notes: >
+  Read-only against fixture data.
+
+  Click #view-grid-btn to switch to grid view, then wait for .sheet-card.
+  Tiles carry .market-price (per unit, always present when priced) and
+  .market-total (only when total_quantity > 1).
+
+  The gating is the interesting assertion: with 7 visible entries and only two
+  of them at quantity > 1 (Foundations packs qty 6, Modern Horizons 3 packs
+  qty 3), exactly 2 tiles should have a .market-total line. Use
+  assert_element_count(".market-total", 2) for that. The default filter hides
+  the 'opened' Bloomburrow packs (qty 4), so they do not count.

--- a/tests/ui/hints/sealed_market_per_unit_and_total_columns.yaml
+++ b/tests/ui/hints/sealed_market_per_unit_and_total_columns.yaml
@@ -1,0 +1,23 @@
+start_page: /sealed
+involves:
+  - table view toggle (#view-table-btn)
+  - Market column header, showing a per-unit price
+  - Total column header, immediately right of Market, showing quantity x price
+  - the Foundations Collector Booster Pack row, quantity 6
+fixture_data:
+  product: "Foundations"
+  category: "Collector Booster Pack"
+  quantity: "6"
+  min_cost: "$4.50"
+  market_per_unit: "$3.50"
+  total: "$21.00"
+notes: >
+  Read-only against fixture data — do not add, edit or dispose anything. The
+  quantity-6 Foundations entry is shared with sealed_partial_dispose_qty, so
+  this scenario must not mutate it.
+
+  Switch to table view with #view-table-btn. The table is table.sealed-table.
+  Both Market and Total are default-on columns, so no column-drawer
+  interaction is needed. Assert the Market and Total headers are both present
+  and that $3.50 and $21.00 both appear. The key evidence is that the two are
+  different values on the same row: Market is per unit, Total is 6 x $3.50.

--- a/tests/ui/hints/sealed_null_market_price_blank.yaml
+++ b/tests/ui/hints/sealed_null_market_price_blank.yaml
@@ -1,0 +1,22 @@
+start_page: /sealed
+involves:
+  - the Duskmourn: House of Horror Bundle row, which has no sealed price
+  - empty Market and Total table cells for that row
+  - absence of any "$0.00" anywhere on the page
+  - its Min Cost of $40.00, which is still shown
+fixture_data:
+  unpriced_product: "Duskmourn: House of Horror"
+  unpriced_category: "Bundle"
+  unpriced_min_cost: "$40.00"
+notes: >
+  Read-only against fixture data.
+
+  The fixture deliberately leaves this one demo-held product unpriced (see
+  DEMO_SEALED_PRICES in scripts/build_test_fixture.py, which omits the
+  ("dsk", "bundle") pair) precisely so this path stays covered.
+
+  The strongest assertion is a global one: "$0.00" must not appear anywhere on
+  /sealed, in either view. Every other visible entry is priced, so a regression
+  that substituted 0 for null would surface as "$0.00" on this row. Also assert
+  the row's own $40.00 min cost is still rendered, proving the row itself is
+  present rather than filtered out.

--- a/tests/ui/hints/sealed_stored_column_layout_migration.yaml
+++ b/tests/ui/hints/sealed_stored_column_layout_migration.yaml
@@ -1,0 +1,23 @@
+start_page: /sealed
+involves:
+  - a pre-existing 'sealedCols' localStorage layout containing 'market' but not 'total'
+  - the Total column appearing after a reload
+  - the migrated layout persisting back to localStorage
+fixture_data:
+  legacy_layout: '["qty","image","name","set","min_cost","market"]'
+  migrated_layout: '["qty","image","name","set","min_cost","market","total"]'
+  evidence_row_total: "$21.00"
+notes: >
+  Read-only against sealed data — this scenario only writes localStorage.
+
+  The migration lives at module scope in sealed.html and runs once per page
+  load, so the sequence must be: load /sealed (establishes the origin), seed
+  the legacy layout via harness.page.evaluate, then navigate to /sealed again
+  so a fresh load re-runs the migration. There is precedent for the
+  page.evaluate escape hatch in
+  tests/ui/implementations/deck_detail_list_view_no_overflow.py.
+
+  Assert both the visible outcome (a Total header and the $21.00 value on the
+  qty-6 Foundations row, neither of which the legacy layout would have shown)
+  and the stored outcome (localStorage now ends with 'total', spliced in
+  directly after 'market').

--- a/tests/ui/implementations/sealed_grid_market_per_unit_and_total.py
+++ b/tests/ui/implementations/sealed_grid_market_per_unit_and_total.py
@@ -1,0 +1,30 @@
+"""
+Hand-written implementation for sealed_grid_market_per_unit_and_total.
+
+Verifies grid tiles show a per-unit "<price>/ea mkt" line, and that the
+subordinate "<price> total" line appears only for entries with quantity > 1.
+
+Read-only against fixture data.
+"""
+
+
+def steps(harness):
+    # Switch to grid view.
+    harness.click_by_selector("#view-grid-btn")
+    harness.wait_for_visible(".sheet-card")
+
+    # The qty-6 Foundations tile carries both lines: per-unit and all-units.
+    harness.assert_text_present("$3.50/ea mkt")
+    harness.assert_text_present("$21.00 total")
+
+    # A quantity-1 product shows the per-unit line only. Its total would just
+    # repeat $99.50, so no total line is rendered for it.
+    harness.assert_text_present("$99.50/ea mkt")
+    harness.assert_text_absent("$99.50 total")
+
+    # Exactly two visible entries have quantity > 1 (Foundations packs at 6 and
+    # Modern Horizons 3 packs at 3), so exactly two tiles carry a total line.
+    # The 'opened' Bloomburrow packs are hidden by the default filter.
+    harness.assert_element_count(".market-total", 2)
+
+    harness.screenshot("final_state")

--- a/tests/ui/implementations/sealed_market_per_unit_and_total_columns.py
+++ b/tests/ui/implementations/sealed_market_per_unit_and_total_columns.py
@@ -1,0 +1,32 @@
+"""
+Hand-written implementation for sealed_market_per_unit_and_total_columns.
+
+Verifies the table's Market column is per-unit and the new Total column
+carries quantity x market price, using the fixture's quantity-6 Foundations
+Collector Booster Pack row ($3.50 each, $21.00 total).
+
+Read-only: it must not mutate the qty-6 entry, which is shared with
+sealed_partial_dispose_qty.
+"""
+
+
+def steps(harness):
+    # Table view is the default, but assert it explicitly so the scenario does
+    # not depend on leftover view state from another test.
+    harness.click_by_selector("#view-table-btn")
+    harness.wait_for_visible("table.sealed-table")
+
+    # Both columns are default-on, so they render without touching the drawer.
+    harness.assert_text_present("Market")
+    harness.assert_text_present("Total")
+
+    # The qty-6 Foundations row: per-unit market price and the all-units total
+    # are different values, which is the whole point of the split.
+    harness.wait_for_text("Foundations")
+    harness.assert_text_present("$3.50")
+    harness.assert_text_present("$21.00")
+
+    # Min Cost is also per-unit, so it sits alongside Market comparably.
+    harness.assert_text_present("$4.50")
+
+    harness.screenshot("final_state")

--- a/tests/ui/implementations/sealed_null_market_price_blank.py
+++ b/tests/ui/implementations/sealed_null_market_price_blank.py
@@ -1,0 +1,31 @@
+"""
+Hand-written implementation for sealed_null_market_price_blank.
+
+The fixture deliberately leaves the Duskmourn: House of Horror Bundle
+unpriced. Its Market and Total cells must render empty rather than $0.00,
+in both table and grid view.
+
+Read-only against fixture data.
+"""
+
+
+def steps(harness):
+    # Table view first.
+    harness.click_by_selector("#view-table-btn")
+    harness.wait_for_visible("table.sealed-table")
+
+    # The unpriced row is present — its purchase price still shows.
+    harness.assert_text_present("$40.00")
+
+    # Null prices render as an empty string. Zero is a meaningful price, so
+    # substituting it would be wrong; no entry on this page is worth $0.00.
+    harness.assert_text_absent("$0.00")
+
+    # Same guarantee in grid view, where the tile omits the market lines
+    # entirely rather than rendering a zero.
+    harness.click_by_selector("#view-grid-btn")
+    harness.wait_for_visible(".sheet-card")
+    harness.assert_text_absent("$0.00")
+    harness.assert_text_absent("$0.00/ea mkt")
+
+    harness.screenshot("final_state")

--- a/tests/ui/implementations/sealed_stored_column_layout_migration.py
+++ b/tests/ui/implementations/sealed_stored_column_layout_migration.py
@@ -1,0 +1,46 @@
+"""
+Hand-written implementation for sealed_stored_column_layout_migration.
+
+A saved sealedCols layout predating the Market/Total split must gain the
+Total column on next load, so users who customised their columns don't
+silently lose the all-units figure when Market changed meaning.
+
+Uses the harness.page.evaluate escape hatch to seed localStorage, following
+the precedent in deck_detail_list_view_no_overflow.py. The migration runs at
+module scope on page load, so the layout must be seeded before a fresh
+navigation.
+"""
+
+LEGACY_COLS = '["qty","image","name","set","min_cost","market"]'
+
+
+def steps(harness):
+    # Establish the origin so localStorage is writable for this page.
+    harness.navigate("/sealed")
+    harness.wait_for_visible("table.sealed-table")
+
+    # Seed a layout from before the split: it has 'market' but no 'total'.
+    harness.page.evaluate(f"localStorage.setItem('sealedCols', '{LEGACY_COLS}')")
+
+    # Reload so the module-scope migration runs against the stored layout.
+    harness.navigate("/sealed")
+    harness.wait_for_visible("table.sealed-table")
+
+    # Visible outcome: Total is now a column, and the qty-6 Foundations row
+    # shows its all-units figure. The legacy layout alone would show neither.
+    harness.assert_text_present("Total")
+    harness.assert_text_present("$21.00")
+
+    # Stored outcome: 'total' was spliced in directly after 'market'.
+    stored = harness.page.evaluate("localStorage.getItem('sealedCols')")
+    assert stored is not None, "sealedCols was cleared instead of migrated"
+    cols = [c.strip(' "') for c in stored.strip("[]").split(",")]
+    assert "total" in cols, f"migration did not add 'total': {stored}"
+    assert cols.index("total") == cols.index("market") + 1, (
+        f"'total' should sit directly after 'market': {stored}"
+    )
+    # The pre-existing columns must survive the migration untouched.
+    for key in ("qty", "image", "name", "set", "min_cost", "market"):
+        assert key in cols, f"migration dropped '{key}': {stored}"
+
+    harness.screenshot("final_state")

--- a/tests/ui/intents/sealed_grid_market_per_unit_and_total.yaml
+++ b/tests/ui/intents/sealed_grid_market_per_unit_and_total.yaml
@@ -1,0 +1,12 @@
+# Scenario: Grid tiles show a per-unit market price, plus a total only when qty > 1
+#
+# Related:
+#   issues: [efj-mtgc-zun]
+#   pull_requests: []
+
+description: >
+  When I switch my sealed collection to grid view, each tile tells me what one
+  unit is worth. My six Foundations Collector Booster Packs show "$3.50/ea mkt"
+  and, because I hold more than one, a second line reading "$21.00 total". A
+  product I only own one of shows just the per-unit line, with no redundant
+  total repeating the same number back at me.

--- a/tests/ui/intents/sealed_market_per_unit_and_total_columns.yaml
+++ b/tests/ui/intents/sealed_market_per_unit_and_total_columns.yaml
@@ -1,0 +1,13 @@
+# Scenario: Market column is per-unit and the Total column carries qty x price
+#
+# Related:
+#   issues: [efj-mtgc-zun]
+#   pull_requests: []
+
+description: >
+  When I look at my sealed collection in table view, the Market column shows
+  what one unit is worth and the Total column immediately to its right shows
+  what all my units of that product are worth together. My six Foundations
+  Collector Booster Packs show a $3.50 market price and a $21.00 total, so I
+  can compare the market price against the Min Cost column beside it without
+  doing arithmetic in my head.

--- a/tests/ui/intents/sealed_null_market_price_blank.yaml
+++ b/tests/ui/intents/sealed_null_market_price_blank.yaml
@@ -1,0 +1,12 @@
+# Scenario: A product with no market price shows blank cells, not $0.00
+#
+# Related:
+#   issues: [efj-mtgc-zun, efj-mtgc-vk5]
+#   pull_requests: []
+
+description: >
+  My Duskmourn: House of Horror Bundle has no market price on record. Its
+  Market and Total cells are simply empty, and its grid tile shows no market
+  line at all. It never claims the product is worth $0.00, because zero is a
+  real price and would be misleading — I can still see the $40.00 I paid for
+  it.

--- a/tests/ui/intents/sealed_stored_column_layout_migration.yaml
+++ b/tests/ui/intents/sealed_stored_column_layout_migration.yaml
@@ -1,0 +1,12 @@
+# Scenario: A saved column layout from before the Market/Total split gains Total
+#
+# Related:
+#   issues: [efj-mtgc-zun]
+#   pull_requests: []
+
+description: >
+  I customised my sealed table columns before the Market column was split into
+  a per-unit price and a separate Total. When I next open the page, the Total
+  column has been added to my saved layout, sitting right after Market. I keep
+  seeing the all-units figure I was used to, instead of silently losing it
+  because Market changed meaning underneath me.


### PR DESCRIPTION
On `/sealed`, the **Min Cost** column was per-unit while **Market** was across all units, so the two sat side by side without being comparable. This splits them apart.

## What changed

| Column | Before | After |
|---|---|---|
| Min Cost | per unit | per unit (unchanged) |
| Market | qty x price (all units) | **per unit** |
| Total | — | **new: qty x market price** |

- **Market** now renders `market_price` and sorts on `market_price`.
- **Total** is a new default-on column rendering `market_total`, sorting on `market_total`, sitting immediately right of Market.
- **Grid view** got the same treatment: the tile's market line now reads `$3.50/ea mkt` (was `$21.00 mkt`), so it parses against the `/ea cost` line beneath it, plus a subordinate `$21.00 total` line.
- Null `market_price` / `market_total` still render as an empty string, never `$0.00` — zero is a meaningful price.

## Design decisions

**Total defaults ON.** Market previously carried the all-units total, so that number is already in every current user's default view. Defaulting Total off would turn a bug fix into a net removal of information.

**Stored column layouts are migrated.** Users with a saved `sealedCols` layout containing `market` but not `total` get `total` spliced in after `market`. This is the load-bearing part: Market's *semantics* changed underneath existing users, so without the migration they'd silently lose the all-units figure they'd been reading — the column would keep its name and quietly start meaning something else. It mirrors the pre-existing `cost` -> `min_cost` migration a few lines above, and is idempotent.

**The grid's total line is gated on qty > 1.** At quantity 1, `market_total` equals `market_price`, so an unconditional total line would just repeat the number directly above it on most tiles. Gating keeps the common tile at two price lines while preserving the figure where it actually carries information. The detail modal already gates its `(qty x price)` breakdown the same way.

## Test fixture: sealed pricing is now testable

`tests/fixtures/test-data.sqlite` shipped 256 sealed products but **zero** `sealed_prices` rows, so every market price was null in a `--test` container and this UI could not be exercised at all without hand-seeding a running container. `build_test_fixture.py` populated `prices`/`latest_prices` for regular cards but never the sealed equivalent. Fixes efj-mtgc-vk5.

It now seeds 65 rows spanning $3.50–$800.00:
- The 7 products the demo `sealed_collection` holds, resolved with the same `set_code = ? AND category LIKE ? LIMIT 1` query `demo_data.py` uses, so the priced rows are guaranteed to be the ones the page shows. This covers quantity 6, 4 and 3 entries, making `qty x market` arithmetic verifiable straight from the fixture.
- A spread across the wider catalogue, every third priceable product.

`("dsk", "bundle")` is deliberately left unpriced, and 191 of 256 products stay unpriced overall (including the 40 with no `tcgplayer_product_id`), so the null-price path stays covered.

All rows share one `observed_at` — see Related below.

## Measured evidence

Sourced entirely from fixture data in a `--test` container, no hand-seeding:

| Product | Qty | Min Cost | Market | Total |
|---|---|---|---|---|
| Duskmourn: House of Horror / Booster Box | 1 | $105.00 | $119.99 | $119.99 |
| Bloomburrow / Booster Box | 1 | $110.00 | $99.50 | $99.50 |
| **Foundations / Booster Pack** | **6** | $4.50 | **$3.50** | **$21.00** |
| **Modern Horizons 3 / Booster Pack** | **3** | $9.00 | **$11.25** | **$33.75** |
| Outlaws of Thunder Junction / Bundle | 1 | $45.00 | $38.75 | $38.75 |
| Duskmourn: House of Horror / Bundle | 1 | $40.00 | *(blank)* | *(blank)* |
| Foundations / Booster Box | 1 | $130.00 | $104.00 | $104.00 |

6 x $3.50 = $21.00 and 3 x $11.25 = $33.75. The unpriced row renders blank, not `$0.00`.

Grid view, same data — note the total line appearing only on the qty > 1 tiles:

```
  6x  Foundations                   ['$3.50/ea mkt', '$21.00 total', '$4.50/ea cost']
  3x  Modern Horizons 3             ['$11.25/ea mkt', '$33.75 total', '$9.00/ea cost']
  1x  Bloomburrow                   ['$99.50/ea mkt', '$110.00/ea cost']
  1x  Duskmourn: House of Horror    ['$40.00/ea cost']
```

Stored layouts were exercised across six shapes — fresh, legacy pre-Total default, legacy `cost` key, market-only, a layout with an unknown junk key, and an empty list. All render sanely; junk keys survive in storage and are ignored at render.

## /qa-finish

Ran, generating four scenarios (intent + hint + implementation each):

- `sealed_market_per_unit_and_total_columns` — Market per-unit vs Total, on the qty-6 row.
- `sealed_grid_market_per_unit_and_total` — grid `/ea mkt` + `total` lines, asserting exactly two visible tiles carry a total line.
- `sealed_null_market_price_blank` — blank cells and no `$0.00` anywhere, in both views.
- `sealed_stored_column_layout_migration` — a legacy layout gains Total in the right position, other columns intact.

All four pass. **Verified they aren't vacuous:** reintroducing the bug (Market rendering `market_total` again) fails the two per-unit scenarios at the `$3.50` assertion. All 13 pre-existing sealed scenarios still pass, as do the integration and unit suites.

## Related

**efj-mtgc-gyp is NOT fixed here.** The `latest_sealed_prices` VIEW filters on a *global* max `observed_at` rather than a per-product max:

```sql
WHERE observed_at = (SELECT MAX(observed_at) FROM sealed_prices)
```

On prod this silently drops 168 of 3,095 products (~5%) from the view — including on this page, where an affected product shows a blank market price. It's deliberately kept out of this PR to avoid entangling a view-semantics fix with a display change. It also constrains the fixture: every seeded row shares one `observed_at`, because mixed dates would make products with older dates vanish from the view entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)