### PR TITLE
Make replay text assertions wait instead of sampling instantaneously

### DIFF
--- a/tests/test_replay_text_assertions.py
+++ b/tests/test_replay_text_assertions.py
@@ -1,0 +1,97 @@
+"""Regression tests for the replay harness's text assertions (efj-mtgc-h9z).
+
+Both assertions previously sampled ``page.get_by_text(text).count()`` with no
+waiting.  On a page that renders from an async fetch that races the render:
+
+* ``assert_text_present`` fails even though the text arrives moments later.
+* ``assert_text_absent`` passes *vacuously* — nothing has rendered, so the
+  count is trivially 0 and the assertion proves nothing.
+
+These use a fake page that models an async render, so they are deterministic
+rather than load-dependent.
+"""
+
+import pytest
+
+from tests.ui.replay import ReplayHarness, ReplayStepError
+
+
+class _FakeLocator:
+    def __init__(self, page, text):
+        self._page, self._text = page, text
+
+    @property
+    def first(self):
+        return self
+
+    def count(self):
+        return 1 if self._text in self._page.rendered else 0
+
+    def wait_for(self, state=None, timeout=None):
+        """Model Playwright auto-waiting: the pending render lands."""
+        self._page.flush()
+        if self._text not in self._page.rendered:
+            raise TimeoutError(f"waiting for {self._text}")
+
+
+class _FakePage:
+    """A page whose content only appears once something waits for it."""
+
+    def __init__(self, pending=()):
+        self.rendered, self.pending = set(), set(pending)
+        self.settled = False
+
+    def flush(self):
+        self.rendered |= self.pending
+        self.pending = set()
+
+    def get_by_text(self, text, exact=False):
+        return _FakeLocator(self, text)
+
+    # Harness plumbing the assertions touch.
+    def wait_for_timeout(self, ms):
+        self.settled = True
+        self.flush()
+
+    def wait_for_load_state(self, state, timeout=None):
+        pass
+
+    def screenshot(self, **kw):
+        return b""
+
+    def evaluate(self, js):
+        return []
+
+
+def _harness(page, tmp_path):
+    return ReplayHarness(page, "https://x", tmp_path, "fake_scenario")
+
+
+def test_present_waits_for_async_render(tmp_path):
+    """Text arriving after the assertion starts must still pass."""
+    page = _FakePage(pending={"$3.50"})
+    assert page.get_by_text("$3.50").count() == 0, "precondition: not yet rendered"
+
+    _harness(page, tmp_path).assert_text_present("$3.50")
+
+
+def test_present_still_fails_when_text_never_arrives(tmp_path):
+    """Waiting must not paper over genuinely missing text."""
+    page = _FakePage()
+    with pytest.raises(ReplayStepError):
+        _harness(page, tmp_path).assert_text_present("$3.50")
+
+
+def test_absent_is_not_vacuous_on_unrendered_page(tmp_path):
+    """Text pending render must be caught, not passed over."""
+    page = _FakePage(pending={"$21.00"})
+    assert page.get_by_text("$21.00").count() == 0, "precondition: not yet rendered"
+
+    with pytest.raises(ReplayStepError):
+        _harness(page, tmp_path).assert_text_absent("$21.00")
+
+
+def test_absent_passes_for_genuinely_missing_text(tmp_path):
+    page = _FakePage(pending={"something else"})
+    _harness(page, tmp_path).assert_text_absent("$21.00")
+    assert page.settled, "absent assertion must settle the page before counting"

--- a/tests/ui/replay.py
+++ b/tests/ui/replay.py
@@ -13,6 +13,11 @@ from pathlib import Path
 
 from .harness import EXTRACT_ELEMENTS_JS
 
+# Text assertions wait for async renders rather than sampling instantaneously.
+# Every other harness call passes timeout=500 to Playwright; these two used a
+# bare count() and raced page updates under load (efj-mtgc-h9z).
+TEXT_ASSERT_TIMEOUT_MS = 5_000
+
 log = logging.getLogger(__name__)
 
 
@@ -171,15 +176,35 @@ class ReplayHarness:
             self._fail(f"Expected hidden: {selector}")
         self._snap()
 
-    def assert_text_present(self, text: str):
+    def assert_text_present(self, text: str, timeout: int = TEXT_ASSERT_TIMEOUT_MS):
+        """Assert text is in the DOM, waiting for async renders to land.
+
+        Uses Playwright's auto-waiting rather than an instantaneous count():
+        pages that populate from a fetch would otherwise lose the race under
+        load and fail with no relation to the code under test.
+
+        Waits on "attached" rather than "visible" to preserve the previous
+        count() semantics, which counted DOM nodes regardless of visibility.
+        """
         self._record("assert_text_present", text)
-        count = self.page.get_by_text(text).count()
-        if count == 0:
+        try:
+            self.page.get_by_text(text).first.wait_for(
+                state="attached", timeout=timeout
+            )
+        except Exception:
             self._fail(f"Expected text present: {text}")
         self._snap()
 
     def assert_text_absent(self, text: str):
+        """Assert text is not in the DOM, after letting the page settle.
+
+        _settle() first is load-bearing: an instantaneous count() on a page
+        that has not rendered yet returns 0 and passes vacuously, asserting
+        nothing. Settling means a pass reflects genuinely-absent text rather
+        than an unrendered page.
+        """
         self._record("assert_text_absent", text)
+        self._settle()
         count = self.page.get_by_text(text).count()
         if count > 0:
             self._fail(f"Expected text absent but found {count} matches: {text}")


### PR DESCRIPTION
`assert_text_present` and `assert_text_absent` in `tests/ui/replay.py` both called `page.get_by_text(text).count()` — an instantaneous sample with **no timeout and no auto-wait**, unlike every other harness method (which passes `timeout=500` to Playwright). On any page rendering from an async fetch, the assertion raced the render.

## How this surfaced

PR #271 failed CI twice on three sealed scenarios. The branch was fine — I built it standalone and `$3.50` / `$21.00` rendered correctly, and a sampler polling `shared.sqlite` throughout a full local suite run showed `sealed_prices` held at 65 the entire time, never dropping.

The tell was the failure pattern:

| scenario | assertion | result |
|---|---|---|
| `sealed_grid_market_per_unit_and_total` | text **present** | FAILED 1.5s |
| `sealed_market_per_unit_and_total_columns` | text **present** | FAILED 1.6s |
| `sealed_stored_column_layout_migration` | text **present** | FAILED 3.3s |
| `sealed_null_market_price_blank` | text **absent** | PASSED 2.1s |

`assert_text_absent` was the more insidious half. On an unrendered page `count()` returns 0, so it passes **vacuously** — asserting nothing. That is exactly why the one absent-assertion scenario stayed green while its three siblings failed: it wasn't confirming the text was legitimately missing, only that nothing had rendered yet.

## The change

- **`assert_text_present`** waits via Playwright auto-waiting (`wait_for(state="attached")`, 5s). `attached` rather than `visible` is deliberate — it preserves the old `count()` semantics, which counted DOM nodes regardless of visibility, so no existing scenario changes meaning.
- **`assert_text_absent`** calls `_settle()` first, so a pass reflects genuinely-absent text rather than an unrendered page.
- Adds `TEXT_ASSERT_TIMEOUT_MS = 5_000` — the named constant proposed in `efj-mtgc-ckq` and closed there as unnecessary. This is evidence it wasn't.

## Verification

`tests/test_replay_text_assertions.py` uses a fake page modelling an async render, so it is deterministic rather than load-dependent. Verified in both directions per CLAUDE.md:

```
                                              before   after
present waits for async render                 FAIL     pass
present still fails when text never arrives    pass     pass   <- control
absent not vacuous on unrendered page          FAIL     pass
absent settles before counting                 FAIL     pass
```

The control row passes either way, confirming the fix does not paper over genuinely missing text.

All **11 scenarios using `assert_text_absent`** were run against a live container, since this change makes them stricter and could have surfaced real failures. All 11 pass — none were relying on the vacuous behaviour.

Unit suite exit 0; `ruff check mtg_collector/` clean.

## Note

**#271 should go green once this lands** — that branch was never broken. It needs this merged, or a rebase onto it.

Closes efj-mtgc-h9z.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
