### PR TITLE
Fix connection leaks wedging all DB writes across 33 handlers

### DIFF
--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -7050,36 +7050,40 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             color=data.get("color"), binder_type=data.get("binder_type"),
             storage_location=data.get("storage_location"),
         )
-        binder_id = repo.add(binder)
-        conn.commit()
-        result = repo.get(binder_id)
-        conn.close()
+        try:
+            binder_id = repo.add(binder)
+            conn.commit()
+            result = repo.get(binder_id)
+        finally:
+            conn.close()
         self._send_json(result, 201)
 
     def _api_binder_update(self, binder_id: int, data: dict):
         conn = self._get_conn()
         from mtg_collector.db.models import BinderRepository
         repo = BinderRepository(conn)
-        if not repo.get(binder_id):
+        try:
+            if not repo.get(binder_id):
+                self._send_json({"error": "Binder not found"}, 404)
+                return
+            repo.update(binder_id, data)
+            conn.commit()
+            result = repo.get(binder_id)
+        finally:
             conn.close()
-            self._send_json({"error": "Binder not found"}, 404)
-            return
-        repo.update(binder_id, data)
-        conn.commit()
-        result = repo.get(binder_id)
-        conn.close()
         self._send_json(result)
 
     def _api_binder_delete(self, binder_id: int):
         conn = self._get_conn()
         from mtg_collector.db.models import BinderRepository
         repo = BinderRepository(conn)
-        if not repo.delete(binder_id):
+        try:
+            if not repo.delete(binder_id):
+                self._send_json({"error": "Binder not found"}, 404)
+                return
+            conn.commit()
+        finally:
             conn.close()
-            self._send_json({"error": "Binder not found"}, 404)
-            return
-        conn.commit()
-        conn.close()
         self._send_json({"ok": True})
 
     def _api_binder_cards(self, binder_id: int):
@@ -7172,38 +7176,42 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             id=None, name=name, description=data.get("description"),
             filters_json=filters_json,
         )
-        view_id = repo.add(view)
-        conn.commit()
-        result = repo.get(view_id)
-        conn.close()
+        try:
+            view_id = repo.add(view)
+            conn.commit()
+            result = repo.get(view_id)
+        finally:
+            conn.close()
         self._send_json(result, 201)
 
     def _api_view_update(self, view_id: int, data: dict):
         conn = self._get_conn()
         from mtg_collector.db.models import CollectionViewRepository
         repo = CollectionViewRepository(conn)
-        if not repo.get(view_id):
+        try:
+            if not repo.get(view_id):
+                self._send_json({"error": "View not found"}, 404)
+                return
+            if "filters_json" in data and isinstance(data["filters_json"], dict):
+                data["filters_json"] = json.dumps(data["filters_json"])
+            repo.update(view_id, data)
+            conn.commit()
+            result = repo.get(view_id)
+        finally:
             conn.close()
-            self._send_json({"error": "View not found"}, 404)
-            return
-        if "filters_json" in data and isinstance(data["filters_json"], dict):
-            data["filters_json"] = json.dumps(data["filters_json"])
-        repo.update(view_id, data)
-        conn.commit()
-        result = repo.get(view_id)
-        conn.close()
         self._send_json(result)
 
     def _api_view_delete(self, view_id: int):
         conn = self._get_conn()
         from mtg_collector.db.models import CollectionViewRepository
         repo = CollectionViewRepository(conn)
-        if not repo.delete(view_id):
+        try:
+            if not repo.delete(view_id):
+                self._send_json({"error": "View not found"}, 404)
+                return
+            conn.commit()
+        finally:
             conn.close()
-            self._send_json({"error": "View not found"}, 404)
-            return
-        conn.commit()
-        conn.close()
         self._send_json({"ok": True})
 
     def _api_shorten(self, params):

--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -7266,45 +7266,46 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             return
 
         conn = self._get_conn()
-        init_db(conn)
+        try:
+            init_db(conn)
 
-        card_repo = CardRepository(conn)
-        printing_repo = PrintingRepository(conn)
+            card_repo = CardRepository(conn)
+            printing_repo = PrintingRepository(conn)
 
-        card = card_repo.get_by_name(name) or card_repo.search_by_name(name)
-        if not card:
+            card = card_repo.get_by_name(name) or card_repo.search_by_name(name)
+            if not card:
+                self._send_json({"error": f"No card found matching '{name}' (run `mtg cache all` to populate)"}, 404)
+                return
+
+            oracle_id = card.oracle_id
+            set_code = data.get("set_code")
+            printing_id = None
+
+            if set_code:
+                cn = data.get("collector_number")
+                printings = printing_repo.get_by_oracle_id(oracle_id)
+                for p in printings:
+                    if p.set_code == set_code.lower():
+                        if cn and p.collector_number != cn:
+                            continue
+                        printing_id = p.printing_id
+                        break
+
+            repo = WishlistRepository(conn)
+            entry = WishlistEntry(
+                id=None,
+                oracle_id=oracle_id,
+                printing_id=printing_id,
+                max_price=data.get("max_price"),
+                priority=data.get("priority", 0),
+                notes=data.get("notes"),
+                added_at=now_iso(),
+                source="server",
+            )
+            new_id = repo.add(entry)
+            conn.commit()
+        finally:
             conn.close()
-            self._send_json({"error": f"No card found matching '{name}' (run `mtg cache all` to populate)"}, 404)
-            return
-
-        oracle_id = card.oracle_id
-        set_code = data.get("set_code")
-        printing_id = None
-
-        if set_code:
-            cn = data.get("collector_number")
-            printings = printing_repo.get_by_oracle_id(oracle_id)
-            for p in printings:
-                if p.set_code == set_code.lower():
-                    if cn and p.collector_number != cn:
-                        continue
-                    printing_id = p.printing_id
-                    break
-
-        repo = WishlistRepository(conn)
-        entry = WishlistEntry(
-            id=None,
-            oracle_id=oracle_id,
-            printing_id=printing_id,
-            max_price=data.get("max_price"),
-            priority=data.get("priority", 0),
-            notes=data.get("notes"),
-            added_at=now_iso(),
-            source="server",
-        )
-        new_id = repo.add(entry)
-        conn.commit()
-        conn.close()
 
         self._send_json({"id": new_id, "name": card.name, "oracle_id": oracle_id, "printing_id": printing_id})
 
@@ -7325,52 +7326,54 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             return
 
         conn = self._get_conn()
-        init_db(conn)
+        try:
+            init_db(conn)
 
-        card_repo = CardRepository(conn)
-        printing_repo = PrintingRepository(conn)
-        wishlist_repo = WishlistRepository(conn)
+            card_repo = CardRepository(conn)
+            printing_repo = PrintingRepository(conn)
+            wishlist_repo = WishlistRepository(conn)
 
-        added = []
-        errors = []
+            added = []
+            errors = []
 
-        for item in cards:
-            name = (item.get("name") or "").strip()
-            if not name:
-                errors.append({"name": name, "error": "name is required"})
-                continue
-            set_code = item.get("set_code")
-            cn = item.get("collector_number")
-            try:
-                card = card_repo.get_by_name(name) or card_repo.search_by_name(name)
-                if not card:
-                    errors.append({"name": name, "error": f"No card found matching '{name}'"})
+            for item in cards:
+                name = (item.get("name") or "").strip()
+                if not name:
+                    errors.append({"name": name, "error": "name is required"})
                     continue
-                oracle_id = card.oracle_id
-                printing_id = None
-                if set_code:
-                    printings = printing_repo.get_by_oracle_id(oracle_id)
-                    for p in printings:
-                        if p.set_code == set_code.lower():
-                            if cn and p.collector_number != cn:
-                                continue
-                            printing_id = p.printing_id
-                            break
-                entry = WishlistEntry(
-                    id=None,
-                    oracle_id=oracle_id,
-                    printing_id=printing_id,
-                    priority=item.get("priority", 0),
-                    added_at=now_iso(),
-                    source="server",
-                )
-                new_id = wishlist_repo.add(entry)
-                added.append({"id": new_id, "name": card.name, "oracle_id": oracle_id, "printing_id": printing_id})
-            except Exception as exc:
-                errors.append({"name": name, "error": str(exc)})
+                set_code = item.get("set_code")
+                cn = item.get("collector_number")
+                try:
+                    card = card_repo.get_by_name(name) or card_repo.search_by_name(name)
+                    if not card:
+                        errors.append({"name": name, "error": f"No card found matching '{name}'"})
+                        continue
+                    oracle_id = card.oracle_id
+                    printing_id = None
+                    if set_code:
+                        printings = printing_repo.get_by_oracle_id(oracle_id)
+                        for p in printings:
+                            if p.set_code == set_code.lower():
+                                if cn and p.collector_number != cn:
+                                    continue
+                                printing_id = p.printing_id
+                                break
+                    entry = WishlistEntry(
+                        id=None,
+                        oracle_id=oracle_id,
+                        printing_id=printing_id,
+                        priority=item.get("priority", 0),
+                        added_at=now_iso(),
+                        source="server",
+                    )
+                    new_id = wishlist_repo.add(entry)
+                    added.append({"id": new_id, "name": card.name, "oracle_id": oracle_id, "printing_id": printing_id})
+                except Exception as exc:
+                    errors.append({"name": name, "error": str(exc)})
 
-        conn.commit()
-        conn.close()
+            conn.commit()
+        finally:
+            conn.close()
         self._send_json({"added": added, "errors": errors})
 
     def _api_wishlist_delete(self, wid: int):
@@ -7398,12 +7401,14 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         from mtg_collector.db.schema import init_db
 
         conn = self._get_conn()
-        init_db(conn)
+        try:
+            init_db(conn)
 
-        repo = WishlistRepository(conn)
-        fulfilled = repo.fulfill(wid)
-        conn.commit()
-        conn.close()
+            repo = WishlistRepository(conn)
+            fulfilled = repo.fulfill(wid)
+            conn.commit()
+        finally:
+            conn.close()
 
         if fulfilled:
             self._send_json({"ok": True})
@@ -7500,45 +7505,47 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             purchase_price = float(purchase_price)
 
         conn = self._get_conn()
-        init_db(conn)
+        try:
+            init_db(conn)
 
-        collection_repo = CollectionRepository(conn)
-        entry = CollectionEntry(
-            id=None,
-            printing_id=printing_id,
-            finish=finish,
-            acquired_at=acquired_at,
-            purchase_price=purchase_price,
-            source=source,
-        )
-        new_id = collection_repo.add(entry)
+            collection_repo = CollectionRepository(conn)
+            entry = CollectionEntry(
+                id=None,
+                printing_id=printing_id,
+                finish=finish,
+                acquired_at=acquired_at,
+                purchase_price=purchase_price,
+                source=source,
+            )
+            new_id = collection_repo.add(entry)
 
-        # Auto-fulfill matching wishlist entry
-        fulfilled_wishlist_id = None
-        wishlist_repo = WishlistRepository(conn)
-        # Check for a printing-specific wishlist entry first
-        row = conn.execute(
-            "SELECT id FROM wishlist WHERE printing_id = ? AND fulfilled_at IS NULL LIMIT 1",
-            (printing_id,),
-        ).fetchone()
-        if row:
-            wishlist_repo.fulfill(row["id"])
-            fulfilled_wishlist_id = row["id"]
-        else:
-            # Check for an oracle-level wishlist entry
+            # Auto-fulfill matching wishlist entry
+            fulfilled_wishlist_id = None
+            wishlist_repo = WishlistRepository(conn)
+            # Check for a printing-specific wishlist entry first
             row = conn.execute(
-                """SELECT w.id FROM wishlist w
-                   JOIN printings p ON p.oracle_id = w.oracle_id
-                   WHERE p.printing_id = ? AND w.printing_id IS NULL
-                     AND w.fulfilled_at IS NULL LIMIT 1""",
+                "SELECT id FROM wishlist WHERE printing_id = ? AND fulfilled_at IS NULL LIMIT 1",
                 (printing_id,),
             ).fetchone()
             if row:
                 wishlist_repo.fulfill(row["id"])
                 fulfilled_wishlist_id = row["id"]
+            else:
+                # Check for an oracle-level wishlist entry
+                row = conn.execute(
+                    """SELECT w.id FROM wishlist w
+                       JOIN printings p ON p.oracle_id = w.oracle_id
+                       WHERE p.printing_id = ? AND w.printing_id IS NULL
+                         AND w.fulfilled_at IS NULL LIMIT 1""",
+                    (printing_id,),
+                ).fetchone()
+                if row:
+                    wishlist_repo.fulfill(row["id"])
+                    fulfilled_wishlist_id = row["id"]
 
-        conn.commit()
-        conn.close()
+            conn.commit()
+        finally:
+            conn.close()
 
         result = {"id": new_id}
         if fulfilled_wishlist_id is not None:
@@ -7578,22 +7585,24 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             return
 
         conn = self._get_conn()
-        init_db(conn)
-
-        repo = CollectionRepository(conn)
         try:
-            repo.dispose(
-                entry_id,
-                new_status,
-                sale_price=data.get("sale_price"),
-                note=data.get("note"),
-            )
-            conn.commit()
+            init_db(conn)
+
+            repo = CollectionRepository(conn)
+            try:
+                repo.dispose(
+                    entry_id,
+                    new_status,
+                    sale_price=data.get("sale_price"),
+                    note=data.get("note"),
+                )
+                conn.commit()
+            except ValueError as e:
+                self._send_json({"error": str(e)}, 400)
+                return
+        finally:
             conn.close()
-            self._send_json({"ok": True})
-        except ValueError as e:
-            conn.close()
-            self._send_json({"error": str(e)}, 400)
+        self._send_json({"ok": True})
 
     def _api_collection_delete(self, entry_id: int):
         """Hard-delete a collection entry with lineage cleanup."""

--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -4918,35 +4918,34 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             return
 
         conn = self._get_conn()
-        init_db(conn)
-        batch_repo = BatchRepository(conn)
-        deck_repo = DeckRepository(conn)
-
-        batch = batch_repo.get(batch_id)
-        if not batch:
-            conn.close()
-            self._send_json({"error": "Batch not found"}, 404)
-            return
-
-        # Get collection IDs for this batch
-        cards = batch_repo.get_cards(batch_id)
-        collection_ids = [c["id"] for c in cards]
-
-        if not collection_ids:
-            conn.close()
-            self._send_json({"error": "No cards in batch"}, 400)
-            return
-
         try:
-            deck_repo.add_cards(int(deck_id), collection_ids, zone=deck_zone)
-        except ValueError as e:
-            conn.close()
-            self._send_json({"error": str(e)}, 409)
-            return
+            init_db(conn)
+            batch_repo = BatchRepository(conn)
+            deck_repo = DeckRepository(conn)
 
-        batch_repo.set_deck(batch_id, int(deck_id), deck_zone)
-        conn.commit()
-        conn.close()
+            batch = batch_repo.get(batch_id)
+            if not batch:
+                self._send_json({"error": "Batch not found"}, 404)
+                return
+
+            # Get collection IDs for this batch
+            cards = batch_repo.get_cards(batch_id)
+            collection_ids = [c["id"] for c in cards]
+
+            if not collection_ids:
+                self._send_json({"error": "No cards in batch"}, 400)
+                return
+
+            try:
+                deck_repo.add_cards(int(deck_id), collection_ids, zone=deck_zone)
+            except ValueError as e:
+                self._send_json({"error": str(e)}, 409)
+                return
+
+            batch_repo.set_deck(batch_id, int(deck_id), deck_zone)
+            conn.commit()
+        finally:
+            conn.close()
         self._send_json({"ok": True, "assigned": len(collection_ids)})
 
     def _api_batch_update(self, batch_id: int, data: dict):
@@ -5659,53 +5658,57 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             self._send_json({"error": "name is required"}, 400)
             return
         conn = self._get_conn()
-        from mtg_collector.db.models import Deck, DeckRepository
-        repo = DeckRepository(conn)
-        origin_var = data.get("origin_variation")
-        if origin_var is not None:
-            origin_var = int(origin_var)
-        deck = Deck(
-            id=None, name=name, description=data.get("description"),
-            format=data.get("format"), is_precon=bool(data.get("is_precon")),
-            sleeve_color=data.get("sleeve_color"), deck_box=data.get("deck_box"),
-            storage_location=data.get("storage_location"),
-            origin_set_code=data.get("origin_set_code"),
-            origin_theme=data.get("origin_theme"),
-            origin_variation=origin_var,
-            state_id=self._resolve_state_id(data.get("state", "idea")),
-        )
-        deck_id = repo.add(deck)
-        conn.commit()
-        result = repo.get(deck_id)
-        conn.close()
+        try:
+            from mtg_collector.db.models import Deck, DeckRepository
+            repo = DeckRepository(conn)
+            origin_var = data.get("origin_variation")
+            if origin_var is not None:
+                origin_var = int(origin_var)
+            deck = Deck(
+                id=None, name=name, description=data.get("description"),
+                format=data.get("format"), is_precon=bool(data.get("is_precon")),
+                sleeve_color=data.get("sleeve_color"), deck_box=data.get("deck_box"),
+                storage_location=data.get("storage_location"),
+                origin_set_code=data.get("origin_set_code"),
+                origin_theme=data.get("origin_theme"),
+                origin_variation=origin_var,
+                state_id=self._resolve_state_id(data.get("state", "idea")),
+            )
+            deck_id = repo.add(deck)
+            conn.commit()
+            result = repo.get(deck_id)
+        finally:
+            conn.close()
         self._send_json(result, 201)
 
     def _api_deck_update(self, deck_id: int, data: dict):
         conn = self._get_conn()
-        from mtg_collector.db.models import DeckRepository
-        repo = DeckRepository(conn)
-        if not repo.get(deck_id):
+        try:
+            from mtg_collector.db.models import DeckRepository
+            repo = DeckRepository(conn)
+            if not repo.get(deck_id):
+                self._send_json({"error": "Deck not found"}, 404)
+                return
+            if "state" in data:
+                data["state_id"] = self._resolve_state_id(data.pop("state"))
+            repo.update(deck_id, data)
+            conn.commit()
+            result = repo.get(deck_id)
+        finally:
             conn.close()
-            self._send_json({"error": "Deck not found"}, 404)
-            return
-        if "state" in data:
-            data["state_id"] = self._resolve_state_id(data.pop("state"))
-        repo.update(deck_id, data)
-        conn.commit()
-        result = repo.get(deck_id)
-        conn.close()
         self._send_json(result)
 
     def _api_deck_delete(self, deck_id: int):
         conn = self._get_conn()
-        from mtg_collector.db.models import DeckRepository
-        repo = DeckRepository(conn)
-        if not repo.delete(deck_id):
+        try:
+            from mtg_collector.db.models import DeckRepository
+            repo = DeckRepository(conn)
+            if not repo.delete(deck_id):
+                self._send_json({"error": "Deck not found"}, 404)
+                return
+            conn.commit()
+        finally:
             conn.close()
-            self._send_json({"error": "Deck not found"}, 404)
-            return
-        conn.commit()
-        conn.close()
         self._send_json({"ok": True})
 
     def _api_deck_cards(self, deck_id: int, params: dict):
@@ -5842,83 +5845,82 @@ class CrackPackHandler(BaseHTTPRequestHandler):
 
     def _api_deck_expected_set(self, deck_id: int, data: dict):
         conn = self._get_conn()
-        from mtg_collector.db.models import DeckRepository
-        repo = DeckRepository(conn)
-        if not repo.get(deck_id):
-            conn.close()
-            self._send_json({"error": "Deck not found"}, 404)
-            return
-
-        if "decklist" in data:
-            # Parse text decklist and resolve to printing_ids
-            from mtg_collector.db.models import CardRepository, PrintingRepository
-            from mtg_collector.importers.decklist import parse_line
-            card_repo = CardRepository(conn)
-            printing_repo = PrintingRepository(conn)
-            lines = data["decklist"].strip().split("\n")
-            cards = []
-            errors = []
-            for i, line in enumerate(lines, 1):
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    parsed = parse_line(line, i)
-                except ValueError as e:
-                    errors.append(str(e))
-                    continue
-                name = parsed["Name"]
-                set_code = (parsed.get("Edition") or "").strip().lower() or None
-                cn = parsed.get("Collector Number") or None
-                qty = int(parsed.get("Count", 1))
-                # Resolve card: try set+CN first, then name lookup
-                printing_id = None
-                if set_code and cn:
-                    p = printing_repo.get_by_set_cn(set_code, cn)
-                    if p:
-                        printing_id = p.printing_id
-                if not printing_id:
-                    card = card_repo.get_by_name(name) or card_repo.search_by_name(name)
-                    if card:
-                        # Prefer owned printing, fallback to most recent non-digital
-                        owned = conn.execute(
-                            """SELECT p.printing_id FROM collection col
-                               JOIN printings p ON col.printing_id = p.printing_id
-                               JOIN sets s ON p.set_code = s.set_code
-                               WHERE p.oracle_id = ? AND col.status = 'owned'
-                               ORDER BY s.released_at DESC LIMIT 1""",
-                            (card.oracle_id,),
-                        ).fetchone()
-                        if owned:
-                            printing_id = owned[0]
-                        else:
-                            printings = printing_repo.get_by_oracle_id(card.oracle_id)
-                            if printings:
-                                printing_id = printings[0].printing_id
-                if not printing_id:
-                    errors.append(f"Line {i}: card not found: {name}")
-                    continue
-                cards.append({
-                    "printing_id": printing_id,
-                    "zone": "mainboard",
-                    "quantity": qty,
-                })
-            if errors:
-                conn.close()
-                self._send_json({"error": "Some cards could not be resolved",
-                                 "details": errors}, 400)
+        try:
+            from mtg_collector.db.models import DeckRepository
+            repo = DeckRepository(conn)
+            if not repo.get(deck_id):
+                self._send_json({"error": "Deck not found"}, 404)
                 return
-            count = repo.set_expected_cards(deck_id, cards)
-        elif "cards" in data:
-            count = repo.set_expected_cards(deck_id, data["cards"])
-        else:
-            conn.close()
-            self._send_json({"error": "Provide 'cards' or 'decklist'"}, 400)
-            return
 
-        conn.commit()
-        result = repo.get_expected_cards(deck_id)
-        conn.close()
+            if "decklist" in data:
+                # Parse text decklist and resolve to printing_ids
+                from mtg_collector.db.models import CardRepository, PrintingRepository
+                from mtg_collector.importers.decklist import parse_line
+                card_repo = CardRepository(conn)
+                printing_repo = PrintingRepository(conn)
+                lines = data["decklist"].strip().split("\n")
+                cards = []
+                errors = []
+                for i, line in enumerate(lines, 1):
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        parsed = parse_line(line, i)
+                    except ValueError as e:
+                        errors.append(str(e))
+                        continue
+                    name = parsed["Name"]
+                    set_code = (parsed.get("Edition") or "").strip().lower() or None
+                    cn = parsed.get("Collector Number") or None
+                    qty = int(parsed.get("Count", 1))
+                    # Resolve card: try set+CN first, then name lookup
+                    printing_id = None
+                    if set_code and cn:
+                        p = printing_repo.get_by_set_cn(set_code, cn)
+                        if p:
+                            printing_id = p.printing_id
+                    if not printing_id:
+                        card = card_repo.get_by_name(name) or card_repo.search_by_name(name)
+                        if card:
+                            # Prefer owned printing, fallback to most recent non-digital
+                            owned = conn.execute(
+                                """SELECT p.printing_id FROM collection col
+                                   JOIN printings p ON col.printing_id = p.printing_id
+                                   JOIN sets s ON p.set_code = s.set_code
+                                   WHERE p.oracle_id = ? AND col.status = 'owned'
+                                   ORDER BY s.released_at DESC LIMIT 1""",
+                                (card.oracle_id,),
+                            ).fetchone()
+                            if owned:
+                                printing_id = owned[0]
+                            else:
+                                printings = printing_repo.get_by_oracle_id(card.oracle_id)
+                                if printings:
+                                    printing_id = printings[0].printing_id
+                    if not printing_id:
+                        errors.append(f"Line {i}: card not found: {name}")
+                        continue
+                    cards.append({
+                        "printing_id": printing_id,
+                        "zone": "mainboard",
+                        "quantity": qty,
+                    })
+                if errors:
+                    self._send_json({"error": "Some cards could not be resolved",
+                                     "details": errors}, 400)
+                    return
+                count = repo.set_expected_cards(deck_id, cards)
+            elif "cards" in data:
+                count = repo.set_expected_cards(deck_id, data["cards"])
+            else:
+                self._send_json({"error": "Provide 'cards' or 'decklist'"}, 400)
+                return
+
+            conn.commit()
+            result = repo.get_expected_cards(deck_id)
+        finally:
+            conn.close()
         self._send_json({"ok": True, "count": count, "cards": result})
 
     def _api_deck_expected_add(self, deck_id: int, data: dict):
@@ -6060,21 +6062,21 @@ class CrackPackHandler(BaseHTTPRequestHandler):
 
     def _api_deck_materialize(self, deck_id: int):
         conn = self._get_conn()
-        from mtg_collector.db.models import DeckRepository
-        repo = DeckRepository(conn)
-        deck = repo.get(deck_id)
-        if not deck:
+        try:
+            from mtg_collector.db.models import DeckRepository
+            repo = DeckRepository(conn)
+            deck = repo.get(deck_id)
+            if not deck:
+                self._send_json({"error": "Deck not found"}, 404)
+                return
+            from mtg_collector.db.models import DECK_STATE_CONSTRUCTED
+            if deck["state_id"] == DECK_STATE_CONSTRUCTED:
+                self._send_json({"error": "Deck is already constructed"}, 400)
+                return
+            result = repo.materialize_deck(deck_id)
+            conn.commit()
+        finally:
             conn.close()
-            self._send_json({"error": "Deck not found"}, 404)
-            return
-        from mtg_collector.db.models import DECK_STATE_CONSTRUCTED
-        if deck["state_id"] == DECK_STATE_CONSTRUCTED:
-            conn.close()
-            self._send_json({"error": "Deck is already constructed"}, 400)
-            return
-        result = repo.materialize_deck(deck_id)
-        conn.commit()
-        conn.close()
         self._send_json(result)
 
     def _api_deck_reassemble(self, deck_id: int, data: dict):
@@ -6083,16 +6085,17 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             self._send_json({"error": "collection_ids is required"}, 400)
             return
         conn = self._get_conn()
-        from mtg_collector.db.models import DeckRepository
-        repo = DeckRepository(conn)
-        if not repo.get(deck_id):
+        try:
+            from mtg_collector.db.models import DeckRepository
+            repo = DeckRepository(conn)
+            if not repo.get(deck_id):
+                self._send_json({"error": "Deck not found"}, 404)
+                return
+            count = repo.move_cards(collection_ids, deck_id, zone="mainboard")
+            conn.commit()
+            result = repo.get_deck_completeness(deck_id)
+        finally:
             conn.close()
-            self._send_json({"error": "Deck not found"}, 404)
-            return
-        count = repo.move_cards(collection_ids, deck_id, zone="mainboard")
-        conn.commit()
-        result = repo.get_deck_completeness(deck_id)
-        conn.close()
         self._send_json({"ok": True, "moved": count, "completeness": result})
 
     # ===== Deck Builder API handlers =====
@@ -6144,42 +6147,40 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             self._send_json({"error": "commander_oracle_id is required"}, 400)
             return
         conn = self._get_conn()
-        card = conn.execute("SELECT name FROM cards WHERE oracle_id = ?",
-                            (commander_oracle_id,)).fetchone()
-        if not card:
-            conn.close()
-            self._send_json({"error": "Commander not found"}, 404)
-            return
-        from mtg_collector.db.models import DECK_STATE_CONSTRUCTED
-        state_id = self._resolve_state_id(data.get("state", "idea"))
-        if state_id != DECK_STATE_CONSTRUCTED:
-            # Use DeckBuilderService for idea/ready decks to pre-populate
-            # template role categories (Lands, Ramp, etc.)
-            from mtg_collector.services.deck_builder import DeckBuilderService
-            svc = DeckBuilderService(conn)
-            try:
-                result = svc.create_deck(commander_oracle_id)
-            except ValueError as e:
-                conn.close()
-                self._send_json({"error": str(e)}, 400)
+        try:
+            card = conn.execute("SELECT name FROM cards WHERE oracle_id = ?",
+                                (commander_oracle_id,)).fetchone()
+            if not card:
+                self._send_json({"error": "Commander not found"}, 404)
                 return
+            from mtg_collector.db.models import DECK_STATE_CONSTRUCTED
+            state_id = self._resolve_state_id(data.get("state", "idea"))
+            if state_id != DECK_STATE_CONSTRUCTED:
+                # Use DeckBuilderService for idea/ready decks to pre-populate
+                # template role categories (Lands, Ramp, etc.)
+                from mtg_collector.services.deck_builder import DeckBuilderService
+                svc = DeckBuilderService(conn)
+                try:
+                    result = svc.create_deck(commander_oracle_id)
+                except ValueError as e:
+                    self._send_json({"error": str(e)}, 400)
+                    return
+            else:
+                from mtg_collector.db.models import Deck, DeckRepository
+                repo = DeckRepository(conn)
+                deck_name = data.get("name") or card["name"]
+                deck = Deck(
+                    id=None, name=deck_name, format="commander",
+                    state_id=DECK_STATE_CONSTRUCTED,
+                    commander_oracle_id=commander_oracle_id,
+                    commander_printing_id=data.get("commander_printing_id"),
+                )
+                deck_id = repo.add(deck)
+                conn.commit()
+                result = repo.get(deck_id)
+        finally:
             conn.close()
-            self._send_json(result, 201)
-        else:
-            from mtg_collector.db.models import Deck, DeckRepository
-            repo = DeckRepository(conn)
-            deck_name = data.get("name") or card["name"]
-            deck = Deck(
-                id=None, name=deck_name, format="commander",
-                state_id=DECK_STATE_CONSTRUCTED,
-                commander_oracle_id=commander_oracle_id,
-                commander_printing_id=data.get("commander_printing_id"),
-            )
-            deck_id = repo.add(deck)
-            conn.commit()
-            result = repo.get(deck_id)
-            conn.close()
-            self._send_json(result, 201)
+        self._send_json(result, 201)
 
     def _categorize_card_type(self, type_line: str) -> str:
         """Categorize a card by its type line, priority order."""
@@ -6399,11 +6400,13 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             self._send_json({"error": "collection_id is required"}, 400)
             return
         conn = self._get_conn()
-        from mtg_collector.db.models import DeckRepository
-        repo = DeckRepository(conn)
-        count = repo.remove_cards(deck_id, [collection_id])
-        conn.commit()
-        conn.close()
+        try:
+            from mtg_collector.db.models import DeckRepository
+            repo = DeckRepository(conn)
+            count = repo.remove_cards(deck_id, [collection_id])
+            conn.commit()
+        finally:
+            conn.close()
         self._send_json({"ok": True, "removed": count})
 
     def _api_builder_browse_commanders(self, params: dict):

--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -4241,22 +4241,24 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             self._send_json({"error": "printing_id is required"}, 400)
             return
         conn = self._get_conn()
-        init_db(conn)
-        entry = CollectionEntry(
-            id=None,
-            printing_id=printing_id,
-            finish=data.get("finish", "nonfoil"),
-            condition=data.get("condition", "Near Mint"),
-            purchase_price=data.get("purchase_price"),
-            acquired_at=now_iso(),
-            source="order_import",
-            status="ordered",
-            order_id=order_id,
-        )
-        repo = CollectionRepository(conn)
-        new_id = repo.add(entry)
-        conn.commit()
-        conn.close()
+        try:
+            init_db(conn)
+            entry = CollectionEntry(
+                id=None,
+                printing_id=printing_id,
+                finish=data.get("finish", "nonfoil"),
+                condition=data.get("condition", "Near Mint"),
+                purchase_price=data.get("purchase_price"),
+                acquired_at=now_iso(),
+                source="order_import",
+                status="ordered",
+                order_id=order_id,
+            )
+            repo = CollectionRepository(conn)
+            new_id = repo.add(entry)
+            conn.commit()
+        finally:
+            conn.close()
         self._send_json({"id": new_id})
 
     def _api_order_parse(self):
@@ -4451,33 +4453,34 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             resolved_orders.append(ro)
 
         conn = self._get_conn()
-        init_db(conn)
-        collection_repo = CollectionRepository(conn)
-        order_repo = OrderRepository(conn)
+        try:
+            init_db(conn)
+            collection_repo = CollectionRepository(conn)
+            order_repo = OrderRepository(conn)
 
-        from mtg_collector.db.models import BatchRepository
-        batch_repo = BatchRepository(conn)
+            from mtg_collector.db.models import BatchRepository
+            batch_repo = BatchRepository(conn)
 
-        summary = commit_orders(
-            resolved_orders, order_repo, collection_repo, conn,
-            status=status, source=source, batch_repo=batch_repo,
-        )
+            summary = commit_orders(
+                resolved_orders, order_repo, collection_repo, conn,
+                status=status, source=source, batch_repo=batch_repo,
+            )
 
-        # Optional deck/binder assignment for newly added cards
-        assign_target = data.get("assign_target", "")
-        if assign_target and summary.get("collection_ids"):
-            from mtg_collector.db.models import BinderRepository, DeckRepository
-            cids = summary["collection_ids"]
-            if assign_target.startswith("deck:"):
-                did = int(assign_target.split(":")[1])
-                zone = data.get("assign_zone", "mainboard")
-                DeckRepository(conn).add_cards(did, cids, zone=zone)
-            elif assign_target.startswith("binder:"):
-                bid = int(assign_target.split(":")[1])
-                BinderRepository(conn).add_cards(bid, cids)
-            conn.commit()
-
-        conn.close()
+            # Optional deck/binder assignment for newly added cards
+            assign_target = data.get("assign_target", "")
+            if assign_target and summary.get("collection_ids"):
+                from mtg_collector.db.models import BinderRepository, DeckRepository
+                cids = summary["collection_ids"]
+                if assign_target.startswith("deck:"):
+                    did = int(assign_target.split(":")[1])
+                    zone = data.get("assign_zone", "mainboard")
+                    DeckRepository(conn).add_cards(did, cids, zone=zone)
+                elif assign_target.startswith("binder:"):
+                    bid = int(assign_target.split(":")[1])
+                    BinderRepository(conn).add_cards(bid, cids)
+                conn.commit()
+        finally:
+            conn.close()
         self._send_json(summary)
 
     def _api_collection_history(self, collection_id: int):
@@ -4542,11 +4545,13 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         from mtg_collector.db.models import CollectionRepository
         from mtg_collector.db.schema import init_db
         conn = self._get_conn()
-        init_db(conn)
-        repo = CollectionRepository(conn)
-        ok = repo.receive_card(collection_id)
-        conn.commit()
-        conn.close()
+        try:
+            init_db(conn)
+            repo = CollectionRepository(conn)
+            ok = repo.receive_card(collection_id)
+            conn.commit()
+        finally:
+            conn.close()
         self._send_json({"received": 1 if ok else 0})
 
     def _api_order_receive(self, order_id: int):
@@ -4556,11 +4561,13 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         data = self._read_json_body()  # None when no body — backward-compatible
         card_ids = data.get("card_ids") if data else None
         conn = self._get_conn()
-        init_db(conn)
-        repo = OrderRepository(conn)
-        count = repo.receive_order(order_id, card_ids=card_ids)
-        conn.commit()
-        conn.close()
+        try:
+            init_db(conn)
+            repo = OrderRepository(conn)
+            count = repo.receive_order(order_id, card_ids=card_ids)
+            conn.commit()
+        finally:
+            conn.close()
         self._send_json({"received": count})
 
     # ── Corner Ingest API endpoints ──

--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -5777,10 +5777,10 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             count = repo.add_cards(deck_id, collection_ids, zone=zone)
             conn.commit()
         except ValueError as e:
-            conn.close()
             self._send_json({"error": str(e)}, 409)
             return
-        conn.close()
+        finally:
+            conn.close()
         self._send_json({"ok": True, "count": count})
 
     def _api_deck_remove_cards(self, deck_id: int, data: dict):
@@ -5791,9 +5791,11 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         conn = self._get_conn()
         from mtg_collector.db.models import DeckRepository
         repo = DeckRepository(conn)
-        count = repo.remove_cards(deck_id, collection_ids)
-        conn.commit()
-        conn.close()
+        try:
+            count = repo.remove_cards(deck_id, collection_ids)
+            conn.commit()
+        finally:
+            conn.close()
         self._send_json({"ok": True, "count": count})
 
     def _api_deck_adjust_quantity(self, deck_id: int, data: dict):
@@ -5827,9 +5829,11 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         conn = self._get_conn()
         from mtg_collector.db.models import DeckRepository
         repo = DeckRepository(conn)
-        count = repo.move_cards(collection_ids, deck_id, zone=zone)
-        conn.commit()
-        conn.close()
+        try:
+            count = repo.move_cards(collection_ids, deck_id, zone=zone)
+            conn.commit()
+        finally:
+            conn.close()
         self._send_json({"ok": True, "count": count})
 
     def _api_deck_expected_get(self, deck_id: int):
@@ -7102,10 +7106,10 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             count = repo.add_cards(binder_id, collection_ids)
             conn.commit()
         except ValueError as e:
-            conn.close()
             self._send_json({"error": str(e)}, 409)
             return
-        conn.close()
+        finally:
+            conn.close()
         self._send_json({"ok": True, "count": count})
 
     def _api_binder_remove_cards(self, binder_id: int, data: dict):
@@ -7116,9 +7120,11 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         conn = self._get_conn()
         from mtg_collector.db.models import BinderRepository
         repo = BinderRepository(conn)
-        count = repo.remove_cards(binder_id, collection_ids)
-        conn.commit()
-        conn.close()
+        try:
+            count = repo.remove_cards(binder_id, collection_ids)
+            conn.commit()
+        finally:
+            conn.close()
         self._send_json({"ok": True, "count": count})
 
     def _api_binder_move_cards(self, binder_id: int, data: dict):
@@ -7129,9 +7135,11 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         conn = self._get_conn()
         from mtg_collector.db.models import BinderRepository
         repo = BinderRepository(conn)
-        count = repo.move_cards(collection_ids, binder_id)
-        conn.commit()
-        conn.close()
+        try:
+            count = repo.move_cards(collection_ids, binder_id)
+            conn.commit()
+        finally:
+            conn.close()
         self._send_json({"ok": True, "count": count})
 
     # ===== Collection View API handlers =====

--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -8099,36 +8099,37 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             return
 
         conn = self._get_conn()
-        init_db(conn)
+        try:
+            init_db(conn)
 
-        # Verify the product exists
-        product_repo = SealedProductRepository(conn)
-        product = product_repo.get(uuid)
-        if not product:
+            # Verify the product exists
+            product_repo = SealedProductRepository(conn)
+            product = product_repo.get(uuid)
+            if not product:
+                self._send_json({"error": f"Sealed product '{uuid}' not found"}, 404)
+                return
+
+            entry = SealedCollectionEntry(
+                id=None,
+                sealed_product_uuid=uuid,
+                quantity=data.get("quantity", 1),
+                condition=data.get("condition", "Near Mint"),
+                purchase_price=data.get("purchase_price"),
+                purchase_date=data.get("purchase_date"),
+                source=data.get("source"),
+                seller_name=data.get("seller_name"),
+                notes=data.get("notes"),
+                status=data.get("status", "owned"),
+            )
+
+            repo = SealedCollectionRepository(conn)
+            new_id = repo.add(entry)
+            conn.commit()
+
+            # Fetch back for response
+            created = repo.get(new_id)
+        finally:
             conn.close()
-            self._send_json({"error": f"Sealed product '{uuid}' not found"}, 404)
-            return
-
-        entry = SealedCollectionEntry(
-            id=None,
-            sealed_product_uuid=uuid,
-            quantity=data.get("quantity", 1),
-            condition=data.get("condition", "Near Mint"),
-            purchase_price=data.get("purchase_price"),
-            purchase_date=data.get("purchase_date"),
-            source=data.get("source"),
-            seller_name=data.get("seller_name"),
-            notes=data.get("notes"),
-            status=data.get("status", "owned"),
-        )
-
-        repo = SealedCollectionRepository(conn)
-        new_id = repo.add(entry)
-        conn.commit()
-
-        # Fetch back for response
-        created = repo.get(new_id)
-        conn.close()
 
         image_url = None
         if product.tcgplayer_product_id:
@@ -8200,10 +8201,10 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             return
 
         conn = self._get_conn()
-        init_db(conn)
-        repo = SealedCollectionRepository(conn)
-
         try:
+            init_db(conn)
+            repo = SealedCollectionRepository(conn)
+
             qty = data.get("quantity")
             if qty is not None:
                 qty = int(qty)
@@ -8213,11 +8214,12 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                 quantity=qty,
             )
             conn.commit()
-            conn.close()
-            self._send_json({"ok": True})
         except ValueError as e:
-            conn.close()
             self._send_json({"error": str(e)}, 400)
+            return
+        finally:
+            conn.close()
+        self._send_json({"ok": True})
 
     def _api_sealed_collection_bulk_dispose(self, data: dict):
         """Bulk-transition sealed collection entries' status."""
@@ -8234,11 +8236,13 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             return
 
         conn = self._get_conn()
-        init_db(conn)
-        repo = SealedCollectionRepository(conn)
-        result = repo.bulk_dispose(ids, new_status, sale_price=data.get("sale_price"))
-        conn.commit()
-        conn.close()
+        try:
+            init_db(conn)
+            repo = SealedCollectionRepository(conn)
+            result = repo.bulk_dispose(ids, new_status, sale_price=data.get("sale_price"))
+            conn.commit()
+        finally:
+            conn.close()
         self._send_json({
             "disposed": len(result["disposed"]),
             "skipped": len(result["skipped"]),

--- a/tests/test_attach_shared.py
+++ b/tests/test_attach_shared.py
@@ -398,3 +398,110 @@ def test_handler_write_error_does_not_lock_db(single_db_path):
     assert row is not None
     assert row[0] == "ok"
     check.close()
+
+
+# ── Sealed collection handler connection-leak tests (efj-mtgc-dw0) ──
+
+
+def _seed_sealed_product(db_path, *, entry_status=None, quantity=1):
+    """Insert a sealed_products row, and optionally a sealed_collection entry."""
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO sealed_products (uuid, name, set_code, category, imported_at) "
+        "VALUES ('sealed-uuid-1', 'Test Booster Box', 'tst', 'booster_box', "
+        "'2025-01-01T00:00:00')"
+    )
+    if entry_status is not None:
+        conn.execute(
+            "INSERT INTO sealed_collection "
+            "(id, sealed_product_uuid, quantity, condition, status, added_at) "
+            "VALUES (1, 'sealed-uuid-1', ?, 'Near Mint', ?, '2025-01-01T00:00:00')",
+            (quantity, entry_status),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _assert_writes_still_work(db_path, key):
+    """The next writer must not hit 'database is locked'."""
+    conn2 = sqlite3.connect(db_path, timeout=1)
+    conn2.execute("INSERT INTO settings (key, value) VALUES (?, 'ok')", (key,))
+    conn2.commit()
+    conn2.close()
+
+    check = sqlite3.connect(db_path)
+    row = check.execute(
+        "SELECT value FROM settings WHERE key = ?", (key,)).fetchone()
+    assert row is not None
+    assert row[0] == "ok"
+    check.close()
+
+
+def test_sealed_collection_add_integrity_error_does_not_lock_db(single_db_path):
+    """_api_sealed_collection_add must release the connection on any exception.
+
+    Reproduces efj-mtgc-dw0: the handler closed the connection only on its
+    success and not-found paths, so the IntegrityError raised by
+    sealed_collection's status CHECK constraint escaped before conn.close().
+    The leaked connection kept an open write transaction; under WAL mode that
+    holds the write lock and every subsequent write fails "database is locked"
+    until the service is restarted.
+
+    Also asserts the error still propagates — releasing the lock must not turn
+    into swallowing the error into a tidy JSON response.
+    """
+    _seed_sealed_product(single_db_path)
+    handler = _make_handler(single_db_path)
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        with pytest.raises(sqlite3.IntegrityError):
+            handler._api_sealed_collection_add({
+                "sealed_product_uuid": "sealed-uuid-1",
+                "status": "not_a_real_status",
+            })
+        assert handler._responses == []
+
+        _assert_writes_still_work(single_db_path, "after_sealed_add_error")
+
+
+def test_sealed_collection_dispose_non_valueerror_does_not_lock_db(single_db_path):
+    """_api_sealed_collection_dispose catches only ValueError — anything else leaks.
+
+    Disposing part of a stack takes the split path: the original entry is
+    UPDATEd (opening a write transaction) and only then is the split row
+    INSERTed. An unsupported JSON type for sale_price makes sqlite3 raise
+    ProgrammingError on that INSERT, which sails past the narrow
+    `except ValueError` and past conn.close() — leaving the write transaction,
+    and the WAL write lock, held by the leaked connection.
+    """
+    _seed_sealed_product(single_db_path, entry_status="owned", quantity=3)
+    handler = _make_handler(single_db_path)
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        with pytest.raises(sqlite3.ProgrammingError):
+            handler._api_sealed_collection_dispose(
+                1, {"new_status": "sold", "quantity": 1,
+                    "sale_price": {"usd": 5}})
+        assert handler._responses == []
+
+        _assert_writes_still_work(single_db_path, "after_sealed_dispose_error")
+
+
+def test_sealed_collection_bulk_dispose_error_does_not_lock_db(single_db_path):
+    """_api_sealed_collection_bulk_dispose has no except at all — every error leaks.
+
+    The first id disposes cleanly (opening a write transaction); the second is
+    an unsupported JSON type, so the lookup SELECT raises ProgrammingError with
+    that transaction still open. Without a finally the connection — and the WAL
+    write lock it holds — is never released.
+    """
+    _seed_sealed_product(single_db_path, entry_status="owned")
+    handler = _make_handler(single_db_path)
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        with pytest.raises(sqlite3.ProgrammingError):
+            handler._api_sealed_collection_bulk_dispose(
+                {"ids": [1, {"bad": "id"}], "new_status": "sold"})
+        assert handler._responses == []
+
+        _assert_writes_still_work(single_db_path, "after_sealed_bulk_error")

--- a/tests/test_attach_shared.py
+++ b/tests/test_attach_shared.py
@@ -398,3 +398,76 @@ def test_handler_write_error_does_not_lock_db(single_db_path):
     assert row is not None
     assert row[0] == "ok"
     check.close()
+
+
+def test_deck_add_cards_integrity_error_does_not_lock_db(single_db_path):
+    """A non-ValueError exception must not leak the connection or its lock.
+
+    Reproduces efj-mtgc-7rp: _api_deck_add_cards caught only ValueError, so the
+    IntegrityError raised by deck_cards' zone CHECK constraint escaped before
+    conn.close(). The leaked connection held an open write transaction, and in
+    WAL mode that wedges every subsequent writer with "database is locked".
+
+    Also asserts the error still propagates — releasing the lock must not turn
+    into swallowing the error.
+    """
+    setup = sqlite3.connect(single_db_path)
+    setup.execute(
+        "INSERT INTO decks (id, name, state_id, created_at, updated_at) "
+        "VALUES (1, 'Test Deck', 1, '2025-01-01T00:00:00', '2025-01-01T00:00:00')"
+    )
+    setup.commit()
+    setup.close()
+
+    handler = _make_handler(single_db_path)
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        # The IntegrityError must reach the caller, not be converted into a
+        # tidy JSON error response.
+        with pytest.raises(sqlite3.IntegrityError):
+            handler._api_deck_add_cards(
+                1, {"collection_ids": [1], "zone": "not_a_real_zone"})
+        assert handler._responses == []
+
+        # ...and the connection must have been released, so the next write
+        # succeeds instead of failing with "database is locked".
+        conn2 = sqlite3.connect(single_db_path, timeout=1)
+        conn2.execute(
+            "INSERT INTO settings (key, value) VALUES ('after_deck_error', 'ok')")
+        conn2.commit()
+        conn2.close()
+
+    check = sqlite3.connect(single_db_path)
+    row = check.execute(
+        "SELECT value FROM settings WHERE key = 'after_deck_error'").fetchone()
+    assert row is not None
+    assert row[0] == "ok"
+    check.close()
+
+
+def test_binder_add_cards_integrity_error_does_not_lock_db(single_db_path):
+    """Sibling of the deck handler — same except-ValueError-only shape.
+
+    BinderRepository.add_cards writes a movement_log row whose binder column is
+    a foreign key; a non-existent binder_id raises IntegrityError once FK
+    enforcement is on (default mode), which must not leak the connection.
+    """
+    handler = _make_handler(single_db_path)
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        with pytest.raises(sqlite3.IntegrityError):
+            handler._api_binder_add_cards(999999, {"collection_ids": [1]})
+        assert handler._responses == []
+
+        conn2 = sqlite3.connect(single_db_path, timeout=1)
+        conn2.execute(
+            "INSERT INTO settings (key, value) VALUES ('after_binder_error', 'ok')")
+        conn2.commit()
+        conn2.close()
+
+    check = sqlite3.connect(single_db_path)
+    row = check.execute(
+        "SELECT value FROM settings WHERE key = 'after_binder_error'").fetchone()
+    assert row is not None
+    assert row[0] == "ok"
+    check.close()

--- a/tests/test_attach_shared.py
+++ b/tests/test_attach_shared.py
@@ -398,3 +398,163 @@ def test_handler_write_error_does_not_lock_db(single_db_path):
     assert row is not None
     assert row[0] == "ok"
     check.close()
+
+
+# ── Binder / view CRUD handlers must not leak the connection (efj-mtgc-5oa) ──
+
+
+def _abort_after(conn, event, table):
+    """Install a trigger that aborts *after* a write has dirtied `table`.
+
+    RAISE(ABORT) surfaces as sqlite3.IntegrityError. Because the row was
+    already written, the connection is left holding an open write transaction
+    — exactly the state a leaked connection wedges the DB in under WAL. A
+    trigger (not a foreign key) is used deliberately: the deployed split-DB
+    config runs with PRAGMA foreign_keys OFF, so FK errors are unreachable
+    there, while trigger/CHECK aborts always fire.
+    """
+    conn.execute(
+        f"CREATE TRIGGER boom_{event}_{table} AFTER {event} ON {table} "
+        f"BEGIN SELECT RAISE(ABORT, 'boom'); END"
+    )
+
+
+def _assert_writes_still_work(db_path, key):
+    """The DB must still accept writes — i.e. the connection was released."""
+    conn2 = sqlite3.connect(db_path, timeout=1)
+    conn2.execute("INSERT INTO settings (key, value) VALUES (?, 'ok')", (key,))
+    conn2.commit()
+    conn2.close()
+
+    check = sqlite3.connect(db_path)
+    row = check.execute(
+        "SELECT value FROM settings WHERE key = ?", (key,)).fetchone()
+    assert row is not None
+    assert row[0] == "ok"
+    check.close()
+
+
+def test_binder_create_error_does_not_lock_db(single_db_path):
+    """_api_binder_create must release its connection when the write fails."""
+    setup = sqlite3.connect(single_db_path)
+    _abort_after(setup, "INSERT", "binders")
+    setup.commit()
+    setup.close()
+
+    handler = _make_handler(single_db_path)
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        # The error must reach the caller, not become a tidy JSON response.
+        with pytest.raises(sqlite3.IntegrityError):
+            handler._api_binder_create({"name": "Boom Binder"})
+        assert handler._responses == []
+
+        _assert_writes_still_work(single_db_path, "after_binder_create_error")
+
+
+def test_binder_update_error_does_not_lock_db(single_db_path):
+    """_api_binder_update must release its connection when the write fails."""
+    setup = sqlite3.connect(single_db_path)
+    setup.execute(
+        "INSERT INTO binders (id, name, created_at, updated_at) "
+        "VALUES (1, 'Binder', '2025-01-01T00:00:00', '2025-01-01T00:00:00')"
+    )
+    _abort_after(setup, "UPDATE", "binders")
+    setup.commit()
+    setup.close()
+
+    handler = _make_handler(single_db_path)
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        with pytest.raises(sqlite3.IntegrityError):
+            handler._api_binder_update(1, {"name": "Renamed"})
+        assert handler._responses == []
+
+        _assert_writes_still_work(single_db_path, "after_binder_update_error")
+
+
+def test_binder_delete_error_does_not_lock_db(single_db_path):
+    """_api_binder_delete must release its connection when the write fails.
+
+    The binder holds a card, so delete() writes movement_log rows and clears
+    collection.binder_id before the DELETE aborts — the transaction is already
+    dirty when the exception escapes.
+    """
+    setup = sqlite3.connect(single_db_path)
+    setup.execute(
+        "INSERT INTO binders (id, name, created_at, updated_at) "
+        "VALUES (1, 'Binder', '2025-01-01T00:00:00', '2025-01-01T00:00:00')"
+    )
+    setup.execute("UPDATE collection SET binder_id = 1 WHERE id = 1")
+    _abort_after(setup, "DELETE", "binders")
+    setup.commit()
+    setup.close()
+
+    handler = _make_handler(single_db_path)
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        with pytest.raises(sqlite3.IntegrityError):
+            handler._api_binder_delete(1)
+        assert handler._responses == []
+
+        _assert_writes_still_work(single_db_path, "after_binder_delete_error")
+
+
+def test_view_create_error_does_not_lock_db(single_db_path):
+    """_api_view_create must release its connection when the write fails."""
+    setup = sqlite3.connect(single_db_path)
+    _abort_after(setup, "INSERT", "collection_views")
+    setup.commit()
+    setup.close()
+
+    handler = _make_handler(single_db_path)
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        with pytest.raises(sqlite3.IntegrityError):
+            handler._api_view_create(
+                {"name": "Boom View", "filters_json": '{"q": "t:creature"}'})
+        assert handler._responses == []
+
+        _assert_writes_still_work(single_db_path, "after_view_create_error")
+
+
+def test_view_update_error_does_not_lock_db(single_db_path):
+    """_api_view_update must release its connection when the write fails."""
+    setup = sqlite3.connect(single_db_path)
+    setup.execute(
+        "INSERT INTO collection_views (id, name, filters_json, created_at, updated_at) "
+        "VALUES (1, 'View', '{}', '2025-01-01T00:00:00', '2025-01-01T00:00:00')"
+    )
+    _abort_after(setup, "UPDATE", "collection_views")
+    setup.commit()
+    setup.close()
+
+    handler = _make_handler(single_db_path)
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        with pytest.raises(sqlite3.IntegrityError):
+            handler._api_view_update(1, {"name": "Renamed"})
+        assert handler._responses == []
+
+        _assert_writes_still_work(single_db_path, "after_view_update_error")
+
+
+def test_view_delete_error_does_not_lock_db(single_db_path):
+    """_api_view_delete must release its connection when the write fails."""
+    setup = sqlite3.connect(single_db_path)
+    setup.execute(
+        "INSERT INTO collection_views (id, name, filters_json, created_at, updated_at) "
+        "VALUES (1, 'View', '{}', '2025-01-01T00:00:00', '2025-01-01T00:00:00')"
+    )
+    _abort_after(setup, "DELETE", "collection_views")
+    setup.commit()
+    setup.close()
+
+    handler = _make_handler(single_db_path)
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        with pytest.raises(sqlite3.IntegrityError):
+            handler._api_view_delete(1)
+        assert handler._responses == []
+
+        _assert_writes_still_work(single_db_path, "after_view_delete_error")

--- a/tests/test_attach_shared.py
+++ b/tests/test_attach_shared.py
@@ -416,216 +416,6 @@ def test_deck_add_cards_integrity_error_does_not_lock_db(single_db_path):
         "INSERT INTO decks (id, name, state_id, created_at, updated_at) "
         "VALUES (1, 'Test Deck', 1, '2025-01-01T00:00:00', '2025-01-01T00:00:00')"
     )
-# ── Binder / view CRUD handlers must not leak the connection (efj-mtgc-5oa) ──
-
-
-def _abort_after(conn, event, table):
-    """Install a trigger that aborts *after* a write has dirtied `table`.
-
-    RAISE(ABORT) surfaces as sqlite3.IntegrityError. Because the row was
-    already written, the connection is left holding an open write transaction
-    — exactly the state a leaked connection wedges the DB in under WAL. A
-    trigger (not a foreign key) is used deliberately: the deployed split-DB
-    config runs with PRAGMA foreign_keys OFF, so FK errors are unreachable
-    there, while trigger/CHECK aborts always fire.
-    """
-    conn.execute(
-        f"CREATE TRIGGER boom_{event}_{table} AFTER {event} ON {table} "
-        f"BEGIN SELECT RAISE(ABORT, 'boom'); END"
-    )
-
-
-def _assert_writes_still_work(db_path, key):
-    """The DB must still accept writes — i.e. the connection was released."""
-# ── Sealed collection handler connection-leak tests (efj-mtgc-dw0) ──
-
-
-def _seed_sealed_product(db_path, *, entry_status=None, quantity=1):
-    """Insert a sealed_products row, and optionally a sealed_collection entry."""
-    conn = sqlite3.connect(db_path)
-    conn.execute(
-        "INSERT INTO sealed_products (uuid, name, set_code, category, imported_at) "
-        "VALUES ('sealed-uuid-1', 'Test Booster Box', 'tst', 'booster_box', "
-        "'2025-01-01T00:00:00')"
-    )
-    if entry_status is not None:
-        conn.execute(
-            "INSERT INTO sealed_collection "
-            "(id, sealed_product_uuid, quantity, condition, status, added_at) "
-            "VALUES (1, 'sealed-uuid-1', ?, 'Near Mint', ?, '2025-01-01T00:00:00')",
-            (quantity, entry_status),
-        )
-# ── Order handler connection-leak tests (efj-mtgc-skh) ──
-#
-# Detection pattern: lock-based (as in efj-mtgc-7rp / -5oa / -dw0).
-#
-# Every one of these four handlers writes a `status_log` row as the last step
-# of its unit of work, after it has already dirtied a page in `collection` or
-# `orders`. An AFTER INSERT trigger on `status_log` that RAISE(ABORT)s
-# therefore aborts the statement while leaving the write transaction open —
-# exactly the production shape, where an exception escapes the handler before
-# conn.close() runs and the leaked connection keeps the WAL write lock. Every
-# later write then fails "database is locked" until the process restarts.
-#
-# A trigger is used rather than a foreign key on purpose: in the deployed
-# split-DB configuration PRAGMA foreign_keys is OFF, so FK-based failures are
-# unreachable there.
-#
-# Each test also asserts the exception propagates (pytest.raises) and that the
-# handler sent no response (`_responses == []`), so a "fix" that swallows the
-# error into a tidy JSON body fails — CLAUDE.md forbids that trade.
-
-_STATUS_LOG_BOMB = (
-    "CREATE TRIGGER status_log_bomb AFTER INSERT ON status_log "
-    "BEGIN SELECT RAISE(ABORT, 'status_log_bomb'); END"
-)
-
-
-def _arm_status_log_bomb(db_path):
-    """Make any status_log insert abort, after the caller has dirtied a page."""
-    conn = sqlite3.connect(db_path)
-    conn.execute(_STATUS_LOG_BOMB)
-# ── Wishlist / collection handler connection-leak tests (efj-mtgc-0p8) ──
-#
-# _api_wishlist_add, _api_wishlist_bulk_add, _api_wishlist_fulfill,
-# _api_collection_add and _api_collection_dispose each opened a connection with
-# _get_conn() and closed it only on their success / early-return paths. Any
-# other exception escaped before conn.close(), leaking the connection — the
-# traceback pins the handler frame, so it is never GC'd.
-#
-# Every one of them writes before it can fail, so the leaked connection is still
-# inside an open write transaction. Under WAL that pins the single write lock
-# and every later write fails "database is locked" until the process restarts.
-# Reads keep working, so the service looks healthy while silently refusing all
-# mutations.
-#
-# Detection is lock-based: trigger the error, then assert an independent writer
-# still succeeds. Each test also asserts, before that check, that
-#   1. the original exception still propagates (pytest.raises), and
-#   2. handler._responses == []
-# so a "fix" that swallows the error into a tidy JSON body fails the test
-# (CLAUDE.md: "NEVER add fallback logic. Errors should propagate.").
-#
-# The errors are provoked with an AFTER-trigger that RAISE(ABORT)s. ABORT undoes
-# only the offending statement, so the surrounding write transaction — and its
-# WAL write lock — stays open, exactly as in production. A trigger is used
-# rather than a foreign key because the deployed split-DB configuration runs
-# with PRAGMA foreign_keys OFF, which would make an FK-based error unreachable
-# there; triggers and CHECK constraints fire either way.
-
-
-def _install_abort_trigger(db_path, name, event, table):
-    """Add an AFTER-trigger on `table` that aborts the statement."""
-    conn = sqlite3.connect(db_path)
-    conn.execute(
-        f"CREATE TRIGGER {name} AFTER {event} ON {table} "
-        f"BEGIN SELECT RAISE(ABORT, 'boom'); END"
-    )
-    conn.commit()
-    conn.close()
-
-
-def _assert_writes_still_work(db_path, key):
-    """The next writer must not hit 'database is locked'."""
-    conn2 = sqlite3.connect(db_path, timeout=1)
-    conn2.execute("INSERT INTO settings (key, value) VALUES (?, 'ok')", (key,))
-    conn2.commit()
-    conn2.close()
-# ── Connection-leak regression tests (efj-mtgc-656) ──
-#
-# Each of these handlers opened a connection with _get_conn() and closed it only
-# on its success / early-return paths. Any other exception escaped before
-# conn.close(), leaking the connection — the traceback keeps the handler frame
-# (and therefore the connection) alive, so it is never GC'd.
-#
-# When the escaping error happens *after* the handler has already written, the
-# leaked connection is still inside an open write transaction. Under WAL that
-# pins the single write lock and every later write fails "database is locked"
-# until the process restarts. Reads keep working, so the service looks healthy
-# while silently refusing all mutations.
-#
-# Every test asserts, in order:
-#   1. the original exception still propagates (pytest.raises)
-#   2. handler._responses == []  — the fix must not swallow the error into a
-#      tidy JSON body (CLAUDE.md: "NEVER add fallback logic")
-#   3. every connection the handler opened is now closed
-# and, for the handlers that write before failing, additionally that a
-# subsequent independent write succeeds (the write lock was really released).
-
-
-def _seed_deck_fixtures(db_path):
-    """Add a deck and a one-card batch to the standard single-DB fixture."""
-    conn = sqlite3.connect(db_path)
-    conn.execute(
-        "INSERT INTO decks (id, name, state_id, created_at, updated_at) "
-        "VALUES (1, 'Test Deck', 1, '2025-01-01T00:00:00', '2025-01-01T00:00:00')"
-    )
-    conn.execute(
-        "INSERT INTO batches (id, batch_uuid, name, batch_type, created_at) "
-        "VALUES (1, 'batch-uuid-1', 'Test Batch', 'manual', '2025-01-01T00:00:00')"
-    )
-    conn.execute("UPDATE collection SET batch_id = 1")
-def _seed_wishlist_entry(db_path):
-    """Insert an unfulfilled oracle-level wishlist row (id 1)."""
-    conn = sqlite3.connect(db_path)
-    conn.execute(
-        "INSERT INTO wishlist (id, oracle_id, priority, added_at, source) "
-        "VALUES (1, 'oracle-1', 0, '2025-01-01T00:00:00', 'manual')"
-    )
-    conn.commit()
-    conn.close()
-
-
-def _call_expecting_leak(handler, fn, exc_type):
-    """Run fn() expecting exc_type; assert it propagated and nothing leaked.
-
-    Spies on sqlite3.connect so we can prove every connection the handler
-    opened was actually closed — that is the invariant try/finally restores,
-    and it holds whether or not a write transaction was open at the time.
-    """
-    import mtg_collector.cli.crack_pack_server as cps
-
-    created = []
-    real_connect = sqlite3.connect
-
-    def spy(*args, **kwargs):
-        conn = real_connect(*args, **kwargs)
-        created.append(conn)
-        return conn
-
-    with patch.object(cps.sqlite3, "connect", spy):
-        with pytest.raises(exc_type):
-            fn()
-
-    # The error must reach the caller, not become a tidy JSON error response.
-    assert handler._responses == []
-    assert created, "handler opened no connection — test trigger is wrong"
-    for conn in created:
-        with pytest.raises(sqlite3.ProgrammingError):
-            conn.execute("SELECT 1")
-
-
-def _assert_lock_released(db_path, key):
-    """The WAL write lock must be free: an independent writer must succeed."""
-def _assert_wal_write_lock_free(db_path, key):
-    """An independent writer must succeed — the write lock was really released."""
-    conn = sqlite3.connect(db_path, timeout=1)
-    conn.execute("INSERT INTO settings (key, value) VALUES (?, 'ok')", (key,))
-    conn.commit()
-    conn.close()
-
-    check = sqlite3.connect(db_path)
-    row = check.execute(
-        "SELECT value FROM settings WHERE key = ?", (key,)).fetchone()
-    assert row is not None
-    assert row[0] == "ok"
-    check.close()
-
-
-def test_binder_create_error_does_not_lock_db(single_db_path):
-    """_api_binder_create must release its connection when the write fails."""
-    setup = sqlite3.connect(single_db_path)
-    _abort_after(setup, "INSERT", "binders")
     setup.commit()
     setup.close()
 
@@ -662,48 +452,6 @@ def test_binder_add_cards_integrity_error_does_not_lock_db(single_db_path):
     a foreign key; a non-existent binder_id raises IntegrityError once FK
     enforcement is on (default mode), which must not leak the connection.
     """
-        # The error must reach the caller, not become a tidy JSON response.
-        with pytest.raises(sqlite3.IntegrityError):
-            handler._api_binder_create({"name": "Boom Binder"})
-        assert handler._responses == []
-
-        _assert_writes_still_work(single_db_path, "after_binder_create_error")
-
-
-def test_binder_update_error_does_not_lock_db(single_db_path):
-    """_api_binder_update must release its connection when the write fails."""
-    setup = sqlite3.connect(single_db_path)
-    setup.execute(
-        "INSERT INTO binders (id, name, created_at, updated_at) "
-        "VALUES (1, 'Binder', '2025-01-01T00:00:00', '2025-01-01T00:00:00')"
-    )
-    _abort_after(setup, "UPDATE", "binders")
-    setup.commit()
-    setup.close()
-
-def test_sealed_collection_add_integrity_error_does_not_lock_db(single_db_path):
-    """_api_sealed_collection_add must release the connection on any exception.
-
-    Reproduces efj-mtgc-dw0: the handler closed the connection only on its
-    success and not-found paths, so the IntegrityError raised by
-    sealed_collection's status CHECK constraint escaped before conn.close().
-    The leaked connection kept an open write transaction; under WAL mode that
-    holds the write lock and every subsequent write fails "database is locked"
-    until the service is restarted.
-
-    Also asserts the error still propagates — releasing the lock must not turn
-    into swallowing the error into a tidy JSON response.
-    """
-    _seed_sealed_product(single_db_path)
-def test_wishlist_add_abort_does_not_lock_db(single_db_path):
-    """_api_wishlist_add has no except at all — every error leaks the connection.
-
-    The INSERT into wishlist opens the write transaction and the AFTER-trigger
-    aborts it, so the IntegrityError escapes past conn.close() with the WAL
-    write lock still held by the leaked connection.
-    """
-    _install_abort_trigger(
-        single_db_path, "wishlist_add_boom", "INSERT", "wishlist")
     handler = _make_handler(single_db_path)
 
     with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
@@ -723,6 +471,72 @@ def test_wishlist_add_abort_does_not_lock_db(single_db_path):
     assert row is not None
     assert row[0] == "ok"
     check.close()
+
+
+def _abort_after(conn, event, table):
+    """Install a trigger that aborts *after* a write has dirtied `table`.
+
+    RAISE(ABORT) surfaces as sqlite3.IntegrityError. Because the row was
+    already written, the connection is left holding an open write transaction
+    — exactly the state a leaked connection wedges the DB in under WAL. A
+    trigger (not a foreign key) is used deliberately: the deployed split-DB
+    config runs with PRAGMA foreign_keys OFF, so FK errors are unreachable
+    there, while trigger/CHECK aborts always fire.
+    """
+    conn.execute(
+        f"CREATE TRIGGER boom_{event}_{table} AFTER {event} ON {table} "
+        f"BEGIN SELECT RAISE(ABORT, 'boom'); END"
+    )
+
+
+def _assert_writes_still_work(db_path, key):
+    """The DB must still accept writes — i.e. the connection was released."""
+    conn2 = sqlite3.connect(db_path, timeout=1)
+    conn2.execute("INSERT INTO settings (key, value) VALUES (?, 'ok')", (key,))
+    conn2.commit()
+    conn2.close()
+
+    check = sqlite3.connect(db_path)
+    row = check.execute(
+        "SELECT value FROM settings WHERE key = ?", (key,)).fetchone()
+    assert row is not None
+    assert row[0] == "ok"
+    check.close()
+
+
+def test_binder_create_error_does_not_lock_db(single_db_path):
+    """_api_binder_create must release its connection when the write fails."""
+    setup = sqlite3.connect(single_db_path)
+    _abort_after(setup, "INSERT", "binders")
+    setup.commit()
+    setup.close()
+
+    handler = _make_handler(single_db_path)
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        # The error must reach the caller, not become a tidy JSON response.
+        with pytest.raises(sqlite3.IntegrityError):
+            handler._api_binder_create({"name": "Boom Binder"})
+        assert handler._responses == []
+
+        _assert_writes_still_work(single_db_path, "after_binder_create_error")
+
+
+def test_binder_update_error_does_not_lock_db(single_db_path):
+    """_api_binder_update must release its connection when the write fails."""
+    setup = sqlite3.connect(single_db_path)
+    setup.execute(
+        "INSERT INTO binders (id, name, created_at, updated_at) "
+        "VALUES (1, 'Binder', '2025-01-01T00:00:00', '2025-01-01T00:00:00')"
+    )
+    _abort_after(setup, "UPDATE", "binders")
+    setup.commit()
+    setup.close()
+
+    handler = _make_handler(single_db_path)
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        with pytest.raises(sqlite3.IntegrityError):
             handler._api_binder_update(1, {"name": "Renamed"})
         assert handler._responses == []
 
@@ -746,40 +560,6 @@ def test_binder_delete_error_does_not_lock_db(single_db_path):
     setup.commit()
     setup.close()
 
-            handler._api_wishlist_add({"name": "Local Card"})
-        assert handler._responses == []
-
-        _assert_wal_write_lock_free(single_db_path, "after_wishlist_add_error")
-
-
-def test_wishlist_bulk_add_item_error_does_not_lock_db(single_db_path):
-    """_api_wishlist_bulk_add's per-item except does not cover the item unpack.
-
-    `item.get("name")` runs *outside* the inner `except Exception`, so a
-    non-dict entry raises AttributeError straight out of the handler. The
-    preceding item has already been INSERTed, so the leaked connection holds an
-    open write transaction and, with it, the WAL write lock.
-    """
-    handler = _make_handler(single_db_path)
-
-    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
-        with pytest.raises(AttributeError):
-            handler._api_wishlist_bulk_add(
-                {"cards": [{"name": "Local Card"}, "not-a-dict"]})
-        assert handler._responses == []
-
-        _assert_wal_write_lock_free(single_db_path, "after_wishlist_bulk_error")
-
-
-def test_wishlist_fulfill_abort_does_not_lock_db(single_db_path):
-    """_api_wishlist_fulfill has no except at all — every error leaks.
-
-    The UPDATE opens the write transaction; the AFTER UPDATE trigger aborts the
-    statement but leaves the transaction, and the WAL write lock, held.
-    """
-    _seed_wishlist_entry(single_db_path)
-    _install_abort_trigger(
-        single_db_path, "wishlist_fulfill_boom", "UPDATE", "wishlist")
     handler = _make_handler(single_db_path)
 
     with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
@@ -797,23 +577,6 @@ def test_view_create_error_does_not_lock_db(single_db_path):
     setup.commit()
     setup.close()
 
-            handler._api_wishlist_fulfill(1)
-        assert handler._responses == []
-
-        _assert_wal_write_lock_free(
-            single_db_path, "after_wishlist_fulfill_error")
-
-
-def test_collection_add_abort_does_not_lock_db(single_db_path):
-    """_api_collection_add has no except at all — every error leaks.
-
-    CollectionRepository.add() INSERTs the collection row and only then the
-    status_log row. Aborting the status_log INSERT leaves the already-written
-    collection row in an open write transaction, so the leaked connection pins
-    the WAL write lock.
-    """
-    _install_abort_trigger(
-        single_db_path, "collection_add_boom", "INSERT", "status_log")
     handler = _make_handler(single_db_path)
 
     with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
@@ -836,25 +599,6 @@ def test_view_update_error_does_not_lock_db(single_db_path):
     setup.commit()
     setup.close()
 
-            handler._api_collection_add({"printing_id": "print-1"})
-        assert handler._responses == []
-
-        _assert_wal_write_lock_free(single_db_path, "after_collection_add_error")
-
-
-def test_collection_dispose_non_valueerror_does_not_lock_db(single_db_path):
-    """_api_collection_dispose catches only ValueError — anything else leaks.
-
-    A valid owned -> sold transition UPDATEs the collection row and then logs
-    the change to status_log. Aborting that INSERT raises IntegrityError, which
-    sails past the narrow `except ValueError` and past conn.close() with the
-    collection UPDATE — and the WAL write lock — still uncommitted.
-
-    The `except ValueError` clause must stay exactly as narrow as it is: this
-    test fails if it is widened into swallowing the IntegrityError.
-    """
-    _install_abort_trigger(
-        single_db_path, "collection_dispose_boom", "INSERT", "status_log")
     handler = _make_handler(single_db_path)
 
     with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
@@ -884,7 +628,66 @@ def test_view_delete_error_does_not_lock_db(single_db_path):
         assert handler._responses == []
 
         _assert_writes_still_work(single_db_path, "after_view_delete_error")
-# --- Handlers that write before failing: these wedge the DB when leaked. ---
+
+
+def _seed_deck_fixtures(db_path):
+    """Add a deck and a one-card batch to the standard single-DB fixture."""
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO decks (id, name, state_id, created_at, updated_at) "
+        "VALUES (1, 'Test Deck', 1, '2025-01-01T00:00:00', '2025-01-01T00:00:00')"
+    )
+    conn.execute(
+        "INSERT INTO batches (id, batch_uuid, name, batch_type, created_at) "
+        "VALUES (1, 'batch-uuid-1', 'Test Batch', 'manual', '2025-01-01T00:00:00')"
+    )
+    conn.execute("UPDATE collection SET batch_id = 1")
+    conn.commit()
+    conn.close()
+
+
+def _call_expecting_leak(handler, fn, exc_type):
+    """Run fn() expecting exc_type; assert it propagated and nothing leaked.
+
+    Spies on sqlite3.connect so we can prove every connection the handler
+    opened was actually closed — that is the invariant try/finally restores,
+    and it holds whether or not a write transaction was open at the time.
+    """
+    import mtg_collector.cli.crack_pack_server as cps
+
+    created = []
+    real_connect = sqlite3.connect
+
+    def spy(*args, **kwargs):
+        conn = real_connect(*args, **kwargs)
+        created.append(conn)
+        return conn
+
+    with patch.object(cps.sqlite3, "connect", spy):
+        with pytest.raises(exc_type):
+            fn()
+
+    # The error must reach the caller, not become a tidy JSON error response.
+    assert handler._responses == []
+    assert created, "handler opened no connection — test trigger is wrong"
+    for conn in created:
+        with pytest.raises(sqlite3.ProgrammingError):
+            conn.execute("SELECT 1")
+
+
+def _assert_lock_released(db_path, key):
+    """The WAL write lock must be free: an independent writer must succeed."""
+    conn = sqlite3.connect(db_path, timeout=1)
+    conn.execute("INSERT INTO settings (key, value) VALUES (?, 'ok')", (key,))
+    conn.commit()
+    conn.close()
+
+    check = sqlite3.connect(db_path)
+    row = check.execute(
+        "SELECT value FROM settings WHERE key = ?", (key,)).fetchone()
+    assert row is not None
+    assert row[0] == "ok"
+    check.close()
 
 
 def test_deck_expected_set_error_does_not_lock_db(single_db_path):
@@ -948,11 +751,6 @@ def test_batch_assign_deck_error_does_not_lock_db(single_db_path):
             sqlite3.IntegrityError,
         )
         _assert_lock_released(single_db_path, "after_batch_assign_error")
-
-
-# --- Handlers that fail before their first write. No write transaction is
-# --- open, so the WAL lock is not held; the leak is still a leaked connection
-# --- and is asserted as such.
 
 
 def test_deck_create_error_does_not_leak_conn(single_db_path):
@@ -1030,6 +828,45 @@ def test_builder_remove_card_error_does_not_leak_conn(single_db_path):
                 1, {"collection_id": {"unbindable": 1}}),
             sqlite3.ProgrammingError,
         )
+
+
+def _seed_sealed_product(db_path, *, entry_status=None, quantity=1):
+    """Insert a sealed_products row, and optionally a sealed_collection entry."""
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO sealed_products (uuid, name, set_code, category, imported_at) "
+        "VALUES ('sealed-uuid-1', 'Test Booster Box', 'tst', 'booster_box', "
+        "'2025-01-01T00:00:00')"
+    )
+    if entry_status is not None:
+        conn.execute(
+            "INSERT INTO sealed_collection "
+            "(id, sealed_product_uuid, quantity, condition, status, added_at) "
+            "VALUES (1, 'sealed-uuid-1', ?, 'Near Mint', ?, '2025-01-01T00:00:00')",
+            (quantity, entry_status),
+        )
+    conn.commit()
+    conn.close()
+
+
+def test_sealed_collection_add_integrity_error_does_not_lock_db(single_db_path):
+    """_api_sealed_collection_add must release the connection on any exception.
+
+    Reproduces efj-mtgc-dw0: the handler closed the connection only on its
+    success and not-found paths, so the IntegrityError raised by
+    sealed_collection's status CHECK constraint escaped before conn.close().
+    The leaked connection kept an open write transaction; under WAL mode that
+    holds the write lock and every subsequent write fails "database is locked"
+    until the service is restarted.
+
+    Also asserts the error still propagates — releasing the lock must not turn
+    into swallowing the error into a tidy JSON response.
+    """
+    _seed_sealed_product(single_db_path)
+    handler = _make_handler(single_db_path)
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        with pytest.raises(sqlite3.IntegrityError):
             handler._api_sealed_collection_add({
                 "sealed_product_uuid": "sealed-uuid-1",
                 "status": "not_a_real_status",
@@ -1080,20 +917,20 @@ def test_sealed_collection_bulk_dispose_error_does_not_lock_db(single_db_path):
         assert handler._responses == []
 
         _assert_writes_still_work(single_db_path, "after_sealed_bulk_error")
-def _assert_writes_still_work(db_path, marker):
-    """A leaked connection holds the WAL write lock; this write proves it isn't."""
-    conn2 = sqlite3.connect(db_path, timeout=1)
-    conn2.execute("INSERT INTO settings (key, value) VALUES (?, 'ok')", (marker,))
-    conn2.commit()
-    conn2.close()
 
-    check = sqlite3.connect(db_path)
-    row = check.execute(
-        "SELECT value FROM settings WHERE key = ?", (marker,)
-    ).fetchone()
-    check.close()
-    assert row is not None
-    assert row[0] == "ok"
+
+_STATUS_LOG_BOMB = (
+    "CREATE TRIGGER status_log_bomb AFTER INSERT ON status_log "
+    "BEGIN SELECT RAISE(ABORT, 'status_log_bomb'); END"
+)
+
+
+def _arm_status_log_bomb(db_path):
+    """Make any status_log insert abort, after the caller has dirtied a page."""
+    conn = sqlite3.connect(db_path)
+    conn.execute(_STATUS_LOG_BOMB)
+    conn.commit()
+    conn.close()
 
 
 def _seed_order(db_path, *, ordered_card=False):
@@ -1223,6 +1060,140 @@ def test_order_receive_error_does_not_lock_db(single_db_path):
         assert handler._responses == []
 
         _assert_writes_still_work(single_db_path, "after_order_receive_error")
+
+
+def _install_abort_trigger(db_path, name, event, table):
+    """Add an AFTER-trigger on `table` that aborts the statement."""
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        f"CREATE TRIGGER {name} AFTER {event} ON {table} "
+        f"BEGIN SELECT RAISE(ABORT, 'boom'); END"
+    )
+    conn.commit()
+    conn.close()
+
+
+def _seed_wishlist_entry(db_path):
+    """Insert an unfulfilled oracle-level wishlist row (id 1)."""
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO wishlist (id, oracle_id, priority, added_at, source) "
+        "VALUES (1, 'oracle-1', 0, '2025-01-01T00:00:00', 'manual')"
+    )
+    conn.commit()
+    conn.close()
+
+
+def _assert_wal_write_lock_free(db_path, key):
+    """An independent writer must succeed — the write lock was really released."""
+    conn = sqlite3.connect(db_path, timeout=1)
+    conn.execute("INSERT INTO settings (key, value) VALUES (?, 'ok')", (key,))
+    conn.commit()
+    conn.close()
+
+    check = sqlite3.connect(db_path)
+    row = check.execute(
+        "SELECT value FROM settings WHERE key = ?", (key,)).fetchone()
+    assert row is not None
+    assert row[0] == "ok"
+    check.close()
+
+
+def test_wishlist_add_abort_does_not_lock_db(single_db_path):
+    """_api_wishlist_add has no except at all — every error leaks the connection.
+
+    The INSERT into wishlist opens the write transaction and the AFTER-trigger
+    aborts it, so the IntegrityError escapes past conn.close() with the WAL
+    write lock still held by the leaked connection.
+    """
+    _install_abort_trigger(
+        single_db_path, "wishlist_add_boom", "INSERT", "wishlist")
+    handler = _make_handler(single_db_path)
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        with pytest.raises(sqlite3.IntegrityError):
+            handler._api_wishlist_add({"name": "Local Card"})
+        assert handler._responses == []
+
+        _assert_wal_write_lock_free(single_db_path, "after_wishlist_add_error")
+
+
+def test_wishlist_bulk_add_item_error_does_not_lock_db(single_db_path):
+    """_api_wishlist_bulk_add's per-item except does not cover the item unpack.
+
+    `item.get("name")` runs *outside* the inner `except Exception`, so a
+    non-dict entry raises AttributeError straight out of the handler. The
+    preceding item has already been INSERTed, so the leaked connection holds an
+    open write transaction and, with it, the WAL write lock.
+    """
+    handler = _make_handler(single_db_path)
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        with pytest.raises(AttributeError):
+            handler._api_wishlist_bulk_add(
+                {"cards": [{"name": "Local Card"}, "not-a-dict"]})
+        assert handler._responses == []
+
+        _assert_wal_write_lock_free(single_db_path, "after_wishlist_bulk_error")
+
+
+def test_wishlist_fulfill_abort_does_not_lock_db(single_db_path):
+    """_api_wishlist_fulfill has no except at all — every error leaks.
+
+    The UPDATE opens the write transaction; the AFTER UPDATE trigger aborts the
+    statement but leaves the transaction, and the WAL write lock, held.
+    """
+    _seed_wishlist_entry(single_db_path)
+    _install_abort_trigger(
+        single_db_path, "wishlist_fulfill_boom", "UPDATE", "wishlist")
+    handler = _make_handler(single_db_path)
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        with pytest.raises(sqlite3.IntegrityError):
+            handler._api_wishlist_fulfill(1)
+        assert handler._responses == []
+
+        _assert_wal_write_lock_free(
+            single_db_path, "after_wishlist_fulfill_error")
+
+
+def test_collection_add_abort_does_not_lock_db(single_db_path):
+    """_api_collection_add has no except at all — every error leaks.
+
+    CollectionRepository.add() INSERTs the collection row and only then the
+    status_log row. Aborting the status_log INSERT leaves the already-written
+    collection row in an open write transaction, so the leaked connection pins
+    the WAL write lock.
+    """
+    _install_abort_trigger(
+        single_db_path, "collection_add_boom", "INSERT", "status_log")
+    handler = _make_handler(single_db_path)
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        with pytest.raises(sqlite3.IntegrityError):
+            handler._api_collection_add({"printing_id": "print-1"})
+        assert handler._responses == []
+
+        _assert_wal_write_lock_free(single_db_path, "after_collection_add_error")
+
+
+def test_collection_dispose_non_valueerror_does_not_lock_db(single_db_path):
+    """_api_collection_dispose catches only ValueError — anything else leaks.
+
+    A valid owned -> sold transition UPDATEs the collection row and then logs
+    the change to status_log. Aborting that INSERT raises IntegrityError, which
+    sails past the narrow `except ValueError` and past conn.close() with the
+    collection UPDATE — and the WAL write lock — still uncommitted.
+
+    The `except ValueError` clause must stay exactly as narrow as it is: this
+    test fails if it is widened into swallowing the IntegrityError.
+    """
+    _install_abort_trigger(
+        single_db_path, "collection_dispose_boom", "INSERT", "status_log")
+    handler = _make_handler(single_db_path)
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        with pytest.raises(sqlite3.IntegrityError):
             handler._api_collection_dispose(1, {"new_status": "sold"})
         assert handler._responses == []
 

--- a/tests/test_attach_shared.py
+++ b/tests/test_attach_shared.py
@@ -398,3 +398,233 @@ def test_handler_write_error_does_not_lock_db(single_db_path):
     assert row is not None
     assert row[0] == "ok"
     check.close()
+
+
+# ── Connection-leak regression tests (efj-mtgc-656) ──
+#
+# Each of these handlers opened a connection with _get_conn() and closed it only
+# on its success / early-return paths. Any other exception escaped before
+# conn.close(), leaking the connection — the traceback keeps the handler frame
+# (and therefore the connection) alive, so it is never GC'd.
+#
+# When the escaping error happens *after* the handler has already written, the
+# leaked connection is still inside an open write transaction. Under WAL that
+# pins the single write lock and every later write fails "database is locked"
+# until the process restarts. Reads keep working, so the service looks healthy
+# while silently refusing all mutations.
+#
+# Every test asserts, in order:
+#   1. the original exception still propagates (pytest.raises)
+#   2. handler._responses == []  — the fix must not swallow the error into a
+#      tidy JSON body (CLAUDE.md: "NEVER add fallback logic")
+#   3. every connection the handler opened is now closed
+# and, for the handlers that write before failing, additionally that a
+# subsequent independent write succeeds (the write lock was really released).
+
+
+def _seed_deck_fixtures(db_path):
+    """Add a deck and a one-card batch to the standard single-DB fixture."""
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO decks (id, name, state_id, created_at, updated_at) "
+        "VALUES (1, 'Test Deck', 1, '2025-01-01T00:00:00', '2025-01-01T00:00:00')"
+    )
+    conn.execute(
+        "INSERT INTO batches (id, batch_uuid, name, batch_type, created_at) "
+        "VALUES (1, 'batch-uuid-1', 'Test Batch', 'manual', '2025-01-01T00:00:00')"
+    )
+    conn.execute("UPDATE collection SET batch_id = 1")
+    conn.commit()
+    conn.close()
+
+
+def _call_expecting_leak(handler, fn, exc_type):
+    """Run fn() expecting exc_type; assert it propagated and nothing leaked.
+
+    Spies on sqlite3.connect so we can prove every connection the handler
+    opened was actually closed — that is the invariant try/finally restores,
+    and it holds whether or not a write transaction was open at the time.
+    """
+    import mtg_collector.cli.crack_pack_server as cps
+
+    created = []
+    real_connect = sqlite3.connect
+
+    def spy(*args, **kwargs):
+        conn = real_connect(*args, **kwargs)
+        created.append(conn)
+        return conn
+
+    with patch.object(cps.sqlite3, "connect", spy):
+        with pytest.raises(exc_type):
+            fn()
+
+    # The error must reach the caller, not become a tidy JSON error response.
+    assert handler._responses == []
+    assert created, "handler opened no connection — test trigger is wrong"
+    for conn in created:
+        with pytest.raises(sqlite3.ProgrammingError):
+            conn.execute("SELECT 1")
+
+
+def _assert_lock_released(db_path, key):
+    """The WAL write lock must be free: an independent writer must succeed."""
+    conn = sqlite3.connect(db_path, timeout=1)
+    conn.execute("INSERT INTO settings (key, value) VALUES (?, 'ok')", (key,))
+    conn.commit()
+    conn.close()
+
+    check = sqlite3.connect(db_path)
+    row = check.execute(
+        "SELECT value FROM settings WHERE key = ?", (key,)).fetchone()
+    assert row is not None
+    assert row[0] == "ok"
+    check.close()
+
+
+# --- Handlers that write before failing: these wedge the DB when leaked. ---
+
+
+def test_deck_expected_set_error_does_not_lock_db(single_db_path):
+    """set_expected_cards() DELETEs, then hits UNIQUE(deck_id, printing_id, zone).
+
+    The DELETE opens the write transaction, so the leaked connection holds the
+    WAL write lock.
+    """
+    _seed_deck_fixtures(single_db_path)
+    handler = _make_handler(single_db_path)
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        _call_expecting_leak(
+            handler,
+            lambda: handler._api_deck_expected_set(1, {"cards": [
+                {"printing_id": "print-1", "zone": "mainboard"},
+                {"printing_id": "print-1", "zone": "mainboard"},
+            ]}),
+            sqlite3.IntegrityError,
+        )
+        _assert_lock_released(single_db_path, "after_expected_set_error")
+
+
+def test_deck_materialize_error_does_not_lock_db(single_db_path):
+    """An expected card whose zone deck_cards' CHECK rejects.
+
+    deck_expected_cards.zone has no CHECK, but materialize_deck() copies it
+    into deck_cards.zone, which does. CHECK constraints fire regardless of
+    PRAGMA foreign_keys, so this also reproduces in the split-DB deployment.
+    """
+    _seed_deck_fixtures(single_db_path)
+    conn = sqlite3.connect(single_db_path)
+    conn.execute(
+        "INSERT INTO deck_expected_cards (deck_id, printing_id, zone, quantity) "
+        "VALUES (1, 'print-1', 'bogus_zone', 1)"
+    )
+    conn.commit()
+    conn.close()
+
+    handler = _make_handler(single_db_path)
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        _call_expecting_leak(
+            handler, lambda: handler._api_deck_materialize(1),
+            sqlite3.IntegrityError,
+        )
+        _assert_lock_released(single_db_path, "after_materialize_error")
+
+
+def test_batch_assign_deck_error_does_not_lock_db(single_db_path):
+    """deck_cards' zone CHECK raises IntegrityError past the except ValueError.
+
+    Same shape as the efj-mtgc-7rp reproduction: the handler caught only
+    ValueError, so IntegrityError escaped before conn.close().
+    """
+    _seed_deck_fixtures(single_db_path)
+    handler = _make_handler(single_db_path)
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        _call_expecting_leak(
+            handler,
+            lambda: handler._api_batch_assign_deck(
+                1, {"deck_id": 1, "deck_zone": "bogus_zone"}),
+            sqlite3.IntegrityError,
+        )
+        _assert_lock_released(single_db_path, "after_batch_assign_error")
+
+
+# --- Handlers that fail before their first write. No write transaction is
+# --- open, so the WAL lock is not held; the leak is still a leaked connection
+# --- and is asserted as such.
+
+
+def test_deck_create_error_does_not_leak_conn(single_db_path):
+    """int(origin_variation) raises after the connection is already open."""
+    handler = _make_handler(single_db_path)
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        _call_expecting_leak(
+            handler,
+            lambda: handler._api_deck_create(
+                {"name": "X", "origin_variation": "abc"}),
+            ValueError,
+        )
+
+
+def test_deck_update_error_does_not_leak_conn(single_db_path):
+    """An unbindable parameter escapes DeckRepository.update()."""
+    _seed_deck_fixtures(single_db_path)
+    handler = _make_handler(single_db_path)
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        _call_expecting_leak(
+            handler,
+            lambda: handler._api_deck_update(1, {"name": {"unbindable": 1}}),
+            sqlite3.ProgrammingError,
+        )
+
+
+def test_deck_delete_error_does_not_leak_conn(single_db_path):
+    """An unbindable deck_id escapes DeckRepository.delete()."""
+    _seed_deck_fixtures(single_db_path)
+    handler = _make_handler(single_db_path)
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        _call_expecting_leak(
+            handler,
+            lambda: handler._api_deck_delete({"unbindable": 1}),
+            sqlite3.ProgrammingError,
+        )
+
+
+def test_deck_reassemble_error_does_not_leak_conn(single_db_path):
+    """An unbindable collection_id escapes DeckRepository.move_cards()."""
+    _seed_deck_fixtures(single_db_path)
+    handler = _make_handler(single_db_path)
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        _call_expecting_leak(
+            handler,
+            lambda: handler._api_deck_reassemble(
+                1, {"collection_ids": [{"unbindable": 1}]}),
+            sqlite3.ProgrammingError,
+        )
+
+
+def test_builder_create_error_does_not_leak_conn(single_db_path):
+    """An unbindable deck name escapes past the handler's except ValueError."""
+    handler = _make_handler(single_db_path)
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        _call_expecting_leak(
+            handler,
+            lambda: handler._api_builder_create({
+                "commander_oracle_id": "oracle-1",
+                "state": "constructed",
+                "name": {"unbindable": 1},
+            }),
+            sqlite3.ProgrammingError,
+        )
+
+
+def test_builder_remove_card_error_does_not_leak_conn(single_db_path):
+    """An unbindable collection_id escapes DeckRepository.remove_cards()."""
+    _seed_deck_fixtures(single_db_path)
+    handler = _make_handler(single_db_path)
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        _call_expecting_leak(
+            handler,
+            lambda: handler._api_builder_remove_card(
+                1, {"collection_id": {"unbindable": 1}}),
+            sqlite3.ProgrammingError,
+        )

--- a/tests/test_attach_shared.py
+++ b/tests/test_attach_shared.py
@@ -398,3 +398,182 @@ def test_handler_write_error_does_not_lock_db(single_db_path):
     assert row is not None
     assert row[0] == "ok"
     check.close()
+
+
+# ── Order handler connection-leak tests (efj-mtgc-skh) ──
+#
+# Detection pattern: lock-based (as in efj-mtgc-7rp / -5oa / -dw0).
+#
+# Every one of these four handlers writes a `status_log` row as the last step
+# of its unit of work, after it has already dirtied a page in `collection` or
+# `orders`. An AFTER INSERT trigger on `status_log` that RAISE(ABORT)s
+# therefore aborts the statement while leaving the write transaction open —
+# exactly the production shape, where an exception escapes the handler before
+# conn.close() runs and the leaked connection keeps the WAL write lock. Every
+# later write then fails "database is locked" until the process restarts.
+#
+# A trigger is used rather than a foreign key on purpose: in the deployed
+# split-DB configuration PRAGMA foreign_keys is OFF, so FK-based failures are
+# unreachable there.
+#
+# Each test also asserts the exception propagates (pytest.raises) and that the
+# handler sent no response (`_responses == []`), so a "fix" that swallows the
+# error into a tidy JSON body fails — CLAUDE.md forbids that trade.
+
+_STATUS_LOG_BOMB = (
+    "CREATE TRIGGER status_log_bomb AFTER INSERT ON status_log "
+    "BEGIN SELECT RAISE(ABORT, 'status_log_bomb'); END"
+)
+
+
+def _arm_status_log_bomb(db_path):
+    """Make any status_log insert abort, after the caller has dirtied a page."""
+    conn = sqlite3.connect(db_path)
+    conn.execute(_STATUS_LOG_BOMB)
+    conn.commit()
+    conn.close()
+
+
+def _assert_writes_still_work(db_path, marker):
+    """A leaked connection holds the WAL write lock; this write proves it isn't."""
+    conn2 = sqlite3.connect(db_path, timeout=1)
+    conn2.execute("INSERT INTO settings (key, value) VALUES (?, 'ok')", (marker,))
+    conn2.commit()
+    conn2.close()
+
+    check = sqlite3.connect(db_path)
+    row = check.execute(
+        "SELECT value FROM settings WHERE key = ?", (marker,)
+    ).fetchone()
+    check.close()
+    assert row is not None
+    assert row[0] == "ok"
+
+
+def _seed_order(db_path, *, ordered_card=False):
+    """Insert order id 1, optionally with one 'ordered' collection row on it."""
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO orders (id, order_number, source, seller_name, order_date, created_at) "
+        "VALUES (1, 'ORD-1', 'tcgplayer', 'Test Seller', '2025-01-01', "
+        "'2025-01-01T00:00:00')"
+    )
+    cid = None
+    if ordered_card:
+        cur = conn.execute(
+            "INSERT INTO collection "
+            "(printing_id, status, finish, condition, acquired_at, source, order_id) "
+            "VALUES ('print-1', 'ordered', 'nonfoil', 'Near Mint', "
+            "'2025-01-01T00:00:00', 'order_import', 1)"
+        )
+        cid = cur.lastrowid
+    conn.commit()
+    conn.close()
+    return cid
+
+
+def test_order_add_card_error_does_not_lock_db(single_db_path):
+    """_api_order_add_card must release its connection when repo.add() fails.
+
+    CollectionRepository.add() inserts the collection row (dirtying a page and
+    taking the write lock) and then the status_log row, which the trigger
+    aborts. Without try/finally the connection leaks with that write
+    transaction still open and wedges every later writer.
+    """
+    _seed_order(single_db_path)
+    _arm_status_log_bomb(single_db_path)
+
+    handler = _make_handler(single_db_path)
+    handler._read_json_body = lambda: {"printing_id": "print-1"}
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        with pytest.raises(sqlite3.IntegrityError):
+            handler._api_order_add_card(1)
+        assert handler._responses == []
+
+        _assert_writes_still_work(single_db_path, "after_order_add_card_error")
+
+
+def test_order_commit_error_does_not_lock_db(single_db_path):
+    """_api_order_commit must release its connection when the commit fails.
+
+    commit_orders() does real multi-row work — order row, collection rows,
+    status_log rows — so an abort part-way through leaves an open write
+    transaction. try/finally must not change those commit semantics, only
+    guarantee the connection is closed.
+    """
+    _arm_status_log_bomb(single_db_path)
+
+    handler = _make_handler(single_db_path)
+    handler._read_json_body = lambda: {
+        "orders": [
+            {
+                "order_number": "ORD-COMMIT-1",
+                "source": "tcgplayer",
+                "seller_name": "Test Seller",
+                "order_date": "2025-01-01",
+                "total": 3.50,
+                "items": [
+                    {
+                        "card_name": "Local Card",
+                        "parsed_name": "Local Card",
+                        "printing_id": "print-1",
+                        "set_code": "tst",
+                        "collector_number": "1",
+                        "condition": "Near Mint",
+                        "foil": False,
+                        "quantity": 1,
+                        "price": 3.50,
+                    }
+                ],
+            }
+        ]
+    }
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        with pytest.raises(sqlite3.IntegrityError):
+            handler._api_order_commit()
+        assert handler._responses == []
+
+        _assert_writes_still_work(single_db_path, "after_order_commit_error")
+
+
+def test_collection_receive_error_does_not_lock_db(single_db_path):
+    """_api_collection_receive must release its connection when the flip fails.
+
+    receive_card() updates the collection row to 'owned' and then writes the
+    status_log row, which aborts — leaving the UPDATE's write lock held on a
+    leaked connection.
+    """
+    cid = _seed_order(single_db_path, ordered_card=True)
+    _arm_status_log_bomb(single_db_path)
+
+    handler = _make_handler(single_db_path)
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        with pytest.raises(sqlite3.IntegrityError):
+            handler._api_collection_receive(cid)
+        assert handler._responses == []
+
+        _assert_writes_still_work(single_db_path, "after_collection_receive_error")
+
+
+def test_order_receive_error_does_not_lock_db(single_db_path):
+    """_api_order_receive must release its connection when the batch flip fails.
+
+    receive_order() updates every ordered card on the order and then logs each
+    status change; the trigger aborts the log insert with the UPDATE already
+    holding the write lock.
+    """
+    _seed_order(single_db_path, ordered_card=True)
+    _arm_status_log_bomb(single_db_path)
+
+    handler = _make_handler(single_db_path)
+    handler._read_json_body = lambda: None
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        with pytest.raises(sqlite3.IntegrityError):
+            handler._api_order_receive(1)
+        assert handler._responses == []
+
+        _assert_writes_still_work(single_db_path, "after_order_receive_error")

--- a/tests/test_attach_shared.py
+++ b/tests/test_attach_shared.py
@@ -398,3 +398,171 @@ def test_handler_write_error_does_not_lock_db(single_db_path):
     assert row is not None
     assert row[0] == "ok"
     check.close()
+
+
+# ── Wishlist / collection handler connection-leak tests (efj-mtgc-0p8) ──
+#
+# _api_wishlist_add, _api_wishlist_bulk_add, _api_wishlist_fulfill,
+# _api_collection_add and _api_collection_dispose each opened a connection with
+# _get_conn() and closed it only on their success / early-return paths. Any
+# other exception escaped before conn.close(), leaking the connection — the
+# traceback pins the handler frame, so it is never GC'd.
+#
+# Every one of them writes before it can fail, so the leaked connection is still
+# inside an open write transaction. Under WAL that pins the single write lock
+# and every later write fails "database is locked" until the process restarts.
+# Reads keep working, so the service looks healthy while silently refusing all
+# mutations.
+#
+# Detection is lock-based: trigger the error, then assert an independent writer
+# still succeeds. Each test also asserts, before that check, that
+#   1. the original exception still propagates (pytest.raises), and
+#   2. handler._responses == []
+# so a "fix" that swallows the error into a tidy JSON body fails the test
+# (CLAUDE.md: "NEVER add fallback logic. Errors should propagate.").
+#
+# The errors are provoked with an AFTER-trigger that RAISE(ABORT)s. ABORT undoes
+# only the offending statement, so the surrounding write transaction — and its
+# WAL write lock — stays open, exactly as in production. A trigger is used
+# rather than a foreign key because the deployed split-DB configuration runs
+# with PRAGMA foreign_keys OFF, which would make an FK-based error unreachable
+# there; triggers and CHECK constraints fire either way.
+
+
+def _install_abort_trigger(db_path, name, event, table):
+    """Add an AFTER-trigger on `table` that aborts the statement."""
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        f"CREATE TRIGGER {name} AFTER {event} ON {table} "
+        f"BEGIN SELECT RAISE(ABORT, 'boom'); END"
+    )
+    conn.commit()
+    conn.close()
+
+
+def _seed_wishlist_entry(db_path):
+    """Insert an unfulfilled oracle-level wishlist row (id 1)."""
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO wishlist (id, oracle_id, priority, added_at, source) "
+        "VALUES (1, 'oracle-1', 0, '2025-01-01T00:00:00', 'manual')"
+    )
+    conn.commit()
+    conn.close()
+
+
+def _assert_wal_write_lock_free(db_path, key):
+    """An independent writer must succeed — the write lock was really released."""
+    conn = sqlite3.connect(db_path, timeout=1)
+    conn.execute("INSERT INTO settings (key, value) VALUES (?, 'ok')", (key,))
+    conn.commit()
+    conn.close()
+
+    check = sqlite3.connect(db_path)
+    row = check.execute(
+        "SELECT value FROM settings WHERE key = ?", (key,)).fetchone()
+    assert row is not None
+    assert row[0] == "ok"
+    check.close()
+
+
+def test_wishlist_add_abort_does_not_lock_db(single_db_path):
+    """_api_wishlist_add has no except at all — every error leaks the connection.
+
+    The INSERT into wishlist opens the write transaction and the AFTER-trigger
+    aborts it, so the IntegrityError escapes past conn.close() with the WAL
+    write lock still held by the leaked connection.
+    """
+    _install_abort_trigger(
+        single_db_path, "wishlist_add_boom", "INSERT", "wishlist")
+    handler = _make_handler(single_db_path)
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        with pytest.raises(sqlite3.IntegrityError):
+            handler._api_wishlist_add({"name": "Local Card"})
+        assert handler._responses == []
+
+        _assert_wal_write_lock_free(single_db_path, "after_wishlist_add_error")
+
+
+def test_wishlist_bulk_add_item_error_does_not_lock_db(single_db_path):
+    """_api_wishlist_bulk_add's per-item except does not cover the item unpack.
+
+    `item.get("name")` runs *outside* the inner `except Exception`, so a
+    non-dict entry raises AttributeError straight out of the handler. The
+    preceding item has already been INSERTed, so the leaked connection holds an
+    open write transaction and, with it, the WAL write lock.
+    """
+    handler = _make_handler(single_db_path)
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        with pytest.raises(AttributeError):
+            handler._api_wishlist_bulk_add(
+                {"cards": [{"name": "Local Card"}, "not-a-dict"]})
+        assert handler._responses == []
+
+        _assert_wal_write_lock_free(single_db_path, "after_wishlist_bulk_error")
+
+
+def test_wishlist_fulfill_abort_does_not_lock_db(single_db_path):
+    """_api_wishlist_fulfill has no except at all — every error leaks.
+
+    The UPDATE opens the write transaction; the AFTER UPDATE trigger aborts the
+    statement but leaves the transaction, and the WAL write lock, held.
+    """
+    _seed_wishlist_entry(single_db_path)
+    _install_abort_trigger(
+        single_db_path, "wishlist_fulfill_boom", "UPDATE", "wishlist")
+    handler = _make_handler(single_db_path)
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        with pytest.raises(sqlite3.IntegrityError):
+            handler._api_wishlist_fulfill(1)
+        assert handler._responses == []
+
+        _assert_wal_write_lock_free(
+            single_db_path, "after_wishlist_fulfill_error")
+
+
+def test_collection_add_abort_does_not_lock_db(single_db_path):
+    """_api_collection_add has no except at all — every error leaks.
+
+    CollectionRepository.add() INSERTs the collection row and only then the
+    status_log row. Aborting the status_log INSERT leaves the already-written
+    collection row in an open write transaction, so the leaked connection pins
+    the WAL write lock.
+    """
+    _install_abort_trigger(
+        single_db_path, "collection_add_boom", "INSERT", "status_log")
+    handler = _make_handler(single_db_path)
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        with pytest.raises(sqlite3.IntegrityError):
+            handler._api_collection_add({"printing_id": "print-1"})
+        assert handler._responses == []
+
+        _assert_wal_write_lock_free(single_db_path, "after_collection_add_error")
+
+
+def test_collection_dispose_non_valueerror_does_not_lock_db(single_db_path):
+    """_api_collection_dispose catches only ValueError — anything else leaks.
+
+    A valid owned -> sold transition UPDATEs the collection row and then logs
+    the change to status_log. Aborting that INSERT raises IntegrityError, which
+    sails past the narrow `except ValueError` and past conn.close() with the
+    collection UPDATE — and the WAL write lock — still uncommitted.
+
+    The `except ValueError` clause must stay exactly as narrow as it is: this
+    test fails if it is widened into swallowing the IntegrityError.
+    """
+    _install_abort_trigger(
+        single_db_path, "collection_dispose_boom", "INSERT", "status_log")
+    handler = _make_handler(single_db_path)
+
+    with patch("mtg_collector.cli.crack_pack_server._shared_db_path", None):
+        with pytest.raises(sqlite3.IntegrityError):
+            handler._api_collection_dispose(1, {"new_status": "sold"})
+        assert handler._responses == []
+
+        _assert_wal_write_lock_free(
+            single_db_path, "after_collection_dispose_error")


### PR DESCRIPTION
A single malformed HTTP request could take down **every write** to the database until the service was restarted. Reads kept working, so the app looked healthy while silently refusing all mutations — an easy failure to misdiagnose.

## The bug

Handlers opened a connection via `self._get_conn()` and closed it only on success paths. Any exception escaping before `conn.close()` leaked a connection holding the **WAL write lock**. The connection was never garbage-collected because the traceback held the handler frame alive.

Reproduced against a container:

```
poison:  POST /api/decks/2/cards {"zone":"bogus_zone"}   -> HTTP 000
         log: sqlite3.IntegrityError: CHECK constraint failed: zone IN (...)
after:   PUT /api/decks/1  x3                             -> 000, 000, 000
         log: database is locked   (still wedged 60s later)
reads:   GET /api/decks                                   -> 200
```

## Scope

An AST audit of all **119** `_get_conn()` call sites found the bug class was far wider than the handler that surfaced it:

| | count |
|---|---|
| total call sites | 119 |
| already protected | 21 |
| **write handlers fixed here** | **33** |
| read-only (leak fds, no write lock) | ~60 — tracked separately as efj-mtgc-5kt |

The 33 were fixed across six areas — deck/binder cards, binders+views, decks/builder/batch, sealed, orders, wishlist/collection — each independently verified, then merged here.

## The fix

`try/finally` so `conn.close()` always runs, matching this file's canonical idiom (21 pre-existing `finally: conn.close()` sites). No `contextlib.closing`, no new abstraction, and **no `except` clause widened** — several handlers keep their narrow `except ValueError`.

The connection is released while **the error still propagates**. Swallowing it into a tidy error response would trade an availability bug for a silent-failure bug, which CLAUDE.md forbids. Every test asserts `pytest.raises(<error>)` **and** `handler._responses == []` before checking the next write succeeds — so a future "fix" that swallows the error fails the tests.

## Verification

Each of the six areas was verified failing-before and passing-after. Two detection patterns were used, both legitimate:

- **Lock-based** — trigger the error, then assert an independent writer succeeds (fails `database is locked` pre-fix). Uses an `AFTER INSERT` trigger that `RAISE(ABORT)`s *after* dirtying a page, so the write lock is genuinely held.
- **Closure-based** — assert `sqlite3.ProgrammingError` on later use, proving closure directly.

Triggers rather than foreign keys, deliberately: the deployed split-DB config runs with `PRAGMA foreign_keys` OFF, so FK-based failures are unreachable there. CHECK constraints always fire.

On the merged branch: **44 leak tests pass**, full unit suite exit 0, `ruff check mtg_collector/` clean, and all **33/33** handlers confirmed wrapped.

## Merge note

The six branches each appended to `tests/test_attach_shared.py` at the same location, so they collided pairwise. The test file here was rebuilt by carrying every new top-level function *and module-level constant* from each branch, deduplicating by name. Three branches defined `_assert_writes_still_work` identically apart from docstring and parameter naming; one copy is kept.

## Related, not fixed here

- **efj-mtgc-5kt** — ~60 read-only handlers with the same pattern. Lower severity (fd exhaustion, not a write wedge). Worth considering a connection context manager before hand-writing 60 more `try/finally` blocks.
- **efj-mtgc-qji** — `_api_collection_copies` is defined twice with differing bodies; the first is dead code.
- `_api_deck_adjust_quantity` has an odd `except (ValueError, Exception)` that does not leak but swallows `IntegrityError` into a 500 body. Left alone as out of scope.
- There is no top-level 500 wrapper in this stdlib `http.server`, so a propagating error surfaces as a logged traceback and dropped connection (HTTP 000) rather than a formatted 500. Pre-existing, and arguably consistent with "let it crash visibly" — but a deliberate decision someone should make.

Closes efj-mtgc-c6j, efj-mtgc-7rp, efj-mtgc-skh, efj-mtgc-656, efj-mtgc-5oa, efj-mtgc-0p8, efj-mtgc-dw0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
