### PR TITLE
Fix latest_sealed_prices dropping ~5% of products from the view

### DIFF
--- a/mtg_collector/db/schema.py
+++ b/mtg_collector/db/schema.py
@@ -3,7 +3,7 @@
 import re
 import sqlite3
 
-SCHEMA_VERSION = 44
+SCHEMA_VERSION = 45
 
 
 class SchemaIntegrityError(Exception):
@@ -559,12 +559,19 @@ FROM sealed_collection sc
 JOIN sealed_products sp ON sc.sealed_product_uuid = sp.uuid
 LEFT JOIN sets s ON sp.set_code = s.set_code;
 
--- Latest sealed prices view (same pattern as latest_prices)
+-- Latest sealed prices view: most recent row PER product (same per-key semantics
+-- as latest_prices). A global MAX(observed_at) would drop any product missing from
+-- the newest fetch even though it has usable price history.
+-- UNIQUE(tcgplayer_product_id, observed_at) makes ties impossible, so this yields
+-- exactly one row per product that has any price row.
 CREATE VIEW IF NOT EXISTS latest_sealed_prices AS
 SELECT tcgplayer_product_id, low_price, mid_price, high_price,
        market_price, direct_low_price, observed_at
-FROM sealed_prices
-WHERE observed_at = (SELECT MAX(observed_at) FROM sealed_prices);
+FROM sealed_prices p
+WHERE p.observed_at = (
+    SELECT MAX(p2.observed_at) FROM sealed_prices p2
+    WHERE p2.tcgplayer_product_id = p.tcgplayer_product_id
+);
 
 -- Denormalized collection view
 CREATE VIEW IF NOT EXISTS collection_view AS
@@ -861,6 +868,8 @@ def init_db(conn: sqlite3.Connection, force: bool = False) -> bool:
             _migrate_v42_to_v43(conn)
         if current < 44:
             _migrate_v43_to_v44(conn)
+        if current < 45:
+            _migrate_v44_to_v45(conn)
 
     # Record schema version
     conn.execute(
@@ -2817,6 +2826,30 @@ def _migrate_v43_to_v44(conn: sqlite3.Connection):
         );
         CREATE INDEX IF NOT EXISTS idx_mtgjson_decks_type ON mtgjson_decks(type);
         CREATE INDEX IF NOT EXISTS idx_mtgjson_decks_set_type ON mtgjson_decks(set_code, type);
+    """)
+
+
+def _migrate_v44_to_v45(conn: sqlite3.Connection):
+    """Redefine latest_sealed_prices to take the latest row PER product.
+
+    The v18 definition filtered on a single global MAX(observed_at), so any product
+    absent from the most recent fetch vanished from the view even when it had a
+    perfectly good price from an earlier day (measured on prod: 2,927 of 3,095
+    products visible, ~5% silently dropped). This matches latest_prices, which is
+    genuinely per-key most-recent.
+
+    A view cannot be altered in place — it must be dropped and recreated.
+    """
+    conn.execute("DROP VIEW IF EXISTS latest_sealed_prices")
+    conn.execute("""
+        CREATE VIEW latest_sealed_prices AS
+        SELECT tcgplayer_product_id, low_price, mid_price, high_price,
+               market_price, direct_low_price, observed_at
+        FROM sealed_prices p
+        WHERE p.observed_at = (
+            SELECT MAX(p2.observed_at) FROM sealed_prices p2
+            WHERE p2.tcgplayer_product_id = p.tcgplayer_product_id
+        )
     """)
 
 

--- a/tests/test_decks_binders.py
+++ b/tests/test_decks_binders.py
@@ -36,7 +36,7 @@ from mtg_collector.db.models import (
     Set,
     SetRepository,
 )
-from mtg_collector.db.schema import get_current_version, init_db
+from mtg_collector.db.schema import SCHEMA_VERSION, get_current_version, init_db
 
 
 @pytest.fixture
@@ -86,8 +86,8 @@ def seeded_db(db):
 # =============================================================================
 
 class TestMigration:
-    def test_fresh_install_has_v44(self, db):
-        assert get_current_version(db) == 44
+    def test_fresh_install_is_current_version(self, db):
+        assert get_current_version(db) == SCHEMA_VERSION
 
     def test_tables_exist(self, db):
         tables = [r[0] for r in db.execute(

--- a/tests/test_sealed_products.py
+++ b/tests/test_sealed_products.py
@@ -1344,3 +1344,196 @@ class TestSealedProductSource:
         product = repo.get("tcgcsv-uuid")
         assert product is not None
         assert product.source == "tcgcsv"
+
+
+# =============================================================================
+# latest_sealed_prices: most recent row PER product (efj-mtgc-gyp)
+# =============================================================================
+
+
+def _seed_prices(conn, rows):
+    """rows = [(product_id, observed_at, market_price), ...]"""
+    conn.executemany(
+        "INSERT INTO sealed_prices (tcgplayer_product_id, observed_at, market_price,"
+        " low_price, mid_price, high_price, direct_low_price)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?)",
+        [(p, d, m, m - 1, m, m + 1, m - 2) for p, d, m in rows],
+    )
+    conn.commit()
+
+
+class TestLatestSealedPricesPerProduct:
+    """The view must return the newest row per tcgplayer_product_id.
+
+    A global MAX(observed_at) filter silently drops every product that was absent
+    from the most recent fetch, even when it has usable price history.
+    """
+
+    def test_product_absent_from_latest_fetch_keeps_its_earlier_price(self, test_db):
+        """Priced on day 1 but not day 2 => still visible, with the day-1 price."""
+        _, conn = test_db
+        _seed_prices(conn, [
+            ("prod-stale", "2026-01-01", 100.0),   # only ever priced on day 1
+            ("prod-fresh", "2026-01-01", 50.0),
+            ("prod-fresh", "2026-01-02", 55.0),    # day 2 = global max
+        ])
+
+        rows = {
+            r["tcgplayer_product_id"]: r
+            for r in conn.execute("SELECT * FROM latest_sealed_prices")
+        }
+
+        assert "prod-stale" in rows, "product missing from newest fetch was dropped"
+        assert rows["prod-stale"]["market_price"] == 100.0
+        assert rows["prod-stale"]["observed_at"] == "2026-01-01"
+        # and the freshly-priced product still resolves to its newest row
+        assert rows["prod-fresh"]["market_price"] == 55.0
+        assert rows["prod-fresh"]["observed_at"] == "2026-01-02"
+
+    def test_row_count_equals_distinct_products_with_any_price(self, test_db):
+        """One row per product that has any price row at all."""
+        _, conn = test_db
+        _seed_prices(conn, [
+            ("a", "2026-01-01", 1.0), ("a", "2026-01-02", 2.0), ("a", "2026-01-03", 3.0),
+            ("b", "2026-01-01", 10.0), ("b", "2026-01-02", 20.0),
+            ("c", "2026-01-01", 100.0),
+            ("d", "2026-01-03", 7.0),
+        ])
+
+        distinct = conn.execute(
+            "SELECT COUNT(DISTINCT tcgplayer_product_id) FROM sealed_prices"
+        ).fetchone()[0]
+        view_rows = conn.execute(
+            "SELECT COUNT(*) FROM latest_sealed_prices"
+        ).fetchone()[0]
+
+        assert distinct == 4
+        assert view_rows == distinct
+
+    def test_single_price_row_product_is_visible(self, test_db):
+        """A product with exactly one price row appears with that row."""
+        _, conn = test_db
+        _seed_prices(conn, [
+            ("only-once", "2026-01-01", 42.0),
+            ("noisy", "2026-01-05", 9.0),
+        ])
+
+        row = conn.execute(
+            "SELECT * FROM latest_sealed_prices WHERE tcgplayer_product_id = 'only-once'"
+        ).fetchone()
+
+        assert row is not None
+        assert row["market_price"] == 42.0
+        assert row["observed_at"] == "2026-01-01"
+
+    def test_per_product_latest_differs_from_global_latest(self, test_db):
+        """The view is genuinely per-product, not the global-max set."""
+        _, conn = test_db
+        _seed_prices(conn, [
+            ("p1", "2026-01-01", 1.0),
+            ("p2", "2026-01-02", 2.0),
+            ("p3", "2026-01-03", 3.0),
+        ])
+
+        global_max_rows = conn.execute(
+            "SELECT COUNT(*) FROM sealed_prices"
+            " WHERE observed_at = (SELECT MAX(observed_at) FROM sealed_prices)"
+        ).fetchone()[0]
+        view_rows = conn.execute("SELECT COUNT(*) FROM latest_sealed_prices").fetchone()[0]
+
+        assert global_max_rows == 1, "global-max filter sees only the newest day"
+        assert view_rows == 3, "per-product view sees every product"
+        assert view_rows != global_max_rows
+
+    def test_no_duplicate_rows_per_product(self, test_db):
+        """UNIQUE(tcgplayer_product_id, observed_at) makes ties impossible.
+
+        Two rows for the same product can never share an observed_at, so the
+        per-product MAX resolves to exactly one row. Documented by asserting the
+        constraint is enforced and that the view never duplicates a product.
+        """
+        _, conn = test_db
+        _seed_prices(conn, [
+            ("dup", "2026-01-01", 5.0),
+            ("dup", "2026-01-02", 6.0),
+        ])
+
+        # A tie on (product, observed_at) is rejected by the schema.
+        with pytest.raises(sqlite3.IntegrityError):
+            _seed_prices(conn, [("dup", "2026-01-02", 99.0)])
+        conn.rollback()
+
+        rows = conn.execute(
+            "SELECT tcgplayer_product_id, COUNT(*) AS n FROM latest_sealed_prices"
+            " GROUP BY tcgplayer_product_id HAVING n > 1"
+        ).fetchall()
+        assert rows == [], "view returned more than one row for a product"
+
+    def test_stats_market_value_includes_stale_priced_products(self, test_db):
+        """/sealed stats must value a product whose newest price is not from today."""
+        _, conn = test_db
+        conn.execute("INSERT INTO sets (set_code, set_name) VALUES ('tst', 'Test Set')")
+        conn.executemany(
+            "INSERT INTO sealed_products (uuid, name, set_code, category,"
+            " tcgplayer_product_id, imported_at) VALUES (?, ?, 'tst', 'booster_box', ?, '2026-01-01')",
+            [("u-stale", "Stale Box", "prod-stale"), ("u-fresh", "Fresh Box", "prod-fresh")],
+        )
+        conn.executemany(
+            "INSERT INTO sealed_collection (sealed_product_uuid, quantity, status, added_at)"
+            " VALUES (?, 1, 'owned', '2026-01-01')",
+            [("u-stale",), ("u-fresh",)],
+        )
+        _seed_prices(conn, [
+            ("prod-stale", "2026-01-01", 100.0),
+            ("prod-fresh", "2026-01-02", 55.0),
+        ])
+
+        stats = SealedCollectionRepository(conn).stats()
+
+        assert stats["market_value"] == 155.0, "stale-priced product valued at zero"
+
+
+class TestMigrationV44ToV45:
+    """An existing DB carrying the old global-max view gets it redefined."""
+
+    def test_existing_db_view_is_redefined(self, test_db):
+        """Simulate a pre-v45 DB, re-run init_db, verify per-product semantics."""
+        db_path, conn = test_db
+
+        # Reinstate the old (buggy) view definition and roll the version back.
+        conn.execute("DROP VIEW IF EXISTS latest_sealed_prices")
+        conn.execute("""
+            CREATE VIEW latest_sealed_prices AS
+            SELECT tcgplayer_product_id, low_price, mid_price, high_price,
+                   market_price, direct_low_price, observed_at
+            FROM sealed_prices
+            WHERE observed_at = (SELECT MAX(observed_at) FROM sealed_prices)
+        """)
+        _seed_prices(conn, [
+            ("keeps", "2026-01-01", 100.0),
+            ("newer", "2026-01-02", 55.0),
+        ])
+        conn.execute("DELETE FROM schema_version")
+        conn.execute(
+            "INSERT INTO schema_version (version, applied_at) VALUES (44, '2026-01-01T00:00:00Z')"
+        )
+        conn.commit()
+
+        # Old view drops the stale product.
+        assert conn.execute("SELECT COUNT(*) FROM latest_sealed_prices").fetchone()[0] == 1
+
+        close_connection()
+        conn2 = get_connection(db_path)
+        init_db(conn2)
+
+        assert get_current_version(conn2) == SCHEMA_VERSION
+        assert conn2.execute("SELECT COUNT(*) FROM latest_sealed_prices").fetchone()[0] == 2
+        row = conn2.execute(
+            "SELECT * FROM latest_sealed_prices WHERE tcgplayer_product_id = 'keeps'"
+        ).fetchone()
+        assert row["market_price"] == 100.0
+
+        # Idempotent: a second init_db is a no-op and leaves the view correct.
+        init_db(conn2)
+        assert conn2.execute("SELECT COUNT(*) FROM latest_sealed_prices").fetchone()[0] == 2
+        close_connection()


### PR DESCRIPTION
The `latest_sealed_prices` view filtered on a **global** max date rather than a per-product max, so any product missing from the most recent fetch vanished from the view entirely — even with a perfectly good price from the day before.

```sql
CREATE VIEW latest_sealed_prices AS
SELECT ... FROM sealed_prices
WHERE observed_at = (SELECT MAX(observed_at) FROM sealed_prices)   -- global
```

## Impact (MEASURED on prod, read-only)

```
sealed_prices rows:                        224,004
distinct products with a price row:          3,095
products visible in latest_sealed_prices:    2,927
==> silently dropped:                          168   (~5%)
```

Per-day product counts drift (07-19: 2927, 07-18: 2931, 07-17: 2934, 07-16: 2931, 07-15: 2936), so products blink in and out of the UI depending on that day's fetch coverage. Users see a blank market price for a product that has price history.

This is inconsistent with card prices, where `latest_prices` is keyed `PRIMARY KEY (set_code, collector_number, source, price_type)` — genuinely per-key.

## The fix

Correlated per-product `MAX(observed_at)`, plus a `44 → 45` migration (views must be dropped and recreated, not altered).

**The measurement that decided the approach is not the obvious one.** Benchmarked as *standalone queries*, join-to-groupmax wins (30ms vs 108ms). Benchmarked as **deployed views** — the shape that actually ships — the ranking inverts, because only the correlated form gets inlined by SQLite; the window and join forms materialise all 3,095 rows before the join and destroy predicate pushdown:

| query (prod, `mode=ro`) | OLD | **CORRELATED** | JOIN-groupmax | WINDOW |
|---|---|---|---|---|
| /sealed list (65 rows) | 0.13ms | **5.82ms** | 34.60ms | 490ms |
| stats market_value | 0.07ms | **5.17ms** | 37.46ms | 484ms |
| single-product lookup | 0.01ms | **0.01ms** | 0.06ms | 0.10ms |
| full view scan | 0.11ms | **108ms** | 30.5ms | 421ms |

Slower than the broken view in relative terms, negligible in absolute, and identical on single-product lookup. `EXPLAIN QUERY PLAN` stays an index seek — no materialisation.

**No index added.** The existing `UNIQUE(tcgplayer_product_id, observed_at)` already provides a covering autoindex. A wider covering index was measured: it halves the list query (6.24 → 3.12ms) but costs **12 MB on a ~15 MB table** and does not help the full scan. Not worth it.

**Ties are impossible by construction** — that same UNIQUE constraint forbids two rows per product per date. Verified: 0 duplicates on prod.

## Verification

- Correctness: fixed view returns **3,095** rows on prod, not 2,927. All 168 recovered, 0 duplicates.
- Migration applies to an **existing** database: container came up at v45 with the view SQL carrying the migration function's indentation rather than `SCHEMA_SQL`'s — proof the migration path ran, not a fresh create.
- End-to-end: `/sealed` HTTP 200; 8 owned products priced on day 1 but only 3 on day 2 all returned a market price (3 fresh, 5 retaining day-1 values) where the old view would have blanked 5.
- Tests verified failing-before (6 failures incl. `assert 55.0 == 155.0` — stats undervalued) and passing-after (7 pass). Full unit suite green, ruff clean.

## Notes for the reviewer

- **Out of scope but touched:** `tests/test_decks_binders.py` hardcoded schema version `44`, which any bump breaks. Changed to assert against `SCHEMA_VERSION`.
- **Follow-up required:** the test fixture and seed volume need regenerating for schema 45. Deliberately not done here — that fixture was contended by concurrent work at the time.
- CLAUDE.md still documents "Schema version 43" and is now two versions behind.
- `sealed_prices` and this view live in `shared.sqlite` (`MTGC_SHARED_DB`), not `collection.sqlite` — seeding the latter has no effect on `/sealed`. Cost a validation cycle; worth knowing.
- Prod has **not** had this migration applied.

Closes efj-mtgc-gyp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
