### PR TITLE
Fix ingest agent failing on accented card names and uppercase set codes

### DIFF
--- a/mtg_collector/services/agent.py
+++ b/mtg_collector/services/agent.py
@@ -1,9 +1,12 @@
 """Tool-using Claude agent service for MTG card identification from photos."""
 
 import json
+import re
 import sqlite3
 import sys
 import time
+import unicodedata
+from functools import lru_cache
 
 import anthropic
 import httpx
@@ -194,7 +197,13 @@ _QUERY_TOOL_NOTES = (
     "- There is NO 'foil' column — use finishes (JSON TEXT, e.g. '[\"nonfoil\"]')\n"
     "- There is NO 'set_name' column on printings — set_name is on sets. JOIN sets to get it.\n"
     "- Always qualify set_code with a table alias (e.g. p.set_code) to avoid ambiguity.\n"
-    "- Use LIKE with % for substring matching; COLLATE NOCASE for case-insensitivity\n"
+    "- set_code is ALWAYS stored lowercase (e.g. 'ltr', not 'LTR'). OCR reads set codes in\n"
+    "  uppercase off the card, so lowercase them before comparing: p.set_code = 'ltr'.\n"
+    "  An uppercase literal will silently match zero rows.\n"
+    "- Use LIKE with % for substring matching. On this connection LIKE is both\n"
+    "  case-insensitive and accent-insensitive, so LIKE '%Eomer%' matches the stored\n"
+    "  'Éomer of the Riddermark'. Never add or strip diacritics to work around a miss —\n"
+    "  either spelling matches. COLLATE NOCASE is unnecessary.\n"
     "- Do NOT use LIMIT when fetching printings of a specific card — you need all rows to find the right printing\n"
     "- Use LIMIT only for broad/exploratory queries (e.g. browsing sets)\n"
     "- Only SELECT is permitted"
@@ -220,6 +229,67 @@ _ANALYZE_IMAGE_TOOL = {
 }
 
 _AGENT_TABLES = ("cards", "printings", "sets")
+
+
+@lru_cache(maxsize=8192)
+def _fold(s: str) -> str:
+    """Strip diacritics and casefold, so 'Éomer' and 'eomer' compare equal.
+
+    NFKD splits precomposed characters into base + combining marks; dropping the
+    combining marks leaves the unaccented base letter.
+    """
+    return "".join(
+        c for c in unicodedata.normalize("NFKD", s) if not unicodedata.combining(c)
+    ).casefold()
+
+
+@lru_cache(maxsize=512)
+def _like_pattern_to_regex(pattern: str, escape: str | None) -> re.Pattern:
+    """Compile a folded SQL LIKE pattern into an equivalent anchored regex."""
+    out = ["(?s)"]
+    i = 0
+    while i < len(pattern):
+        ch = pattern[i]
+        if escape and ch == escape and i + 1 < len(pattern):
+            out.append(re.escape(pattern[i + 1]))
+            i += 2
+            continue
+        if ch == "%":
+            out.append(".*")
+        elif ch == "_":
+            out.append(".")
+        else:
+            out.append(re.escape(ch))
+        i += 1
+    return re.compile("".join(out) + r"\Z")
+
+
+def _like_accent_insensitive(pattern, subject, escape=None):
+    """Accent- and case-insensitive replacement for SQLite's built-in like().
+
+    SQLite calls this as like(pattern, subject[, escape]) — note the reversed
+    argument order relative to `subject LIKE pattern`. NULL on either side yields
+    NULL, matching built-in behaviour.
+    """
+    if pattern is None or subject is None:
+        return None
+    regex = _like_pattern_to_regex(_fold(str(pattern)), _fold(escape) if escape else None)
+    return 1 if regex.match(_fold(str(subject))) else 0
+
+
+def _install_accent_insensitive_like(conn: sqlite3.Connection) -> None:
+    """Override LIKE on this connection so OCR'd names match accented DB values.
+
+    OCR strips diacritics ('Éomer' is read as 'Eomer'), so the agent's SQL would
+    never match. SQLite lets an application-defined `like` function replace the
+    built-in one; overriding it here fixes every LIKE the agent emits, in either
+    spelling direction, without touching the schema. Scoped to the agent's own
+    connection — the collection search path is unaffected.
+    """
+    conn.create_function(
+        "like", 2, lambda p, s: _like_accent_insensitive(p, s), deterministic=True
+    )
+    conn.create_function("like", 3, _like_accent_insensitive, deterministic=True)
 
 
 def _build_tools(conn: sqlite3.Connection) -> list[dict]:
@@ -449,6 +519,7 @@ def run_agent(
     )
     conn = sqlite3.connect(get_db_path())
     conn.row_factory = sqlite3.Row
+    _install_accent_insensitive_like(conn)
     tools = _build_tools(conn)
 
     trace_lines: list[str] = trace_out if trace_out is not None else []

--- a/tests/test_agent_db_matching.py
+++ b/tests/test_agent_db_matching.py
@@ -1,0 +1,195 @@
+"""Regression tests for the ingest agent's query_local_db matching layer.
+
+Bug efj-mtgc-q29 / GitHub #222: the agent could not identify cards with accented
+names. OCR reads "Éomer of the Riddermark" as "Eomer of the Riddermark", and
+SQLite's built-in LIKE is not accent-insensitive, so every query the agent
+emitted returned nothing and it gave up with {"cards": []}.
+
+Two distinct defects are covered here:
+  1. LIKE not matching across diacritics (fixed in the matching layer).
+  2. set_code compared against an uppercase literal, while set codes are stored
+     lowercase (fixed in the tool description the agent is prompted with).
+
+Card names and set codes below are real values read out of the production
+catalogue, not invented.
+"""
+
+import sqlite3
+
+import pytest
+
+from mtg_collector.services.agent import (
+    _QUERY_TOOL_NOTES,
+    _install_accent_insensitive_like,
+    _tool_query_local_db,
+)
+
+# (oracle_id, name, set_code, collector_number) — verified present in prod.
+CATALOGUE = [
+    ("o-eomer", "Éomer of the Riddermark", "ltr", "121"),
+    ("o-eomer", "Éomer of the Riddermark", "ltr", "572"),
+    ("o-eomer", "Éomer of the Riddermark", "altr", "9"),
+    ("o-baraddur", "Barad-dûr", "ltr", "425"),
+    ("o-arwen", "Arwen Undómiel", "ltr", "194"),
+    ("o-juzam", "Juzám Djinn", "arn", "29"),
+    ("o-seance", "Séance", "dka", "20"),
+    ("o-marton", "Márton Stromgald", "ice", "199"),
+    ("o-arana", "Araña, Heart of the Spider", "spm", "4"),
+    ("o-altair", "Altaïr Ibn-La'Ahad", "acr", "1"),
+    ("o-bolt", "Lightning Bolt", "lea", "161"),
+]
+
+
+@pytest.fixture
+def conn():
+    """A connection configured exactly the way run_agent() configures its own."""
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    c.executescript("""
+        CREATE TABLE cards (oracle_id TEXT PRIMARY KEY, name TEXT NOT NULL);
+        CREATE TABLE printings (
+            printing_id TEXT PRIMARY KEY,
+            oracle_id TEXT NOT NULL,
+            set_code TEXT NOT NULL,
+            collector_number TEXT NOT NULL
+        );
+        CREATE TABLE sets (set_code TEXT PRIMARY KEY, set_name TEXT, released_at TEXT);
+    """)
+    for oracle_id, name, set_code, cn in CATALOGUE:
+        c.execute("INSERT OR IGNORE INTO cards VALUES (?, ?)", (oracle_id, name))
+        c.execute(
+            "INSERT INTO printings VALUES (?, ?, ?, ?)",
+            (f"{set_code}-{cn}", oracle_id, set_code, cn),
+        )
+    _install_accent_insensitive_like(c)
+    return c
+
+
+def names_matching(conn, pattern):
+    rows = conn.execute("SELECT name FROM cards WHERE name LIKE ?", (pattern,)).fetchall()
+    return sorted(r["name"] for r in rows)
+
+
+# --- Defect 1: accent-insensitive matching -------------------------------
+
+
+def test_unaccented_query_matches_accented_name(conn):
+    """The exact failure from the bug trace: OCR's 'Eomer' must find 'Éomer'."""
+    assert names_matching(conn, "%Eomer of the Riddermark%") == [
+        "Éomer of the Riddermark"
+    ]
+
+
+@pytest.mark.parametrize(
+    "pattern,expected",
+    [
+        ("%Barad-dur%", "Barad-dûr"),
+        ("%Arwen Undomiel%", "Arwen Undómiel"),
+        ("%Juzam Djinn%", "Juzám Djinn"),
+        ("%Seance%", "Séance"),
+        ("%Marton Stromgald%", "Márton Stromgald"),
+        ("%Arana, Heart of the Spider%", "Araña, Heart of the Spider"),
+        ("%Altair Ibn-La'Ahad%", "Altaïr Ibn-La'Ahad"),
+    ],
+)
+def test_other_diacritics_match_unaccented_queries(conn, pattern, expected):
+    """Diacritics beyond É: û, ó, á, é, ñ, ï all appear in the real catalogue."""
+    assert names_matching(conn, pattern) == [expected]
+
+
+def test_accented_query_matches_accented_name(conn):
+    """The reverse direction: the correctly-accented spelling still matches."""
+    assert names_matching(conn, "%Éomer of the Riddermark%") == [
+        "Éomer of the Riddermark"
+    ]
+
+
+def test_accented_query_matches_unaccented_name(conn):
+    """The other reverse: an over-accented guess must still find an ASCII name."""
+    assert names_matching(conn, "%Lightning Bólt%") == ["Lightning Bolt"]
+
+
+def test_matching_is_case_insensitive(conn):
+    assert names_matching(conn, "%ÉOMER%") == ["Éomer of the Riddermark"]
+    assert names_matching(conn, "%eomer%") == ["Éomer of the Riddermark"]
+
+
+def test_non_matching_pattern_still_returns_nothing(conn):
+    """Folding must not make LIKE promiscuous."""
+    assert names_matching(conn, "%Llanowar Elves%") == []
+
+
+# --- LIKE semantics must be preserved by the override --------------------
+
+
+def test_underscore_wildcard_matches_single_character(conn):
+    assert names_matching(conn, "S_ance") == ["Séance"]
+
+
+def test_escape_clause_is_honoured(conn):
+    rows = conn.execute(
+        r"SELECT 'a%b' LIKE 'a\%b' ESCAPE '\' AS literal, "
+        r"'axb' LIKE 'a\%b' ESCAPE '\' AS wildcard"
+    ).fetchone()
+    assert rows["literal"] == 1
+    assert rows["wildcard"] == 0
+
+
+def test_null_operands_yield_null(conn):
+    row = conn.execute("SELECT NULL LIKE '%a%' AS a, 'x' LIKE NULL AS b").fetchone()
+    assert row["a"] is None
+    assert row["b"] is None
+
+
+def test_non_text_column_still_matches(conn):
+    """collector_number is TEXT but SQLite may hand the callback an int."""
+    rows = conn.execute(
+        "SELECT collector_number FROM printings WHERE collector_number LIKE '12%'"
+    ).fetchall()
+    assert [r["collector_number"] for r in rows] == ["121"]
+
+
+# --- Defect 2: set codes are stored lowercase ----------------------------
+
+
+def test_set_codes_are_stored_lowercase(conn):
+    """The stored convention the agent's uppercase literal violated."""
+    rows = conn.execute("SELECT DISTINCT set_code FROM printings").fetchall()
+    codes = [r["set_code"] for r in rows]
+    assert codes == [c.lower() for c in codes]
+
+
+def test_lowercased_set_code_finds_the_card(conn):
+    rows = conn.execute(
+        "SELECT p.printing_id FROM cards c JOIN printings p ON p.oracle_id = c.oracle_id "
+        "WHERE c.name LIKE '%Eomer%' AND p.set_code = 'ltr'"
+    ).fetchall()
+    assert sorted(r["printing_id"] for r in rows) == ["ltr-121", "ltr-572"]
+
+
+def test_tool_description_warns_that_set_codes_are_lowercase():
+    """The agent only learns the casing convention if we tell it."""
+    notes = _QUERY_TOOL_NOTES.lower()
+    assert "set_code" in notes
+    assert "lowercase" in notes
+
+
+def test_tool_description_states_like_is_accent_insensitive():
+    """Stops the agent burning turns re-querying with a different spelling."""
+    assert "accent-insensitive" in _QUERY_TOOL_NOTES.lower()
+
+
+# --- End-to-end through the tool entry point -----------------------------
+
+
+def test_bug_trace_query_now_returns_rows(conn):
+    """Replay the SQL from the recorded failing trace for image 8848."""
+    sql = (
+        "SELECT p.printing_id, c.name, p.set_code, p.collector_number "
+        "FROM cards c JOIN printings p ON p.oracle_id = c.oracle_id "
+        "WHERE c.name LIKE '%Eomer of the Riddermark%'"
+    )
+    result = _tool_query_local_db(sql, conn)
+    assert result != "No results found in local cache"
+    assert "ltr-121" in result
+    assert "Éomer of the Riddermark" in result


### PR DESCRIPTION
The ingest agent could not identify cards with accented names. OCR strips the accent to `Eomer`, and SQLite `LIKE` is not accent-insensitive, so `WHERE c.name LIKE '%Eomer%'` never matched the stored `Éomer`.

Recorded trace (image 8848) — note the agent *recovered* the correct spelling from `analyze_image` and still queried with the unaccented form:

```
query_local_db: "...WHERE c.name LIKE '%Eomer of the Riddermark%'"  -> no results
analyze_image: {}                    -> CARD NAME: Éomer of the Riddermark
query_local_db: "...WHERE c.name LIKE '%Eomer%' AND p.set_code = 'LTR'"  -> no results
query_local_db: "...WHERE c.name LIKE '%Eomer%'"  -> no results
-> agent gives up, returns {"cards": []}
```

## Two distinct defects

**1. Accent-insensitive matching** — fixed in the matching layer. `_install_accent_insensitive_like()` overrides SQLite's built-in `like()` on the agent's own connection with an NFKD-fold + casefold implementation. **No schema change**, scoped to that one connection, so the collection search path is untouched. LIKE semantics preserved and tested: `%`/`_` wildcards, `ESCAPE`, NULL propagation, non-text operands.

**2. Set-code casing** — the agent queried `p.set_code = 'LTR'` but set codes are stored lowercase. MEASURED on prod: **0** printings have `set_code <> lower(set_code)`; `'LTR'` → 0 rows, `'ltr'` → 856. Fixed in prompting only: `=` is an operator and cannot be overridden the way `like()` can, so the only non-schema lever is telling the agent. **This half is mitigated, not eliminated** — verified after the fix that `p.set_code='LTR'` still returns 0 rows.

## Alternatives rejected, with evidence

- **Folded search column** — needs a migration, which would have collided with concurrent schema work.
- **FTS5** — `cards_fts` already exists with `unicode61 remove_diacritics 2`, but it is token-based. MEASURED on prod: `MATCH 'Eomer'` → 4 hits, `MATCH 'Eom'` → **0**. Garbled OCR needs substring matching. Also conditional on `cards_fts` existing, which adds an error path.
- **Python-side folding of agent input** — useless; the agent emits raw SQL that SQLite executes.
- **Prompt-only** — the trace above shows the model had the right spelling and still queried wrong. Prompts are probabilistic; the matching layer is not. A prompt line was added too, but only so the agent stops burning turns re-spelling — the fix does not depend on it.

## Blast radius

**96 of 34,881** distinct card names are non-ASCII (37,231 card rows). Diacritics present: û é ó ú ü É ö á í ñ Š â ï ō ã à î ä. **16 such cards are already in the collection** (Gríma, Lórien Revealed, Nazgûl Battle-Mace, Éowyn, …).

## Verification

`tests/test_agent_db_matching.py`, 21 tests. Failing-before was demonstrated by neutering the fix in source (not by a missing import), so these are real assertion failures — **14 failed**:

```
AssertionError: assert [] == ['Éomer of the Riddermark']
AssertionError: assert [] == ['ltr-121', 'ltr-572']
FAILED test_other_diacritics_match_unaccented_queries[%Barad-dur%-Barad-dûr]
FAILED test_other_diacritics_match_unaccented_queries[%Juzam Djinn%-Juzám Djinn]
  ... (û ó á é ñ ï, all real prod names) ...
```

After: 21 passed. Full unit suite **1096 passed, 0 failed**; ruff clean. The shipped functions were also run against the real prod catalogue read-only: the bug-trace query now returns `Éomer of the Riddermark ltr 121` in 0.01s; full-table folded scans run 0.19–0.38s over 37k rows.

## Unverified

**The end-to-end agent loop was not exercised** — no live `ANTHROPIC_API_KEY` run. Only the matching layer and tool-description strings were tested directly. Whether the model actually starts emitting lowercase set codes is unproven, and that is the weaker of the two fixes.

Closes efj-mtgc-q29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
