### PR TITLE
Verify schema objects exist, and make the repair it recommends work under split-DB

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,10 @@ collection_views (id PK)         — saved filters + column layout for the colle
 - `edhrec_recommendations` — populated by the `mtgc-edhrec` timer.
 - `prices`, `price_fetch_log` — append-only price time series and ingest log.
 
-Schema version **43**, with auto-migrations in `db/schema.py`. Repository classes in `db/models.py`: `CardRepository`, `SetRepository`, `PrintingRepository`, `CollectionRepository`, `OrderRepository`, `WishlistRepository`, `SealedProductRepository`, `SealedProductCardRepository`, `SealedCollectionRepository`, `DeckRepository`, `BinderRepository`, `CollectionViewRepository`, `BatchRepository`.
+Schema version is `SCHEMA_VERSION` in `db/schema.py` — read the constant, never a
+number written down elsewhere. Auto-migrations live in the same file, and
+`init_db` raises `SchemaIntegrityError` if the recorded version is current but
+objects `SCHEMA_SQL` defines are missing (`mtg db verify` checks this on demand). Repository classes in `db/models.py`: `CardRepository`, `SetRepository`, `PrintingRepository`, `CollectionRepository`, `OrderRepository`, `WishlistRepository`, `SealedProductRepository`, `SealedProductCardRepository`, `SealedCollectionRepository`, `DeckRepository`, `BinderRepository`, `CollectionViewRepository`, `BatchRepository`.
 
 Default DB location: `~/.mtgc/collection.sqlite` (override: `--db` or `MTGC_DB`).
 

--- a/mtg_collector/cli/db_cmd.py
+++ b/mtg_collector/cli/db_cmd.py
@@ -1,6 +1,12 @@
 """Database management commands: mtg db init/refresh/split"""
 
-from mtg_collector.db import SCHEMA_VERSION, get_connection, init_db
+from mtg_collector.db import (
+    SCHEMA_OBJECTS,
+    SCHEMA_VERSION,
+    get_connection,
+    init_db,
+    verify_schema,
+)
 
 
 def register(subparsers):
@@ -14,6 +20,12 @@ def register(subparsers):
         "--force", action="store_true", help="Recreate tables even if they exist"
     )
     init_parser.set_defaults(func=run_init)
+
+    # db verify
+    verify_parser = db_subparsers.add_parser(
+        "verify", help="Check that every schema object exists"
+    )
+    verify_parser.set_defaults(func=run_verify)
 
     # db refresh
     refresh_parser = db_subparsers.add_parser(
@@ -59,6 +71,29 @@ def run_init(args):
     else:
         print(f"Database already up to date (version {SCHEMA_VERSION})")
         print(f"Location: {args.db_path}")
+
+
+def run_verify(args):
+    """Report any schema objects missing from the database."""
+    import sys
+
+    from mtg_collector.db.schema import get_current_version
+
+    conn = get_connection(args.db_path)
+    version = get_current_version(conn)
+    missing = verify_schema(conn)
+
+    print(f"Location: {args.db_path}")
+    print(f"Schema version: {version} (expected {SCHEMA_VERSION})")
+
+    if missing:
+        print(f"\nMISSING {len(missing)} of {len(SCHEMA_OBJECTS)} schema objects:")
+        for name in missing:
+            print(f"  {name}")
+        print("\nRun 'mtg db init --force' to re-apply the schema.")
+        sys.exit(1)
+
+    print(f"All {len(SCHEMA_OBJECTS)} schema objects present.")
 
 
 def run_split(args):

--- a/mtg_collector/cli/db_cmd.py
+++ b/mtg_collector/cli/db_cmd.py
@@ -77,11 +77,12 @@ def run_verify(args):
     """Report any schema objects missing from the database."""
     import sys
 
-    from mtg_collector.db.schema import get_current_version
+    from mtg_collector.db.schema import get_current_version, verify_shared_schema
 
     conn = get_connection(args.db_path)
     version = get_current_version(conn)
     missing = verify_schema(conn)
+    missing_shared = verify_shared_schema(conn)
 
     print(f"Location: {args.db_path}")
     print(f"Schema version: {version} (expected {SCHEMA_VERSION})")
@@ -91,6 +92,20 @@ def run_verify(args):
         for name in missing:
             print(f"  {name}")
         print("\nRun 'mtg db init --force' to re-apply the schema.")
+
+    if missing_shared:
+        print(f"\nMISSING {len(missing_shared)} object(s) from the shared reference DB:")
+        for name in missing_shared:
+            print(f"  {name}")
+        # 'db init --force' repairs `main`; it cannot repair the shared DB, which
+        # production mounts read-only. Rebuilding the shared volume is the fix.
+        print(
+            "\nThese are served from MTGC_SHARED_DB, not from this database. "
+            "'mtg db init --force' will NOT repair them — rebuild the shared "
+            "reference DB with 'mtg db split --shared-out <path> --prune'."
+        )
+
+    if missing or missing_shared:
         sys.exit(1)
 
     print(f"All {len(SCHEMA_OBJECTS)} schema objects present.")

--- a/mtg_collector/cli/db_cmd.py
+++ b/mtg_collector/cli/db_cmd.py
@@ -75,6 +75,7 @@ def run_init(args):
 
 def run_verify(args):
     """Report any schema objects missing from the database."""
+    import os
     import sys
 
     from mtg_collector.db.schema import get_current_version, verify_shared_schema
@@ -97,12 +98,19 @@ def run_verify(args):
         print(f"\nMISSING {len(missing_shared)} object(s) from the shared reference DB:")
         for name in missing_shared:
             print(f"  {name}")
-        # 'db init --force' repairs `main`; it cannot repair the shared DB, which
-        # production mounts read-only. Rebuilding the shared volume is the fix.
+        # A plain 'db init --force' repairs `main` only. The shared DB needs its
+        # own pass, pointed at it directly. NOT 'db split' — main is pruned, so
+        # re-splitting would copy zero rows over the reference data.
+        shared_path = os.environ.get("MTGC_SHARED_DB", "<shared db>")
         print(
-            "\nThese are served from MTGC_SHARED_DB, not from this database. "
-            "'mtg db init --force' will NOT repair them — rebuild the shared "
-            "reference DB with 'mtg db split --shared-out <path> --prune'."
+            "\nThese are served from MTGC_SHARED_DB, not from this database, so "
+            "'mtg db init --force' on this database will NOT repair them. "
+            f"Re-apply the schema to the shared DB itself:\n"
+            f"\n  MTGC_DB={shared_path} mtg db init --force\n"
+            "\nThat is CREATE ... IF NOT EXISTS, so the reference rows survive. "
+            "Production mounts the shared volume read-only — run it against a "
+            "writable copy and re-publish the volume. Recreated reference tables "
+            "come back EMPTY; repopulate with 'mtg data fetch'."
         )
 
     if missing or missing_shared:

--- a/mtg_collector/db/__init__.py
+++ b/mtg_collector/db/__init__.py
@@ -16,7 +16,15 @@ from mtg_collector.db.models import (
     SetRepository,
     WishlistRepository,
 )
-from mtg_collector.db.schema import SCHEMA_VERSION, SHARED_TABLES, SHARED_VIEWS, init_db
+from mtg_collector.db.schema import (
+    SCHEMA_OBJECTS,
+    SCHEMA_VERSION,
+    SHARED_TABLES,
+    SHARED_VIEWS,
+    SchemaIntegrityError,
+    init_db,
+    verify_schema,
+)
 
 __all__ = [
     "get_db_path",
@@ -26,6 +34,9 @@ __all__ = [
     "get_shared_db_path",
     "get_shared_write_path",
     "init_db",
+    "verify_schema",
+    "SchemaIntegrityError",
+    "SCHEMA_OBJECTS",
     "SCHEMA_VERSION",
     "SHARED_TABLES",
     "SHARED_VIEWS",

--- a/mtg_collector/db/__init__.py
+++ b/mtg_collector/db/__init__.py
@@ -24,6 +24,7 @@ from mtg_collector.db.schema import (
     SchemaIntegrityError,
     init_db,
     verify_schema,
+    verify_shared_schema,
 )
 
 __all__ = [
@@ -35,6 +36,7 @@ __all__ = [
     "get_shared_write_path",
     "init_db",
     "verify_schema",
+    "verify_shared_schema",
     "SchemaIntegrityError",
     "SCHEMA_OBJECTS",
     "SCHEMA_VERSION",

--- a/mtg_collector/db/connection.py
+++ b/mtg_collector/db/connection.py
@@ -2,6 +2,7 @@
 
 import os
 import sqlite3
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Optional
 
@@ -99,25 +100,46 @@ def get_connection(db_path: Optional[str] = None) -> sqlite3.Connection:
     return _connection
 
 
-def attach_shared(conn, shared_db_path):
-    """ATTACH a shared reference DB and create temp views to shadow local tables.
+#: Cross-schema views re-created as temp views so they resolve through the
+#: shadow chain instead of reading from the emptied main-schema tables.
+_CROSS_SCHEMA_VIEWS = ("collection_view", "sealed_collection_view")
 
-    Also re-creates cross-schema views (collection_view, sealed_collection_view)
-    as temp views so they resolve table references through the temp view chain
-    instead of reading from empty main-schema tables.
+
+def shadow_view_names():
+    """Every temp view name create_shared_shadow() installs."""
+    from mtg_collector.db.schema import SHARED_TABLES, SHARED_VIEWS
+
+    return list(SHARED_TABLES) + list(SHARED_VIEWS) + list(_CROSS_SCHEMA_VIEWS)
+
+
+def shared_is_attached(conn) -> bool:
+    """True when a `shared` database is ATTACHed to this connection."""
+    return any(row[1] == "shared" for row in conn.execute("PRAGMA database_list"))
+
+
+def attach_shared(conn, shared_db_path):
+    """ATTACH a shared reference DB and create temp views to shadow local tables."""
+    conn.execute("ATTACH DATABASE ? AS shared", (shared_db_path,))
+    create_shared_shadow(conn)
+
+
+def create_shared_shadow(conn):
+    """Create the temp views that route reads at the ATTACHed `shared` DB.
+
+    Requires `shared` to already be ATTACHed.  Split out from attach_shared() so
+    the shadow can be rebuilt without re-ATTACHing — see suspend_shared_shadow().
     """
     from mtg_collector.db.schema import SHARED_TABLES, SHARED_VIEWS
 
-    conn.execute("ATTACH DATABASE ? AS shared", (shared_db_path,))
     for table in SHARED_TABLES:
         conn.execute(f"CREATE TEMP VIEW IF NOT EXISTS [{table}] AS SELECT * FROM shared.[{table}]")
     for view in SHARED_VIEWS:
         conn.execute(f"CREATE TEMP VIEW IF NOT EXISTS [{view}] AS SELECT * FROM shared.[{view}]")
 
-    # Re-create cross-schema views as temp views. Stored views in main resolve
-    # table names in the main schema (empty user tables). Temp views resolve via
-    # SQLite's temp → main → attached priority, hitting our temp view redirects.
-    for view_name in ("collection_view", "sealed_collection_view"):
+    # Stored views in main resolve table names in the main schema (empty user
+    # tables). Temp views resolve via SQLite's temp → main → attached priority,
+    # hitting our temp view redirects.
+    for view_name in _CROSS_SCHEMA_VIEWS:
         row = conn.execute(
             "SELECT sql FROM main.sqlite_master WHERE type='view' AND name=?",
             (view_name,),
@@ -130,6 +152,40 @@ def attach_shared(conn, shared_db_path):
         temp_sql = sql.replace(f"CREATE VIEW IF NOT EXISTS {view_name}", f"CREATE TEMP VIEW {view_name}", 1)
         temp_sql = temp_sql.replace(f"CREATE VIEW {view_name}", f"CREATE TEMP VIEW {view_name}", 1)
         conn.execute(temp_sql)
+
+
+def drop_shared_shadow(conn):
+    """Drop the temp views create_shared_shadow() installed."""
+    for name in shadow_view_names():
+        conn.execute(f"DROP VIEW IF EXISTS temp.[{name}]")
+
+
+@contextmanager
+def suspend_shared_shadow(conn):
+    """Run a block with the temp shadow views removed, then restore them.
+
+    The shadow is a *read* routing mechanism: it makes `SELECT ... FROM cards`
+    reach `shared.cards` on a connection whose `main.cards` was emptied by
+    `db split --prune`.  It has no business being visible to DDL.  While it is
+    installed, SQLite resolves unqualified names temp → main → attached, so
+    `CREATE INDEX ... ON latest_prices` finds the temp *view* shadowing the
+    main-schema table and fails with "views may not be indexed".
+
+    DETACHing `shared` is not sufficient: the temp views outlive the DETACH and
+    keep shadowing the same names.  The shadow itself has to come down.
+
+    A no-op when no shared DB is attached, so single-DB deployments are
+    unaffected.
+    """
+    if not shared_is_attached(conn):
+        yield
+        return
+
+    drop_shared_shadow(conn)
+    try:
+        yield
+    finally:
+        create_shared_shadow(conn)
 
 
 def close_connection():

--- a/mtg_collector/db/schema.py
+++ b/mtg_collector/db/schema.py
@@ -1,8 +1,13 @@
 """Database schema and migrations."""
 
+import re
 import sqlite3
 
 SCHEMA_VERSION = 44
+
+
+class SchemaIntegrityError(Exception):
+    """Raised when the recorded schema version does not match the objects on disk."""
 
 # Tables whose data can be served from an ATTACHed shared DB via temp views.
 SHARED_TABLES = [
@@ -612,6 +617,51 @@ LEFT JOIN batches bat ON c.batch_id = bat.id;
 """
 
 
+_CREATE_RE = re.compile(
+    r"CREATE\s+(?:VIRTUAL\s+)?(?:TABLE|VIEW|INDEX)\s+"
+    r"(?:IF\s+NOT\s+EXISTS\s+)?\[?([A-Za-z_][A-Za-z0-9_]*)\]?",
+    re.IGNORECASE,
+)
+
+# Every object a complete schema must contain, derived from SCHEMA_SQL itself so
+# it can never drift from the DDL.  A fresh install runs SCHEMA_SQL and nothing
+# else, so SCHEMA_SQL *is* the definition of "intact".
+#
+# Names only, no types: `latest_prices` is a TABLE while `latest_sealed_prices`
+# is a VIEW, and which is which changes between releases.  Presence is the
+# invariant worth asserting; the type is not.
+SCHEMA_OBJECTS = frozenset(_CREATE_RE.findall(SCHEMA_SQL))
+
+
+def verify_schema(conn: sqlite3.Connection) -> list[str]:
+    """Return the names of schema objects that SCHEMA_SQL defines but the DB lacks.
+
+    Returns an empty list when the schema is intact.
+
+    Existence only — never row counts.  Under split-DB (MTGC_SHARED_DB) the
+    reference tables are emptied in `main` by `db split --prune` and served from
+    the ATTACHed `shared` schema, so "populated in main?" is false for a
+    perfectly healthy deployment.  `db split --prune` only DELETEs rows, so
+    `main` keeps every definition; searching `main` plus every ATTACHed schema
+    makes the check identical in monolithic and split deployments.
+
+    The `temp` schema is deliberately excluded.  attach_shared() creates a temp
+    view per shared table without validating its target, so a temp view named
+    `sealed_products` exists even when shared.sealed_products does not — trusting
+    `temp` would blind the check to exactly the tables the prod incident lost.
+    """
+    present: set[str] = set()
+    for row in conn.execute("PRAGMA database_list"):
+        schema = row[1]
+        if schema == "temp":
+            continue
+        present.update(
+            r[0] for r in conn.execute(f"SELECT name FROM [{schema}].sqlite_master")
+        )
+
+    return sorted(SCHEMA_OBJECTS - present)
+
+
 def refresh_latest_prices(conn: sqlite3.Connection) -> int:
     """Repopulate the latest_prices table from the prices table.
 
@@ -657,12 +707,30 @@ def init_db(conn: sqlite3.Connection, force: bool = False) -> bool:
 
     Returns:
         True if schema was created/updated, False if already up to date
+
+    Raises:
+        SchemaIntegrityError: if the recorded version is current but objects
+            SCHEMA_SQL defines are missing from the database.
     """
     from mtg_collector.utils import now_iso
 
     current = get_current_version(conn)
 
     if current >= SCHEMA_VERSION and not force:
+        # The version number is the *only* evidence this path has that the DDL
+        # ever ran.  If a version was recorded without its migration executing,
+        # the change is skipped permanently and surfaces much later as an
+        # unrelated "no such table" deep inside a command.  Check the objects.
+        missing = verify_schema(conn)
+        if missing:
+            raise SchemaIntegrityError(
+                f"Database reports schema version {current} but "
+                f"{len(missing)} object(s) defined by the schema are missing: "
+                f"{', '.join(missing)}. "
+                "The recorded version advanced without the DDL being applied. "
+                "Run 'mtg db init --force' to re-apply the schema "
+                "(CREATE ... IF NOT EXISTS; existing data is preserved)."
+            )
         return False
 
     if current == 0 or force:

--- a/mtg_collector/db/schema.py
+++ b/mtg_collector/db/schema.py
@@ -734,8 +734,18 @@ def init_db(conn: sqlite3.Connection, force: bool = False) -> bool:
         return False
 
     if current == 0 or force:
-        # Fresh install - create all tables
-        conn.executescript(SCHEMA_SQL)
+        # Fresh install - create all tables.
+        #
+        # Under split-DB the connection carries temp views shadowing the shared
+        # reference tables.  They are a read-routing device and must not be
+        # visible to DDL: with the shadow up, `CREATE INDEX ... ON latest_prices`
+        # resolves to the temp *view* and SQLite raises "views may not be
+        # indexed", which broke `mtg db init --force` — the very repair the
+        # integrity check above tells the operator to run.
+        from mtg_collector.db.connection import suspend_shared_shadow
+
+        with suspend_shared_shadow(conn):
+            conn.executescript(SCHEMA_SQL)
         # Seed default settings
         _seed_default_settings(conn)
     else:

--- a/mtg_collector/db/schema.py
+++ b/mtg_collector/db/schema.py
@@ -662,6 +662,31 @@ def verify_schema(conn: sqlite3.Connection) -> list[str]:
     return sorted(SCHEMA_OBJECTS - present)
 
 
+def verify_shared_schema(conn: sqlite3.Connection) -> list[str]:
+    """Return shared reference objects absent from the ATTACHed `shared` schema.
+
+    Empty when no shared DB is attached, or when the shared DB is intact.
+
+    verify_schema() unions `main` with every ATTACHed schema, so an object that
+    survives in `main` masks its absence from `shared`.  That union is the right
+    rule for the boot path — `db split --prune` only DELETEs rows, so `main`
+    keeps every definition and a healthy split deployment must not be called
+    damaged.  But under split-DB reads are routed at `shared` by the temp views,
+    so an object missing *there* still breaks queries.  This is the per-schema
+    view of that, reported by `mtg db verify` only.
+
+    Deliberately not wired into init_db: production mounts the shared volume
+    read-only, so the server refusing to boot over it would strand the operator
+    with no in-container remedy.  Rebuilding the shared volume is the fix.
+    """
+    attached = {row[1] for row in conn.execute("PRAGMA database_list")}
+    if "shared" not in attached:
+        return []
+
+    present = {r[0] for r in conn.execute("SELECT name FROM shared.sqlite_master")}
+    return sorted(set(SHARED_TABLES + SHARED_VIEWS) - present)
+
+
 def refresh_latest_prices(conn: sqlite3.Connection) -> int:
     """Repopulate the latest_prices table from the prices table.
 

--- a/tests/test_schema_integrity.py
+++ b/tests/test_schema_integrity.py
@@ -243,3 +243,104 @@ def test_object_present_only_in_shared_counts_as_present(split_dbs):
     attach_shared(conn, shared_path)
     assert "tcgplayer_groups" not in verify_schema(conn)
     conn.close()
+
+
+# ── The remedy must work where the error is raised (efj-mtgc-9hs) ──
+#
+# The integrity check above tells the operator to run `mtg db init --force`.
+# Under split-DB that command aborted with "views may not be indexed": the temp
+# views attach_shared() installs shadow the main-schema tables, so the
+# CREATE INDEX on latest_prices in SCHEMA_SQL hit a view.  A check that
+# recommends a broken remedy is worse than no check.
+
+
+def test_force_repair_succeeds_under_split_db(split_dbs):
+    """`mtg db init --force` must run on the connection the server actually uses.
+
+    Before the fix this raised
+    sqlite3.OperationalError: views may not be indexed.
+    """
+    user_path, shared_path = split_dbs
+    conn = sqlite3.connect(user_path)
+    attach_shared(conn, shared_path)
+
+    # The shadow is up: latest_prices is a TABLE in main and a VIEW in temp.
+    assert conn.execute(
+        "SELECT type FROM main.sqlite_master WHERE name='latest_prices'"
+    ).fetchone()[0] == "table"
+    assert conn.execute(
+        "SELECT type FROM temp.sqlite_master WHERE name='latest_prices'"
+    ).fetchone()[0] == "view"
+
+    assert init_db(conn, force=True) is True
+    conn.close()
+
+
+def test_force_repair_recreates_an_index_the_shadow_hides(split_dbs):
+    """The repair is genuine: the index really lands in main, not skipped."""
+    user_path, shared_path = split_dbs
+    for path in (user_path, shared_path):
+        conn = sqlite3.connect(path)
+        conn.execute("DROP INDEX idx_latest_prices_card")
+        conn.commit()
+        conn.close()
+
+    conn = sqlite3.connect(user_path)
+    attach_shared(conn, shared_path)
+    assert "idx_latest_prices_card" in verify_schema(conn)
+
+    init_db(conn, force=True)
+
+    assert conn.execute(
+        "SELECT 1 FROM main.sqlite_master WHERE name='idx_latest_prices_card'"
+    ).fetchone()
+    assert verify_schema(conn) == []
+    conn.close()
+
+
+def test_shadow_is_restored_after_the_repair(split_dbs):
+    """Suspending the shadow for DDL must not leave the connection degraded."""
+    user_path, shared_path = split_dbs
+    conn = sqlite3.connect(user_path)
+    attach_shared(conn, shared_path)
+
+    init_db(conn, force=True)
+
+    # The temp views are back...
+    assert conn.execute(
+        "SELECT type FROM temp.sqlite_master WHERE name='latest_prices'"
+    ).fetchone()[0] == "view"
+    # ...and unqualified reads still route to shared, not to the emptied main.
+    assert conn.execute("SELECT COUNT(*) FROM main.sets").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM sets").fetchone()[0] == 1
+    conn.close()
+
+
+def test_damaged_split_db_reports_then_the_named_remedy_repairs_it(split_dbs):
+    """End to end: detect, run exactly what the message says, come back clean."""
+    user_path, shared_path = split_dbs
+    for path in (user_path, shared_path):
+        conn = sqlite3.connect(path)
+        conn.execute("DROP TABLE sealed_products")
+        conn.commit()
+        conn.close()
+
+    conn = sqlite3.connect(user_path)
+    attach_shared(conn, shared_path)
+
+    with pytest.raises(SchemaIntegrityError) as exc:
+        init_db(conn)
+    assert "mtg db init --force" in str(exc.value)
+
+    # Run the remedy the message named, on this same split-DB connection.
+    assert init_db(conn, force=True) is True
+    assert verify_schema(conn) == []
+    assert init_db(conn) is False
+    conn.close()
+
+
+def test_force_is_unaffected_without_a_shared_db(db):
+    """Single-DB deployments keep the old behaviour — the suspend is a no-op."""
+    db.execute("DROP TABLE sealed_products")
+    assert init_db(db, force=True) is True
+    assert verify_schema(db) == []

--- a/tests/test_schema_integrity.py
+++ b/tests/test_schema_integrity.py
@@ -1,0 +1,245 @@
+"""
+Schema integrity checks (efj-mtgc-wys).
+
+A current version number is not proof the DDL ever ran.  If a version is
+recorded without its migration executing, init_db's early return skips the
+change permanently.  These tests pin the check that catches it.
+
+To run: uv run pytest tests/test_schema_integrity.py -v
+"""
+
+import os
+import sqlite3
+import tempfile
+
+import pytest
+
+from mtg_collector.db.connection import attach_shared
+from mtg_collector.db.schema import (
+    SCHEMA_OBJECTS,
+    SCHEMA_VERSION,
+    SHARED_TABLES,
+    SHARED_VIEWS,
+    SchemaIntegrityError,
+    init_db,
+    verify_schema,
+)
+
+
+@pytest.fixture
+def db():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    yield conn
+    conn.close()
+
+
+# ── The object registry ──
+
+
+def test_registry_covers_the_documented_tables():
+    """Objects named in the issue must be in the expected set."""
+    for name in (
+        "sealed_products",
+        "sealed_collection",
+        "sealed_prices",
+        "tcgplayer_groups",
+    ):
+        assert name in SCHEMA_OBJECTS
+
+
+def test_registry_holds_tables_views_and_indexes():
+    assert "collection" in SCHEMA_OBJECTS  # table
+    assert "collection_view" in SCHEMA_OBJECTS  # view
+    assert "idx_collection_status" in SCHEMA_OBJECTS  # index
+    assert "cards_fts" in SCHEMA_OBJECTS  # virtual table
+
+
+def test_registry_covers_both_latest_price_objects():
+    """latest_prices is a TABLE, latest_sealed_prices is a VIEW.
+
+    The check keys on name, not type, so a release that flips one to the other
+    does not need the registry updated.
+    """
+    assert "latest_prices" in SCHEMA_OBJECTS
+    assert "latest_sealed_prices" in SCHEMA_OBJECTS
+
+
+# ── verify_schema ──
+
+
+def test_intact_db_reports_nothing_missing(db):
+    assert verify_schema(db) == []
+
+
+def test_dropped_table_is_reported(db):
+    db.execute("DROP TABLE sealed_products")
+    assert "sealed_products" in verify_schema(db)
+
+
+def test_dropped_view_is_reported(db):
+    db.execute("DROP VIEW latest_sealed_prices")
+    assert "latest_sealed_prices" in verify_schema(db)
+
+
+def test_dropped_index_is_reported(db):
+    db.execute("DROP INDEX idx_collection_status")
+    assert "idx_collection_status" in verify_schema(db)
+
+
+def test_empty_tables_are_not_reported_as_missing(db):
+    """Presence, never population — an empty DB is a valid DB."""
+    assert db.execute("SELECT COUNT(*) FROM printings").fetchone()[0] == 0
+    assert verify_schema(db) == []
+
+
+# ── The bug: a current version is not proof the DDL ran ──
+
+
+def test_init_db_rejects_current_version_with_missing_tables():
+    """The exact prod failure: version says 'done', v17->v18 tables are absent.
+
+    Before the fix init_db returns False here and the damage surfaces much
+    later as 'no such table: sealed_products' inside `mtg data fetch`.
+    """
+    conn = sqlite3.connect(":memory:")
+    init_db(conn)
+
+    for table in ("sealed_prices", "sealed_collection", "sealed_products"):
+        conn.execute(f"DROP TABLE {table}")
+    conn.execute("DROP TABLE tcgplayer_groups")
+
+    # The version is untouched and current — the only evidence init_db has.
+    assert conn.execute("SELECT MAX(version) FROM schema_version").fetchone()[0] == (
+        SCHEMA_VERSION
+    )
+
+    with pytest.raises(SchemaIntegrityError) as exc:
+        init_db(conn)
+
+    message = str(exc.value)
+    for table in (
+        "sealed_products",
+        "sealed_collection",
+        "sealed_prices",
+        "tcgplayer_groups",
+    ):
+        assert table in message, f"{table} not named in the error"
+    assert "mtg db init --force" in message
+
+    conn.close()
+
+
+def test_intact_db_still_short_circuits(db):
+    """An intact DB is silent and still reports 'nothing to do'."""
+    assert init_db(db) is False
+
+
+def test_force_repairs_a_damaged_db():
+    """The documented remedy actually works and keeps existing rows."""
+    conn = sqlite3.connect(":memory:")
+    init_db(conn)
+    conn.execute(
+        "INSERT INTO sets (set_code, set_name) VALUES ('tst', 'Test Set')"
+    )
+    conn.commit()
+    conn.execute("DROP TABLE sealed_products")
+
+    assert init_db(conn, force=True) is True
+    assert verify_schema(conn) == []
+    assert conn.execute("SELECT COUNT(*) FROM sets").fetchone()[0] == 1
+    conn.close()
+
+
+# ── Split DB: the false-alarm trap ──
+
+
+@pytest.fixture
+def split_dbs():
+    """A user DB whose reference tables are pruned, plus a shared DB.
+
+    Mirrors `mtg db split --prune`, which deploy/setup.sh runs: the rows move
+    to shared.sqlite and main's copies are emptied but not dropped.
+    """
+    fds = []
+    for _ in range(2):
+        fd, path = tempfile.mkstemp(suffix=".sqlite")
+        os.close(fd)
+        fds.append(path)
+    user_path, shared_path = fds
+
+    shared = sqlite3.connect(shared_path)
+    init_db(shared)
+    shared.execute("INSERT INTO sets (set_code, set_name) VALUES ('tst', 'Test')")
+    shared.commit()
+    shared.close()
+
+    user = sqlite3.connect(user_path)
+    init_db(user)
+    for table in SHARED_TABLES:
+        user.execute(f"DELETE FROM {table}")
+    for view in SHARED_VIEWS:
+        # latest_prices is a table in main; latest_sealed_prices is a view.
+        row = user.execute(
+            "SELECT type FROM main.sqlite_master WHERE name=?", (view,)
+        ).fetchone()
+        if row and row[0] == "table":
+            user.execute(f"DELETE FROM {view}")
+    user.commit()
+    user.close()
+
+    yield user_path, shared_path
+
+    for path in fds:
+        os.unlink(path)
+
+
+def test_split_db_is_not_a_false_alarm(split_dbs):
+    """main.printings is empty BY DESIGN — that must not read as damage."""
+    user_path, shared_path = split_dbs
+    conn = sqlite3.connect(user_path)
+    attach_shared(conn, shared_path)
+
+    assert conn.execute("SELECT COUNT(*) FROM main.printings").fetchone()[0] == 0
+    assert verify_schema(conn) == []
+    assert init_db(conn) is False
+    conn.close()
+
+
+def test_split_db_still_detects_real_damage(split_dbs):
+    """A table missing from every schema is still caught under split-DB."""
+    user_path, shared_path = split_dbs
+
+    for path in (user_path, shared_path):
+        conn = sqlite3.connect(path)
+        conn.execute("DROP TABLE sealed_products")
+        conn.commit()
+        conn.close()
+
+    conn = sqlite3.connect(user_path)
+    attach_shared(conn, shared_path)
+    # attach_shared leaves a temp view named sealed_products behind even though
+    # its target is gone; the check must not be fooled by it.
+    assert conn.execute(
+        "SELECT 1 FROM temp.sqlite_master WHERE name='sealed_products'"
+    ).fetchone()
+    assert "sealed_products" in verify_schema(conn)
+    with pytest.raises(SchemaIntegrityError, match="sealed_products"):
+        init_db(conn)
+    conn.close()
+
+
+def test_object_present_only_in_shared_counts_as_present(split_dbs):
+    """An object dropped from main but live in shared is not missing."""
+    user_path, shared_path = split_dbs
+
+    conn = sqlite3.connect(user_path)
+    conn.execute("DROP TABLE tcgplayer_groups")
+    conn.commit()
+    conn.close()
+
+    conn = sqlite3.connect(user_path)
+    attach_shared(conn, shared_path)
+    assert "tcgplayer_groups" not in verify_schema(conn)
+    conn.close()

--- a/tests/test_schema_integrity.py
+++ b/tests/test_schema_integrity.py
@@ -23,6 +23,7 @@ from mtg_collector.db.schema import (
     SchemaIntegrityError,
     init_db,
     verify_schema,
+    verify_shared_schema,
 )
 
 
@@ -336,6 +337,74 @@ def test_damaged_split_db_reports_then_the_named_remedy_repairs_it(split_dbs):
     assert init_db(conn, force=True) is True
     assert verify_schema(conn) == []
     assert init_db(conn) is False
+    conn.close()
+
+
+# ── The shared DB needs its own pass ──
+
+
+def test_shared_gap_is_invisible_to_the_boot_path_check(split_dbs):
+    """An object live in main but missing from shared is masked by the union.
+
+    This is why verify_shared_schema exists.  The union is still the right rule
+    for init_db: `db split --prune` only empties main, so main legitimately
+    keeps every definition in a healthy split deployment.
+    """
+    user_path, shared_path = split_dbs
+    conn = sqlite3.connect(shared_path)
+    conn.execute("DROP TABLE sealed_products")
+    conn.commit()
+    conn.close()
+
+    conn = sqlite3.connect(user_path)
+    attach_shared(conn, shared_path)
+    assert verify_schema(conn) == []  # masked by main's surviving definition
+    assert init_db(conn) is False  # so the server still boots
+    conn.close()
+
+
+def test_verify_shared_schema_reports_the_shared_gap(split_dbs):
+    user_path, shared_path = split_dbs
+    conn = sqlite3.connect(shared_path)
+    conn.execute("DROP TABLE sealed_products")
+    conn.commit()
+    conn.close()
+
+    conn = sqlite3.connect(user_path)
+    attach_shared(conn, shared_path)
+    assert "sealed_products" in verify_shared_schema(conn)
+    conn.close()
+
+
+def test_verify_shared_schema_is_quiet_on_an_intact_split_db(split_dbs):
+    user_path, shared_path = split_dbs
+    conn = sqlite3.connect(user_path)
+    attach_shared(conn, shared_path)
+    assert verify_shared_schema(conn) == []
+    conn.close()
+
+
+def test_verify_shared_schema_is_empty_without_a_shared_db(db):
+    """Single-DB deployments have no shared schema to check."""
+    assert verify_shared_schema(db) == []
+
+
+def test_force_does_not_claim_to_repair_the_shared_db(split_dbs):
+    """--force repairs main only; the shared gap must survive it, not be hidden.
+
+    Production mounts the shared volume read-only, so this is a real limit of
+    the remedy, not something to paper over.
+    """
+    user_path, shared_path = split_dbs
+    conn = sqlite3.connect(shared_path)
+    conn.execute("DROP TABLE sealed_products")
+    conn.commit()
+    conn.close()
+
+    conn = sqlite3.connect(user_path)
+    attach_shared(conn, shared_path)
+    init_db(conn, force=True)
+    assert "sealed_products" in verify_shared_schema(conn)
     conn.close()
 
 


### PR DESCRIPTION
Ships a schema integrity check (efj-mtgc-wys) together with the repair command it tells operators to run (efj-mtgc-9hs). They belong in one PR: a check that recommends a broken remedy is worse than no check, and `mtg db init --force` was broken under split-DB.

## The failure mode

`init_db` returned early whenever the recorded version was current:

```python
if current >= SCHEMA_VERSION and not force:
    return False
```

That made the version number the *only* evidence the DDL had ever run. If a version is recorded without its migration executing, the change is skipped permanently and nothing ever notices.

This happened in production. The schema version reached 26 while the v17→v18 migration never ran, leaving `sealed_products`, `sealed_collection`, `sealed_prices` and `tcgplayer_groups` missing. `schema_version` showed v18 "applied" on 2026-02-21. No code path drops those tables, so the version counter advanced during a deployment without the DDL fully executing. It surfaced months later, far from the cause, as:

```
Warning: auto-import failed: no such table: sealed_products
```

`verify_schema()` now compares the objects on disk against the set defined by `SCHEMA_SQL`. `init_db` raises `SchemaIntegrityError` naming every missing object instead of returning `False`, and `mtg db verify` runs the same check on demand.

## Design

**`SCHEMA_OBJECTS` is parsed from `SCHEMA_SQL` at import, not hand-listed.** A fresh install runs `SCHEMA_SQL` and nothing else, so `SCHEMA_SQL` *is* the definition of "intact". A hand-maintained list is a second source of truth that drifts the first time someone adds a table and forgets the registry — the same class of bug this PR exists to catch. Parsing makes drift impossible. 80 objects: 35 tables + 3 views + 42 indexes.

**Names only, no types.** `latest_prices` is a TABLE while `latest_sealed_prices` is a VIEW, and which is which changes between releases — unmerged #274 (`fix/latest-sealed-prices-per-product`) changes that view. Presence is the invariant worth asserting; type is not. That branch needs no change here.

**Indexes are included**, because a silently-skipped migration loses indexes too, and this measured zero false positives on a real migrated DB.

**Auto-repair was rejected.** Re-running DDL behind the operator's back is exactly the silent self-heal CLAUDE.md forbids, and it would have quietly papered over the prod incident rather than surfacing it. The check fails loudly and names the remedy; a human decides.

**Placed at the `init_db` early-return** — the exact bug site, where the version number is the sole evidence. Not on the migration path: DDL just ran there, and several existing tests migrate hand-rolled partial DBs that would false-alarm.

**`temp` is deliberately excluded from the search.** `attach_shared()` creates a temp view per shared table *without validating that its target exists*, so a temp view named `sealed_products` is present even when `shared.sealed_products` is not. Trusting `temp` would blind the check to exactly the tables the prod incident lost. Caught by a failing test during development.

Existence only, never row counts — under split-DB `main.printings` is empty by design. The search covers `main` plus every ATTACHed schema; `db split --prune` only DELETEs rows, so `main` keeps every definition and the check is identical in monolithic and split deployments.

## efj-mtgc-9hs: the remedy was itself broken

The error message says to run `mtg db init --force`. Under `MTGC_SHARED_DB` that command aborted before doing anything:

```
sqlite3.OperationalError: views may not be indexed
```

**Root cause.** `attach_shared()` installs a temp view per shared table so unqualified reads reach the ATTACHed shared DB on a connection whose main-schema copies `db split --prune` emptied. SQLite resolves unqualified names `temp` → `main` → attached, so this line of `SCHEMA_SQL`

```sql
CREATE INDEX IF NOT EXISTS idx_latest_prices_card ON latest_prices(set_code, collector_number);
```

found the temp *view* shadowing `main.latest_prices` (a TABLE) and refused. The remedy failed exactly when it was needed. Pre-existing; not introduced by the check.

**Fix.** The shadow is a *read-routing* device and has no business being visible to DDL. `init_db` now suspends it around `executescript` and restores it afterwards, so the DDL resolves against the real `main` schema and the connection is left usable.

Alternatives rejected, both MEASURED:

- **DETACH `shared` for the duration** — does not work. The temp views outlive the `DETACH` and go on shadowing the same names; the error is unchanged.
- **Skip indexes whose target resolves to a view** — only avoids the error. `idx_latest_prices_card` would never be recreated, so the integrity check would keep reporting it missing and the remedy would never converge. It also adds exactly the conditional/fallback logic CLAUDE.md forbids. Taking the shadow down keeps `--force` a genuine repair.

## The shared DB needs its own pass

`verify_schema()` unions `main` with every ATTACHed schema, so an object still defined in `main` masks its absence from `shared.sqlite`. That union is correct for the boot path — a healthy pruned deployment must not be called damaged — but under split-DB reads are routed at `shared`, so an object missing *there* still breaks queries.

`verify_shared_schema()` reports that per-schema view, surfaced by `mtg db verify` only. It is **deliberately not wired into `init_db`**: production mounts the shared volume read-only (`mtgc-shared-ref:/shared:ro`), so a server refusing to boot over it would strand the operator with no in-container remedy.

The first draft of that message recommended re-running `mtg db split`. That is **destructive** — under a split deployment `main` is already pruned, so it copies zero rows over the reference data (MEASURED against a 56 MB `shared.sqlite` holding 7645 printings). Corrected to re-apply the schema to the shared DB itself:

```
MTGC_DB=/data/shared.sqlite mtg db init --force
```

`get_connection()` skips the ATTACH when the target path *is* the shared DB, so this runs the plain single-DB path. MEASURED: recreated the missing tables, size unchanged at 56213504 bytes, printings 7645 and cards 5190 intact. The message also states what the CLI cannot do for you — the volume is read-only in prod, and recreated reference tables come back **empty** and need `mtg data fetch` to repopulate.

## Cost

MEASURED on the container's split-DB: **0.315 ms cold, 0.180 ms warm** (mean of 200). One-time `SCHEMA_SQL` parse at import. It runs once per `init_db`.

MEASURED against the real production DB read-only (`mode=ro`, 9 GB, v44, monolithic): all 80 expected objects present among its 102 — **zero false positives** on a real migrated DB.

## End-to-end demonstration

Container `schemaforce` (`deploy/setup.sh --test`, genuine split-DB: `MTGC_SHARED_DB=/data/shared.sqlite`, `main` pruned to 458 KB, `shared` 56 MB). Torn down with `--purge`.

1. **Intact split-DB** — `mtg db verify` → `All 80 schema objects present`, exit 0. Server boots; `/`, `/sealed`, `/collection` all **200**.

2. **Dropped `sealed_products` from both DBs, `schema_version` left at 44** — server **refuses to boot**:
   ```
   SchemaIntegrityError: Database reports schema version 44 but 4 object(s) defined by
   the schema are missing: idx_sealed_products_category, idx_sealed_products_set,
   idx_sealed_products_tcg, sealed_products. The recorded version advanced without the
   DDL being applied. Run 'mtg db init --force' to re-apply the schema
   (CREATE ... IF NOT EXISTS; existing data is preserved).
   ```
   `/sealed` → connection refused. Note it names the dropped indexes too, not just the table.

3. **Ran the remedy the message names**, verbatim, with `MTGC_SHARED_DB` set. On the same real split-DB, the pre-fix code path still fails and the fixed command succeeds:
   ```
   pre-fix  : FAILED -> OperationalError: views may not be indexed
   post-fix : Database initialized at: /data/collection.sqlite
              Schema version: 44                                  exit=0
   ```

4. **Server boots and serves again** — `/`, `/sealed`, `/collection` all **200**.

5. `mtg db verify` then correctly reported the remaining **shared**-DB gap that repairing `main` did not close, and running the shared-DB remedy it printed returned everything to `All 80 schema objects present` (exit 0) with printings 7645 / cards 5190 preserved.

## Tests

Bug-demonstrating tests fail before the fix and pass after — verified in both directions for both issues.

- **wys**, with only the `init_db` hook reverted: `test_init_db_rejects_current_version_with_missing_tables`, `test_split_db_still_detects_real_damage` and `test_damaged_split_db_reports_then_the_named_remedy_repairs_it` all `DID NOT RAISE`.
- **9hs**, with only the shadow-suspend reverted: `test_force_repair_succeeds_under_split_db`, `test_force_repair_recreates_an_index_the_shadow_hides`, `test_shadow_is_restored_after_the_repair` and `test_damaged_split_db_reports_then_the_named_remedy_repairs_it` all fail with `sqlite3.OperationalError: views may not be indexed`.

24/24 pass in `tests/test_schema_integrity.py` after. Full unit suite **1488 passed, 195 skipped, 0 failed**. Integration suite against a clean container **82 passed, 3 skipped**. `ruff` clean.

## No version bump

No DDL change, so no migration and no `SCHEMA_VERSION` bump. **45 stays free** for the unmerged #274. (`CLAUDE.md` said "Schema version 43" while the constant was 44; it now points at the constant instead of restating it — a stale number in prose is the same failure class as this issue.)

## Unverified / follow-ups

- **Production is monolithic, not split** (MEASURED: `MTGC_SHARED_DB` unset, single 9 GB DB). The split-DB paths here are verified against the `--test` container topology, not against a split production deployment — no such deployment exists to test against.
- **The shared-DB repair is not automated.** `mtg db init --force` on the user DB repairs `main` only; the shared DB needs its own explicit pass, and prod's read-only mount means it cannot be done in place from inside the container. This PR detects and documents the gap rather than closing it automatically — closing it would need shared-volume rebuild tooling, which is out of scope here.
- **Recreated reference tables come back empty.** Schema repair is not data repair; `mtg data fetch` still has to run.
- **Filed efj-mtgc-7fo (pre-existing, not fixed here):** when `shared.sealed_products` is missing, a direct query correctly raises `no such table: shared.sealed_products`, but `GET /api/sealed/products` swallows it and returns **HTTP 200 with `[]`** — a broken shared DB looks like "you own no sealed products". That is the silent-fallback pattern CLAUDE.md forbids. The fix belongs in `crack_pack_server.py`, which was owned by another agent during this work and was deliberately not touched.

Closes efj-mtgc-wys. Closes efj-mtgc-9hs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
