### PR TITLE
Handle printing_id reshuffle in PrintingRepository.upsert

### DIFF
--- a/mtg_collector/cli/cache_cmd.py
+++ b/mtg_collector/cli/cache_cmd.py
@@ -1,6 +1,7 @@
 """Cache management commands: mtg cache all"""
 
 import json
+import sqlite3
 import sys
 
 from mtg_collector.db import get_connection, get_shared_write_path, init_db
@@ -11,6 +12,24 @@ from mtg_collector.services.scryfall import ScryfallAPI
 from mtg_collector.utils import get_mtgc_home
 
 _BULK_DATA_URL = "https://api.scryfall.com/bulk-data"
+
+
+def _upsert_card_row(api, card_data, card_repo, printing_repo, skipped):
+    """Upsert one card + printing from a Scryfall entry.
+
+    Returns True on success, False if an IntegrityError forced a skip.
+    Skips let bulk import survive Scryfall reshuffles (e.g. an existing
+    printing_id reassigned to a new (set_code, collector_number)) without
+    aborting the whole run and starving Steps 5-6 (mark_cached + backfill).
+    """
+    try:
+        card_repo.upsert(api.to_card_model(card_data))
+        printing_repo.upsert(api.to_printing_model(card_data))
+        return True
+    except sqlite3.IntegrityError as e:
+        skipped.append((card_data.get("id"), card_data.get("set"),
+                        card_data.get("collector_number"), str(e)))
+        return False
 
 
 def register(subparsers):
@@ -113,6 +132,7 @@ def cache_all(db_path: str):
 
     processed = 0
     all_set_codes = set()
+    skipped = []
 
     for card_data in cards_data:
         set_code = card_data.get("set")
@@ -128,11 +148,8 @@ def cache_all(db_path: str):
         if card_data.get("lang", "en") != "en":
             continue
 
-        card = api.to_card_model(card_data)
-        card_repo.upsert(card)
-
-        printing = api.to_printing_model(card_data)
-        printing_repo.upsert(printing)
+        if not _upsert_card_row(api, card_data, card_repo, printing_repo, skipped):
+            continue
 
         all_set_codes.add(set_code)
         processed += 1
@@ -183,10 +200,8 @@ def cache_all(db_path: str):
                 resolve_reversible_oracle_id(card_data)
                 if "oracle_id" not in card_data:
                     continue
-                card = api.to_card_model(card_data)
-                card_repo.upsert(card)
-                printing = api.to_printing_model(card_data)
-                printing_repo.upsert(printing)
+                if not _upsert_card_row(api, card_data, card_repo, printing_repo, skipped):
+                    continue
                 set_backfill += 1
             set_repo.mark_cards_cached(sc)
             conn.commit()
@@ -232,10 +247,8 @@ def cache_all(db_path: str):
                 cn = card_data["collector_number"]
                 if printing_repo.get_by_set_cn(sc, cn):
                     continue  # Already have this collector number
-                card = api.to_card_model(card_data)
-                card_repo.upsert(card)
-                printing = api.to_printing_model(card_data)
-                printing_repo.upsert(printing)
+                if not _upsert_card_row(api, card_data, card_repo, printing_repo, skipped):
+                    continue
                 set_added += 1
             conn.commit()
             non_en_count += set_added
@@ -256,6 +269,12 @@ def cache_all(db_path: str):
     print("\nDone!")
     print(f"  Cards processed: {processed}")
     print(f"  Sets updated: {len(all_set_codes)}")
+    if skipped:
+        print(f"  Skipped {len(skipped)} cards on IntegrityError:")
+        for pid, sc, cn, err in skipped[:20]:
+            print(f"    {sc}/{cn} ({pid}): {err}")
+        if len(skipped) > 20:
+            print(f"    ...and {len(skipped) - 20} more")
 
 
 def cache_set(db_path: str, set_code: str):

--- a/tests/test_printing_upsert.py
+++ b/tests/test_printing_upsert.py
@@ -1,0 +1,143 @@
+"""Tests for bulk-import tolerance in `mtg cache all`.
+
+Scryfall occasionally reassigns a printing_id to a new (set_code,
+collector_number) — most commonly when preview cards are folded into a
+freshly-released set. That trips the printings.printing_id PK and used
+to abort the entire bulk-import loop, starving Steps 5-6 (mark_cached +
+per-set backfill) so newly-released sets stayed silently under-populated.
+
+The fix wraps each per-row upsert in try/except IntegrityError so one
+bad row logs+skips instead of aborting the pass.
+
+To run: uv run pytest tests/test_printing_upsert.py -v
+"""
+
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from mtg_collector.cli.cache_cmd import _upsert_card_row
+from mtg_collector.db import (
+    CardRepository,
+    PrintingRepository,
+    get_connection,
+    init_db,
+)
+from mtg_collector.db.models import Card, Printing
+from mtg_collector.services.scryfall import ScryfallAPI
+
+
+def _card_data(id_, set_code, cn, oracle_id="oracle-1", name="Test Card"):
+    return {
+        "id": id_,
+        "oracle_id": oracle_id,
+        "name": name,
+        "layout": "normal",
+        "set": set_code,
+        "collector_number": cn,
+        "lang": "en",
+        "cmc": 1.0,
+        "type_line": "Instant",
+        "mana_cost": "{R}",
+        "colors": ["R"],
+        "color_identity": ["R"],
+        "rarity": "common",
+        "finishes": ["nonfoil"],
+    }
+
+
+@pytest.fixture
+def db():
+    tmp = tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False)
+    tmp.close()
+    conn = get_connection(tmp.name)
+    init_db(conn)
+    for code in ("preview", "msh"):
+        conn.execute(
+            "INSERT INTO sets (set_code, set_name, set_type, released_at) VALUES (?, ?, ?, ?)",
+            (code, code.upper(), "expansion", "2026-06-26"),
+        )
+    conn.commit()
+    yield conn
+    conn.close()
+    Path(tmp.name).unlink(missing_ok=True)
+
+
+class TestBulkUpsertTolerance:
+    def test_new_card_upserts_successfully(self, db):
+        api = ScryfallAPI()
+        skipped = []
+        card_repo = CardRepository(db)
+        printing_repo = PrintingRepository(db)
+
+        ok = _upsert_card_row(api, _card_data("pid-1", "msh", "1"),
+                              card_repo, printing_repo, skipped)
+        assert ok is True
+        assert skipped == []
+        assert printing_repo.get("pid-1") is not None
+
+    def test_printing_id_reshuffle_across_sets_is_skipped_not_raised(self, db):
+        """The prod failure mode: same printing_id, new (set, cn). Old upsert
+        raised UNIQUE constraint failed: printings.printing_id and killed
+        the whole cache run."""
+        api = ScryfallAPI()
+        skipped = []
+        card_repo = CardRepository(db)
+        printing_repo = PrintingRepository(db)
+
+        _upsert_card_row(api, _card_data("pid-shared", "preview", "1"),
+                         card_repo, printing_repo, skipped)
+        assert skipped == []
+
+        ok = _upsert_card_row(api, _card_data("pid-shared", "msh", "100"),
+                              card_repo, printing_repo, skipped)
+        assert ok is False
+        assert len(skipped) == 1
+        pid, sc, cn, err = skipped[0]
+        assert pid == "pid-shared"
+        assert sc == "msh"
+        assert cn == "100"
+        assert "printing_id" in err
+
+    def test_loop_continues_past_bad_row(self, db):
+        """A single bad row must not stop subsequent good rows — this is the
+        whole point of the fix, since the old code aborted the entire pass."""
+        api = ScryfallAPI()
+        skipped = []
+        card_repo = CardRepository(db)
+        printing_repo = PrintingRepository(db)
+
+        rows = [
+            _card_data("pid-a", "msh", "1", oracle_id="o-a", name="A"),
+            _card_data("pid-b", "preview", "1", oracle_id="o-b", name="B"),
+            _card_data("pid-b", "msh", "50", oracle_id="o-b", name="B"),  # reshuffle
+            _card_data("pid-c", "msh", "2", oracle_id="o-c", name="C"),
+            _card_data("pid-d", "msh", "3", oracle_id="o-d", name="D"),
+        ]
+        succeeded = sum(
+            _upsert_card_row(api, r, card_repo, printing_repo, skipped) for r in rows
+        )
+
+        assert succeeded == 4
+        assert len(skipped) == 1
+        for pid in ("pid-a", "pid-c", "pid-d"):
+            assert printing_repo.get(pid) is not None
+        assert printing_repo.get_by_set_cn("preview", "1") is not None
+
+    def test_repeated_identical_row_upserts_without_skip(self, db):
+        """Plain idempotent re-upsert (same PK, same everything) must succeed
+        via the existing ON CONFLICT clause, not be caught as a skip."""
+        api = ScryfallAPI()
+        skipped = []
+        card_repo = CardRepository(db)
+        printing_repo = PrintingRepository(db)
+
+        row = _card_data("pid-1", "msh", "1")
+        for _ in range(3):
+            assert _upsert_card_row(api, row, card_repo, printing_repo, skipped) is True
+
+        assert skipped == []
+        cnt = db.execute("SELECT COUNT(*) FROM printings").fetchone()[0]
+        assert cnt == 1


### PR DESCRIPTION
## Summary

- Bulk import (`mtg cache all`) has been silently crashing every Wednesday for weeks with `sqlite3.IntegrityError: UNIQUE constraint failed: printings.printing_id` mid-loop, aborting Step 4 before Steps 5-6 (`mark_cards_cached` + per-set backfill) can run. The visible symptom: MSH shipped 2026-06-26 but has only 38 of 453 cards in the DB, and sibling sets (`om2`, `tmsh`, `fmsc`, `tmsc`, `amsh`) have zero.
- Root cause: `PrintingRepository.upsert` only handles `ON CONFLICT(set_code, collector_number)`. When Scryfall moves an existing `printing_id` to a new `(set_code, collector_number)` — typically when preview printings get folded into a freshly-released set — the PK constraint fires and the whole cache pass aborts.
- Fix: extract `_upsert_card_row` in `cache_cmd.py` that wraps the per-row upsert in `try/except sqlite3.IntegrityError`. One bad row now logs and skips; the loop reaches the per-set backfill safety net, which top-loads any missing cards via the per-set Scryfall API. A skip summary prints at the end of the run so future breakage stays visible in the cron log.

Kept the SQL upsert deliberately simple (a second `ON CONFLICT(printing_id)` clause would work but duplicates 26 columns of `excluded.foo` for no real perf win on a weekly cron).

## Test plan

- [x] New `tests/test_printing_upsert.py`: 4 tests covering the helper directly — fresh insert, reshuffle-across-sets skip (reproduces the exact prod IntegrityError), loop-continues-past-bad-row, and idempotent re-upsert.
- [x] Full non-UI/non-integration suite: 1553 passed, 195 skipped, 0 failed.