### PR TITLE
perf(growth): window the collection growth series to the requested range

### DIFF
--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -2623,6 +2623,8 @@ class CrackPackHandler(BaseHTTPRequestHandler):
     # Shape, in stages (each a TEMP table so it is computed exactly once):
     #   pop_t     - the filtered population, one row per collection entry.
     #   keys_t    - distinct (set_code, collector_number, price_type); rowid = kid.
+    #   carry_t   - per (key, source), the single most recent price strictly
+    #               before the window. See "Windowing" below.
     #   grp_iv_t  - per key, the cumulative quantity held and the day range that
     #               quantity is valid for (SUM/LEAD windows over acquisition days).
     #   price_iv_t- per (key, source), each price and the day range it is the
@@ -2634,7 +2636,29 @@ class CrackPackHandler(BaseHTTPRequestHandler):
     # running-sums it over the day spine, which is O(segments) rather than
     # O(groups x days).
     #
-    # Days are integer offsets from the first acquisition, not date strings:
+    # Windowing (`?range=` days, 0 = full history)
+    # -------------------------------------------
+    # Day 0 is the window start, not the first acquisition. The series is
+    # cumulative, so the window cannot simply drop everything before it — the
+    # carried-in position has to be reconstructed at day 0:
+    #
+    #   quantity - acquisition day offsets are clamped to >= 0, so every
+    #              pre-window acquisition collapses onto day 0 and the existing
+    #              GROUP BY sums them into the day-0 opening quantity.
+    #   price    - the price in effect at the window start is usually OLDER than
+    #              the window, so `observed_at >= start` alone would zero out
+    #              those cards until their next observation. carry_t adds back
+    #              exactly one row per (key, source): the latest price strictly
+    #              before the window, given sentinel day -1 so it sorts ahead of
+    #              every in-window row and then clamps to day 0. Its real date is
+    #              irrelevant once clamped, which is why only `price` is fetched.
+    #
+    # carry_t is a seek (ORDER BY observed_at DESC LIMIT 1 on the unique index),
+    # so it costs O(keys) regardless of how deep the price history goes; a
+    # GROUP BY ... MAX(observed_at) formulation would instead scan every
+    # pre-window row and reintroduce the O(history) cost this change removes.
+    #
+    # Days are integer offsets from the window start, not date strings:
     # the window sort is the dominant cost and sorting one INTEGER beats sorting
     # five TEXT columns by a wide margin. Dates are rebuilt for the 163-ish
     # output rows only.
@@ -2666,7 +2690,7 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         CREATE TEMP TABLE grp_iv_t AS
         WITH grp AS (
             SELECT k.rowid AS kid,
-                   MIN(CAST(julianday(pop_t.acq_date) - julianday(?) AS INTEGER), ?) AS day,
+                   MAX(MIN(CAST(julianday(pop_t.acq_date) - julianday(?) AS INTEGER), ?), 0) AS day,
                    COUNT(*) AS qty
             FROM pop_t
             JOIN keys_t k ON k.set_code = pop_t.set_code
@@ -2685,9 +2709,39 @@ class CrackPackHandler(BaseHTTPRequestHandler):
 
     # `source` is folded to an integer bit (1 = tcgplayer, 0 = cardkingdom) so the
     # window partition is a single INTEGER expression.
+
+    # The carried-in price: per (key, source) the latest observation strictly
+    # before the window start. One index seek per row of `keys_t` x 2 sources --
+    # the correlated ORDER BY ... DESC LIMIT 1 lets SQLite land on the end of the
+    # range and step back once, so this does not scan pre-window history.
+    _GROWTH_CARRY_SQL = """
+        CREATE TEMP TABLE carry_t AS
+        SELECT kid, src, price FROM (
+            SELECT k.rowid AS kid,
+                   s.src AS src,
+                   (SELECT pr.price
+                      FROM prices pr
+                     WHERE pr.set_code = k.set_code
+                       AND pr.collector_number = k.cn
+                       AND pr.source = s.nm
+                       AND pr.price_type = k.price_type
+                       AND pr.observed_at < ?
+                     ORDER BY pr.observed_at DESC
+                     LIMIT 1) AS price
+            FROM keys_t k
+            CROSS JOIN (SELECT 'tcgplayer' AS nm, 1 AS src
+                        UNION ALL SELECT 'cardkingdom', 0) s
+        )
+        WHERE price IS NOT NULL
+    """
+
+    # LEAD orders on the raw (possibly -1) day so the carried-in row is
+    # unambiguously first; only the emitted `from_d` is clamped into the window.
+    # A carried-in row followed by an observation on day 0 yields the empty
+    # interval [0, 0), whose +cents/-cents deltas cancel.
     _GROWTH_PRICE_SQL = """
         CREATE TEMP TABLE price_iv_t AS
-        SELECT kid, src, from_d,
+        SELECT kid, src, MAX(from_d, 0) AS from_d,
                LEAD(from_d) OVER (PARTITION BY kid * 2 + src ORDER BY from_d) AS to_d,
                price
         FROM (
@@ -2701,6 +2755,8 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                           AND pr.price_type = k.price_type
             WHERE pr.source IN ('tcgplayer', 'cardkingdom')
               AND pr.observed_at >= ?
+            UNION ALL
+            SELECT kid, src, -1 AS from_d, price FROM carry_t
         )
     """
 
@@ -2750,15 +2806,25 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         """Return daily (count, tcg_value, ck_value) series for the filtered collection.
 
         Mirrors the search-filter parsing in `/api/collection`, then aggregates
-        every day from the earliest acquisition through today inside SQLite:
+        each day of the requested window inside SQLite:
           - cards acquired by that date (count)
           - historical price on that date for each held card (value)
 
-        Prices forward-fill: the most recent known price <= D is used. Cards
-        with no price on/before D contribute 0 to value but still count.
+        `?range=` is the window length in days (0 / absent = full history). The
+        window is the last `range` days ending today; it is clamped to the first
+        acquisition, so asking for more days than the collection has is the same
+        as asking for everything. The series is cumulative and every point is
+        absolute, so a windowed response is bit-identical to the corresponding
+        slice of the full-history response.
+
+        Prices forward-fill: the most recent known price <= D is used, including
+        observations from before the window. Cards with no price on/before D
+        contribute 0 to value but still count.
 
         Response: {"dates": ["YYYY-MM-DD", ...], "counts": [...],
-                   "tcg_values": [...], "ck_values": [...]}
+                   "tcg_values": [...], "ck_values": [...], "earliest": "..."}
+        `earliest` is the first acquisition in the whole filtered collection,
+        independent of the window, so the UI can size its range pills.
         """
         import datetime as _dt
 
@@ -2766,6 +2832,7 @@ class CrackPackHandler(BaseHTTPRequestHandler):
 
         q = params.get("q", [""])[0]
         tz = params.get("tz", [""])[0] or None
+        range_days = int(params.get("range", ["0"])[0] or 0)
 
         where_sql = "1=1"
         sql_params: list = []
@@ -2780,7 +2847,9 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                 self._send_json({"error": str(e), "position": e.position}, 400)
                 return
 
-        empty = {"dates": [], "counts": [], "tcg_values": [], "ck_values": []}
+        empty = {
+            "dates": [], "counts": [], "tcg_values": [], "ck_values": [], "earliest": None,
+        }
 
         # is:unowned makes no sense for a growth chart — ignore.
         if compiled and compiled.include_unowned:
@@ -2818,18 +2887,29 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                 sql_params,
             )
 
-            # Date axis: earliest acquisition -> today (UTC). `acquired_at` is
-            # ISO 8601 UTC, so the first 10 chars are a UTC date.
+            # Date axis: window start -> today (UTC). `acquired_at` is ISO 8601
+            # UTC, so the first 10 chars are a UTC date.
             today = _dt.datetime.now(_dt.timezone.utc).date().isoformat()
-            start_d, end_d = conn.execute(
+            earliest, end_d = conn.execute(
                 "SELECT MIN(acq_date),"
                 " CASE WHEN MIN(acq_date) > ? THEN MIN(acq_date) ELSE ? END"
                 " FROM pop_t",
                 (today, today),
             ).fetchone()
-            if start_d is None:
+            if earliest is None:
                 self._send_json(empty)
                 return
+
+            # The window is the last `range_days` days ending at end_d, clamped
+            # to the first acquisition — a range wider than the collection's own
+            # span degrades to full history rather than padding empty days.
+            start_d = earliest
+            if range_days > 0:
+                win_start = (
+                    _dt.date.fromisoformat(end_d) - _dt.timedelta(days=range_days)
+                ).isoformat()
+                if win_start > start_d:
+                    start_d = win_start
             end_dn = (
                 _dt.date.fromisoformat(end_d) - _dt.date.fromisoformat(start_d)
             ).days
@@ -2838,6 +2918,7 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                 "CREATE TEMP TABLE keys_t AS"
                 " SELECT DISTINCT set_code, cn, price_type FROM pop_t"
             )
+            conn.execute(self._GROWTH_CARRY_SQL, (start_d,))
             conn.execute(self._GROWTH_GRP_SQL, (start_d, end_dn))
             conn.execute(self._GROWTH_PRICE_SQL, (start_d, start_d))
             conn.execute(self._GROWTH_SEG_SQL)
@@ -2850,6 +2931,7 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             "counts": [r["n"] for r in rows],
             "tcg_values": [r["tcg_cents"] / 100.0 for r in rows],
             "ck_values": [r["ck_cents"] / 100.0 for r in rows],
+            "earliest": earliest,
         })
 
     def _api_price_history(self, set_code: str, collector_number: str):

--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -1954,56 +1954,76 @@ function _destroyGrowthChart() {
   if (_growthChart) { _growthChart.destroy(); _growthChart = null; }
 }
 
+// The growth endpoint now computes only the window it is asked for, so the
+// default range is what the page pays for on open. 3 months is the common case;
+// ALL is one click away. Widening the default again is a one-line change here.
+const GROWTH_DEFAULT_RANGE = 90;
+let _growthReq = 0;
+
 async function renderGrowthChart(primarySource) {
   _destroyGrowthChart();
   const wrap = document.getElementById('growth-chart-wrap');
   if (!wrap) return;
 
-  // Reuse the existing /api/collection query string so the chart respects
-  // the user's current search filter.
-  let data;
-  try {
-    const res = await fetch(`/api/collection/growth?${getFetchParams()}`);
-    if (!res.ok) throw new Error('fetch failed');
-    data = await res.json();
-  } catch {
-    wrap.innerHTML = '<div class="growth-empty">Failed to load growth history</div>';
-    return;
-  }
-
-  if (!data.dates || !data.dates.length) {
-    wrap.innerHTML = '<div class="growth-empty">No acquisition history for the current filter</div>';
-    return;
-  }
-
-  const valSeries = primarySource === 'ck' ? data.ck_values : data.tcg_values;
   const valLabel = primarySource === 'ck' ? 'Card Kingdom value' : 'TCGplayer value';
-
-  const earliest = new Date(data.dates[0]).getTime();
-  const spanDays = (Date.now() - earliest) / 86400000;
   const pills = document.querySelectorAll('#growth-range-pills .price-range-pill');
   const ranges = [30, 90, 180, 365, 0];
-  pills.forEach((pill, i) => {
-    pill.classList.toggle('disabled', ranges[i] > 0 && spanDays < ranges[i]);
-  });
 
-  function filterData(rangeDays) {
-    if (!rangeDays) return { dates: data.dates, counts: data.counts, values: valSeries };
+  // Payloads by range, scoped to this invocation — reopening the modal picks up
+  // the current search filter and starts empty.
+  const cache = new Map();
+
+  // Every point is an absolute value for its own date, so a narrower range is
+  // exactly a tail slice of a wider one. Narrowing therefore never needs the
+  // network; only widening does.
+  function tail(data, rangeDays) {
+    if (!rangeDays) return data;
     const cutoffMs = Date.now() - rangeDays * 86400000;
-    let idx0 = data.dates.findIndex(d => new Date(d).getTime() >= cutoffMs);
-    if (idx0 === -1) idx0 = data.dates.length - 1;
+    const i = data.dates.findIndex(d => new Date(d).getTime() >= cutoffMs);
+    if (i <= 0) return data;
     return {
-      dates: data.dates.slice(idx0),
-      counts: data.counts.slice(idx0),
-      values: valSeries.slice(idx0),
+      dates: data.dates.slice(i),
+      counts: data.counts.slice(i),
+      tcg_values: data.tcg_values.slice(i),
+      ck_values: data.ck_values.slice(i),
+      earliest: data.earliest,
     };
   }
 
-  function buildDatasets(f) {
+  // Narrowest already-fetched range that fully contains `range` (0 = ALL).
+  function coveringRange(range) {
+    let best = null;
+    for (const r of cache.keys()) {
+      if (r !== 0 && (range === 0 || r < range)) continue;
+      if (best === null || best === 0 || (r !== 0 && r < best)) best = r;
+    }
+    return best;
+  }
+
+  async function load(range) {
+    if (cache.has(range)) return cache.get(range);
+    const cover = coveringRange(range);
+    if (cover !== null) {
+      const sliced = tail(cache.get(cover), range);
+      cache.set(range, sliced);
+      return sliced;
+    }
+    const res = await fetch(`/api/collection/growth?${getFetchParams()}&range=${range}`);
+    if (!res.ok) throw new Error('fetch failed');
+    const data = await res.json();
+    cache.set(range, data);
+    // A window clamped to the first acquisition IS the full history — record it
+    // as ALL so the widest pill is already satisfied.
+    if (data.dates.length && data.dates[0] === data.earliest) cache.set(0, data);
+    return data;
+  }
+
+  function buildDatasets(d) {
+    const values = primarySource === 'ck' ? d.ck_values : d.tcg_values;
     return [
       {
         label: 'Cards',
-        data: f.dates.map((d, i) => ({ x: d, y: f.counts[i] })),
+        data: d.dates.map((x, i) => ({ x, y: d.counts[i] })),
         borderColor: '#7ec8e3',
         backgroundColor: 'transparent',
         borderWidth: 1.5,
@@ -2014,7 +2034,7 @@ async function renderGrowthChart(primarySource) {
       },
       {
         label: valLabel,
-        data: f.dates.map((d, i) => ({ x: d, y: f.values[i] })),
+        data: d.dates.map((x, i) => ({ x, y: values[i] })),
         borderColor: '#e94560',
         backgroundColor: 'transparent',
         borderWidth: 1.5,
@@ -2026,15 +2046,35 @@ async function renderGrowthChart(primarySource) {
     ];
   }
 
-  // Default range: ALL.
-  let activeRange = 0;
+  let activeRange = GROWTH_DEFAULT_RANGE;
+  let data;
+  try {
+    data = await load(activeRange);
+  } catch {
+    wrap.innerHTML = '<div class="growth-empty">Failed to load growth history</div>';
+    return;
+  }
+
+  if (!data.dates || !data.dates.length) {
+    wrap.innerHTML = '<div class="growth-empty">No acquisition history for the current filter</div>';
+    return;
+  }
+
+  // Pills are sized by the whole collection's span, not the fetched window —
+  // `earliest` is the first acquisition regardless of range.
+  const spanDays = (Date.now() - new Date(data.earliest).getTime()) / 86400000;
+  pills.forEach((pill, i) => {
+    pill.classList.toggle('disabled', ranges[i] > 0 && spanDays < ranges[i]);
+  });
+  // Never leave a disabled pill selected: a collection younger than the default
+  // window already has its entire history in hand, so show it as ALL.
+  if (activeRange !== 0 && spanDays < activeRange) activeRange = 0;
   pills.forEach(p => p.classList.toggle('active', parseInt(p.dataset.range) === activeRange));
 
   const canvas = document.getElementById('growth-chart-canvas');
-  const f = filterData(activeRange);
   _growthChart = new Chart(canvas, {
     type: 'line',
-    data: { datasets: buildDatasets(f) },
+    data: { datasets: buildDatasets(data) },
     options: {
       responsive: true,
       maintainAspectRatio: false,
@@ -2076,13 +2116,23 @@ async function renderGrowthChart(primarySource) {
   });
 
   pills.forEach(pill => {
-    pill.addEventListener('click', () => {
+    pill.addEventListener('click', async () => {
       if (pill.classList.contains('disabled')) return;
       pills.forEach(p => p.classList.remove('active'));
       pill.classList.add('active');
       const range = parseInt(pill.dataset.range);
-      const f = filterData(range);
-      _growthChart.data.datasets = buildDatasets(f);
+      // Cached and sliced ranges resolve without awaiting the network; a widening
+      // fetch can still land out of order, so only the newest click may draw.
+      const token = ++_growthReq;
+      let d;
+      try {
+        d = await load(range);
+      } catch {
+        wrap.innerHTML = '<div class="growth-empty">Failed to load growth history</div>';
+        return;
+      }
+      if (token !== _growthReq || !_growthChart) return;
+      _growthChart.data.datasets = buildDatasets(d);
       _growthChart.update();
     });
   });
@@ -2101,10 +2151,10 @@ function openStatsModal() {
       <div class="modal-section-title">Growth over time</div>
       <div class="price-range-pills" id="growth-range-pills">
         <button class="price-range-pill" data-range="30">1M</button>
-        <button class="price-range-pill" data-range="90">3M</button>
+        <button class="price-range-pill active" data-range="90">3M</button>
         <button class="price-range-pill" data-range="180">6M</button>
         <button class="price-range-pill" data-range="365">1Y</button>
-        <button class="price-range-pill active" data-range="0">ALL</button>
+        <button class="price-range-pill" data-range="0">ALL</button>
       </div>
       <div class="growth-chart-wrap" id="growth-chart-wrap">
         <canvas id="growth-chart-canvas"></canvas>

--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -1976,10 +1976,18 @@ async function renderGrowthChart(primarySource) {
   // Every point is an absolute value for its own date, so a narrower range is
   // exactly a tail slice of a wider one. Narrowing therefore never needs the
   // network; only widening does.
+  //
+  // The cutoff is derived the way the server derives it — whole UTC days back
+  // from the series' own last day — so a sliced range is indistinguishable from
+  // a fetched one. Using Date.now() here instead would carry the current
+  // time-of-day and drop the window's first day, making a sliced 1M one point
+  // shorter than a fetched 1M.
   function tail(data, rangeDays) {
     if (!rangeDays) return data;
-    const cutoffMs = Date.now() - rangeDays * 86400000;
-    const i = data.dates.findIndex(d => new Date(d).getTime() >= cutoffMs);
+    const last = data.dates[data.dates.length - 1];
+    const cutoff = new Date(Date.parse(last + 'T00:00:00Z') - rangeDays * 86400000)
+      .toISOString().slice(0, 10);
+    const i = data.dates.indexOf(cutoff);
     if (i <= 0) return data;
     return {
       dates: data.dates.slice(i),

--- a/tests/ui/hints/collection_stats_growth_chart_renders.yaml
+++ b/tests/ui/hints/collection_stats_growth_chart_renders.yaml
@@ -12,9 +12,13 @@ fixture_data:
   seeded_price_pairs: 42
 notes: >
   The chart is driven by GET /api/collection/growth, which returns
-  {dates, counts, tcg_values, ck_values}. It is fetched lazily by
+  {dates, counts, tcg_values, ck_values, earliest}. It is fetched lazily by
   renderGrowthChart() when the modal opens, so seeding before opening the
-  modal is sufficient.
+  modal is sufficient. The request carries &range=<days> and the server
+  computes only that window; the chart opens on range=90 (3M), so the
+  default response is 91 days, not the full seeded span. `earliest` is the
+  first acquisition across the whole filtered collection regardless of
+  window, and is what sizes the range pills.
 
   Seed first, via podman exec. Prices MUST go into /data/shared.sqlite:
   MTGC_SHARED_DB is set in the test container and attach_shared() creates
@@ -31,4 +35,6 @@ notes: >
   to open the modal, wait for #stats-modal-overlay.active, and confirm
   "Growth over time" is present, #growth-chart-canvas is visible, and the
   text "No acquisition history for the current filter" is absent.
-  With this seed the series is 121 days, counts 1 -> 45, TCG 7.00 -> 837.00.
+  With this seed the full history is 121 days (counts 1 -> 45, TCG
+  7.00 -> 837.00), and the 3M window the chart opens on is the last 91 of
+  those days: counts 12 -> 45, opening TCG 154.57.

--- a/tests/ui/hints/collection_stats_growth_range_data_consistent.yaml
+++ b/tests/ui/hints/collection_stats_growth_range_data_consistent.yaml
@@ -1,0 +1,43 @@
+start_page: /collection
+involves:
+  - "result count text in header (#status)"
+  - "stats modal overlay #stats-modal-overlay"
+  - "range pill container #growth-range-pills"
+  - "Chart.js canvas #growth-chart-canvas"
+  - "live Chart instance via Chart.getChart('growth-chart-canvas')"
+fixture_data:
+  seeded_span_days: 120
+  all_points: 121
+  three_month_points: 91
+  one_month_points: 31
+notes: >
+  This is the regression net for the server-side windowing, so assert on the
+  numbers in the Chart.js datasets rather than on pixels. Dataset 0 is the card
+  count, dataset 1 is the value series; both are arrays of {x, y} where x is a
+  "YYYY-MM-DD" string.
+
+  Read the series with page.evaluate:
+  Chart.getChart('growth-chart-canvas').data.datasets[0].data.map(p => [p.x, p.y]).
+
+  Each range is a different server response (GET /api/collection/growth with
+  &range=), not a client-side crop of one payload, so the equality checks below
+  are the thing actually under test. Every point is an absolute value for its
+  own date, so overlapping days MUST agree exactly across ranges.
+
+  Sequence: open on 3M (91 points) and capture it. Click ALL and wait for 121
+  points. Assert the last point (date, count, value) is identical to the last
+  point of the 3M series, and that the final 91 points of the ALL series equal
+  the 3M series element for element. Click 1M, wait for 31 points, assert its
+  points equal the final 31 of ALL. Click back to 3M, wait for 91 points, and
+  assert the series is identical to the one captured on open.
+
+  The carried-in position is the part most likely to regress silently: the
+  FIRST point of a window is not zero and not the first day of the collection.
+  With this seed the 3M window opens at count 12 / TCG 154.57 while the full
+  history opens at count 1 / TCG 7.00. Assert the 3M opening count is well
+  above 1 and that it matches the ALL series on that same date — a broken
+  carried-in position changes only that first point, which is exactly what a
+  pixel or "chart renders" check would miss.
+
+  Pill clicks flip .active before the data resolves, so always wait on the
+  dataset length via page.wait_for_function, never on the pill class.

--- a/tests/ui/hints/collection_stats_growth_range_pills.yaml
+++ b/tests/ui/hints/collection_stats_growth_range_pills.yaml
@@ -10,17 +10,25 @@ fixture_data:
   enabled_pills: 3
   disabled_pills: 2
 notes: >
-  Pills are 1M(data-range=30), 3M(90), 6M(180), 1Y(365), ALL(0). ALL carries
-  .active in the initial markup. renderGrowthChart() computes
-  spanDays = (Date.now() - dates[0]) / 86400000 and then toggles .disabled on
-  each pill where ranges[i] > 0 && spanDays < ranges[i]. ALL is never disabled.
+  Pills are 1M(data-range=30), 3M(90), 6M(180), 1Y(365), ALL(0). 3M carries
+  .active in the initial markup and GROWTH_DEFAULT_RANGE is 90.
+  renderGrowthChart() computes
+  spanDays = (Date.now() - new Date(data.earliest)) / 86400000 -- note
+  `earliest`, not dates[0], since dates[0] is now the window start -- and then
+  toggles .disabled on each pill where ranges[i] > 0 && spanDays < ranges[i].
+  ALL is never disabled.
 
   Seeding 120 days of acquisition history (see
   collection_stats_growth_chart_renders for the required two-database seed)
   gives spanDays ~= 120, so 1M and 3M stay enabled while 6M and 1Y are
   disabled — exactly 2 disabled pills and 3 enabled ones.
 
-  Clicking a disabled pill is a no-op (the handler returns early). Clicking
-  3M removes .active from every pill, adds it to 3M, and re-slices the chart
-  datasets client-side without a refetch. Assert on
-  "#growth-range-pills .price-range-pill.active[data-range='90']" afterwards.
+  Clicking a disabled pill is a no-op (the handler returns early). Clicking an
+  enabled pill removes .active from every pill and adds it to the clicked one
+  immediately, before any data resolves -- so asserting only on .active can
+  pass before the chart redraws. Widening (3M -> ALL) issues a fetch with
+  &range=0; narrowing is sliced from the payload already held and never hits
+  the network. To assert the chart actually redrew, wait on the Chart.js
+  dataset length rather than on the pill class:
+  page.wait_for_function("() => Chart.getChart('growth-chart-canvas')
+  .data.datasets[0].data.length === 121").

--- a/tests/ui/hints/collection_stats_growth_short_history_opens_on_all.yaml
+++ b/tests/ui/hints/collection_stats_growth_short_history_opens_on_all.yaml
@@ -1,0 +1,29 @@
+start_page: /collection
+involves:
+  - "result count text in header (#status)"
+  - "stats modal overlay #stats-modal-overlay"
+  - "range pill container #growth-range-pills"
+  - "'.active' marks the selected pill, '.disabled' marks unavailable ranges"
+  - "Chart.js canvas #growth-chart-canvas"
+fixture_data:
+  seeded_span_days: 20
+  disabled_pills: 4
+  enabled_pills: 1
+  expected_points: 21
+notes: >
+  Seed exactly as collection_stats_growth_chart_renders does (acquisitions into
+  /data/collection.sqlite, prices into /data/shared.sqlite) but compress the
+  span to 20 days, prices every 2nd day.
+
+  spanDays ~= 20 is below every finite range, so 1M/3M/6M/1Y all get .disabled
+  and only ALL is selectable. GROWTH_DEFAULT_RANGE is 90, which would leave a
+  disabled pill selected, so renderGrowthChart() falls back to ALL:
+  `if (activeRange !== 0 && spanDays < activeRange) activeRange = 0`. Assert
+  .active is on data-range='0' and that exactly 4 pills carry .disabled.
+
+  Note the first request still goes out as &range=90. The server clamps a
+  window wider than the collection to the first acquisition, so the response
+  is the full 21-day history and dates[0] === earliest; the client sees that
+  and files the same payload under ALL, so no second request is made. The
+  chart therefore carries 21 points, and the empty-state placeholder
+  "No acquisition history for the current filter" must be absent.

--- a/tests/ui/implementations/collection_stats_growth_range_data_consistent.py
+++ b/tests/ui/implementations/collection_stats_growth_range_data_consistent.py
@@ -1,0 +1,167 @@
+"""
+Hand-written implementation for collection_stats_growth_range_data_consistent.
+
+Each range pill is a separate server-side computation over a different window,
+so this asserts the windows agree with each other on the days they share --
+including the carried-in position at a window's first day, which is the part
+that regresses silently (a wrong opening balance changes one point, not the
+shape of the chart).
+"""
+
+import subprocess
+
+# Identical seed to collection_stats_growth_chart_renders: acquisitions spread
+# over 120 days, price rows only every 5th day so a window start can land in a
+# gap and must inherit the carried-in price.
+#
+# Prices go into /data/shared.sqlite, NOT /data/collection.sqlite: the test
+# container sets MTGC_SHARED_DB and attach_shared() creates temp views that
+# shadow the main-schema tables, so rows written to collection.sqlite's
+# `prices` table are invisible to the server.
+_SEED = """
+import sqlite3, datetime as dt
+col = sqlite3.connect('/data/collection.sqlite')
+sh = sqlite3.connect('/data/shared.sqlite')
+today = dt.date.today()
+ids = [r[0] for r in col.execute("SELECT id FROM collection ORDER BY id")]
+for n, cid in enumerate(ids):
+    d = today - dt.timedelta(days=120 - (n * 120 // max(len(ids), 1)))
+    col.execute("UPDATE collection SET acquired_at=? WHERE id=?",
+                (d.isoformat() + "T12:00:00.000Z", cid))
+col.commit()
+pids = [r[0] for r in col.execute("SELECT DISTINCT printing_id FROM collection")]
+q = ",".join("?" * len(pids))
+pairs = [tuple(r) for r in sh.execute(
+    "SELECT DISTINCT set_code, collector_number FROM printings "
+    "WHERE printing_id IN (%s)" % q, pids)]
+rows = []
+for i, (sc, cn) in enumerate(pairs):
+    base = 2.0 + (i % 20)
+    for k in range(0, 121, 5):
+        d = (today - dt.timedelta(days=120 - k)).isoformat()
+        grow = 1.0 + k / 240.0
+        for src, pt, mult in (('tcgplayer', 'normal', 1.0),
+                              ('cardkingdom', 'normal', 0.92),
+                              ('tcgplayer', 'foil', 2.4),
+                              ('cardkingdom', 'foil', 2.2),
+                              ('cardkingdom', 'buylist_normal', 0.4)):
+            rows.append((sc, cn, src, pt, round(base * grow * mult, 2), d))
+sh.executemany("INSERT OR REPLACE INTO prices "
+               "(set_code,collector_number,source,price_type,price,observed_at) "
+               "VALUES (?,?,?,?,?,?)", rows)
+sh.commit()
+"""
+
+# Both datasets as [date, count, value] triples, so a range mismatch names the
+# exact day it diverged.
+_READ_SERIES = """
+(() => {
+  const c = Chart.getChart('growth-chart-canvas');
+  if (!c) return null;
+  const n = c.data.datasets[0].data;
+  const v = c.data.datasets[1].data;
+  return n.map((p, i) => [p.x, Number(p.y), Number(v[i].y)]);
+})()
+"""
+
+
+def _find_container(base_url):
+    """Find the container serving the given base_url by matching its port."""
+    port = base_url.rstrip("/").rsplit(":", 1)[-1]
+    result = subprocess.run(
+        ["podman", "ps", "--format", "{{.Names}}"], capture_output=True, text=True
+    )
+    for name in result.stdout.strip().split("\n"):
+        if not name:
+            continue
+        port_result = subprocess.run(
+            ["podman", "port", name, "8081/tcp"], capture_output=True, text=True
+        )
+        if port in port_result.stdout:
+            return name
+    raise AssertionError(f"no container found serving {base_url}")
+
+
+def _select_range(harness, data_range, expected_points):
+    """Click a range pill and wait for the chart to actually carry its series."""
+    harness.click_by_selector(
+        f"#growth-range-pills .price-range-pill[data-range='{data_range}']"
+    )
+    harness.page.wait_for_function(
+        "(n) => { const c = Chart.getChart('growth-chart-canvas');"
+        "         return c && c.data.datasets[0].data.length === n; }",
+        arg=expected_points,
+        timeout=15_000,
+    )
+    return harness.page.evaluate(_READ_SERIES)
+
+
+def steps(harness):
+    container = _find_container(harness.base_url)
+    subprocess.run(
+        ["podman", "exec", container, "python3", "-c", _SEED],
+        capture_output=True, text=True, check=True,
+    )
+
+    harness.navigate("/collection")
+    harness.wait_for_visible(".collection-table", timeout=15_000)
+    harness.wait_for_text("45 cards", timeout=15_000)
+
+    harness.click_by_selector("#status")
+    harness.wait_for_visible("#stats-modal-overlay.active", timeout=10_000)
+    harness.wait_for_visible("#growth-chart-canvas", timeout=15_000)
+
+    # Opens on 3M: 90-day window, 91 inclusive days.
+    harness.page.wait_for_function(
+        "() => { const c = Chart.getChart('growth-chart-canvas');"
+        "        return c && c.data.datasets[0].data.length === 91; }",
+        timeout=15_000,
+    )
+    three_month = harness.page.evaluate(_READ_SERIES)
+    assert three_month is not None, "Chart.js never instantiated the growth chart"
+    harness.screenshot("opened_on_3m")
+
+    # The window opens on a carried-in position, not from scratch: the cards
+    # already owned 90 days ago are counted and priced on day 0.
+    assert three_month[0][1] > 1, (
+        "3M window opened at count "
+        f"{three_month[0][1]} — carried-in quantity was not applied"
+    )
+    assert three_month[0][2] > 0, (
+        "3M window opened at value 0 — the price carried in from before the "
+        "window start was lost"
+    )
+
+    # Widen to ALL: the line extends back to the earliest acquisition.
+    all_series = _select_range(harness, 0, 121)
+    assert all_series[0][1] == 1, (
+        f"full history should open at the first card, got {all_series[0][1]}"
+    )
+
+    # Today is unchanged by how far back the chart looks.
+    assert all_series[-1] == three_month[-1], (
+        f"latest point changed with range: {three_month[-1]} vs {all_series[-1]}"
+    )
+
+    # Every day the two windows share must agree exactly — this is where a
+    # wrong carried-in position or a mis-clamped day offset shows up.
+    assert all_series[-91:] == three_month, (
+        "3M series does not match the last 91 days of the full history; first "
+        "divergence at "
+        f"{next(a for a, b in zip(all_series[-91:], three_month) if a != b)}"
+    )
+
+    # Narrowing is served from the payload already held; it must still agree.
+    one_month = _select_range(harness, 30, 31)
+    assert all_series[-31:] == one_month, (
+        "1M series does not match the last 31 days of the full history"
+    )
+
+    # Returning to a previously shown range reproduces it exactly.
+    back_to_three = _select_range(harness, 90, 91)
+    assert back_to_three == three_month, (
+        "returning to 3M did not reproduce the series shown on open"
+    )
+
+    harness.assert_text_absent("Failed to load growth history")
+    harness.screenshot("final_state")

--- a/tests/ui/implementations/collection_stats_growth_range_pills.py
+++ b/tests/ui/implementations/collection_stats_growth_range_pills.py
@@ -2,8 +2,9 @@
 Hand-written implementation for collection_stats_growth_range_pills.
 
 Seeds ~120 days of history so the 1M/3M ranges are covered but 6M/1Y are not,
-then verifies the pills grey out accordingly and that clicking 3M moves the
-active selection.
+then verifies the pills grey out accordingly, that 3M is selected on open, and
+that clicking an enabled pill moves the active selection while clicking a
+greyed-out one does nothing.
 """
 
 import subprocess
@@ -85,9 +86,10 @@ def steps(harness):
     harness.wait_for_visible("#stats-modal-overlay.active", timeout=10_000)
     harness.wait_for_visible("#growth-chart-canvas", timeout=15_000)
 
-    # All five pills exist; ALL starts selected.
+    # All five pills exist; 3M is the default selection.
     harness.assert_element_count("#growth-range-pills .price-range-pill", 5)
-    harness.assert_visible("#growth-range-pills .price-range-pill.active[data-range='0']")
+    harness.assert_visible("#growth-range-pills .price-range-pill.active[data-range='90']")
+    harness.assert_element_count("#growth-range-pills .price-range-pill.active", 1)
 
     # 6M and 1Y exceed the seeded span, so exactly those two are disabled.
     harness.assert_element_count("#growth-range-pills .price-range-pill.disabled", 2)
@@ -98,14 +100,41 @@ def steps(harness):
     harness.assert_element_count("#growth-range-pills .price-range-pill:not(.disabled)", 3)
     harness.screenshot("pills_initial")
 
-    # Selecting 3M re-slices the chart and moves the active marker.
-    harness.click_by_selector("#growth-range-pills .price-range-pill[data-range='90']")
-    harness.wait_for_visible(
-        "#growth-range-pills .price-range-pill.active[data-range='90']", timeout=5_000
+    # Widening to ALL moves the active marker and redraws over the full span.
+    # The pill class flips before the fetch resolves, so wait on the chart data.
+    harness.click_by_selector("#growth-range-pills .price-range-pill[data-range='0']")
+    harness.page.wait_for_function(
+        "() => { const c = Chart.getChart('growth-chart-canvas');"
+        "        return c && c.data.datasets[0].data.length === 121; }",
+        timeout=15_000,
     )
+    harness.assert_visible("#growth-range-pills .price-range-pill.active[data-range='0']")
     harness.assert_element_count("#growth-range-pills .price-range-pill.active", 1)
 
-    # The chart is still rendered after the update.
+    # Narrowing to 1M is served from the payload already held.
+    harness.click_by_selector("#growth-range-pills .price-range-pill[data-range='30']")
+    harness.page.wait_for_function(
+        "() => { const c = Chart.getChart('growth-chart-canvas');"
+        "        return c && c.data.datasets[0].data.length === 31; }",
+        timeout=15_000,
+    )
+    harness.assert_visible("#growth-range-pills .price-range-pill.active[data-range='30']")
+
+    # A greyed-out range cannot be selected at all: .disabled sets
+    # pointer-events: none, so the click never reaches 1Y and 1M stays active.
+    # (Asserted via computed style rather than by clicking — Playwright
+    # correctly refuses to click an element that cannot receive pointer events.)
+    pointer_events = harness.page.eval_on_selector(
+        "#growth-range-pills .price-range-pill[data-range='365']",
+        "el => getComputedStyle(el).pointerEvents",
+    )
+    assert pointer_events == "none", (
+        f"disabled 1Y pill is still clickable (pointer-events: {pointer_events})"
+    )
+    harness.assert_visible("#growth-range-pills .price-range-pill.active[data-range='30']")
+    harness.assert_element_count("#growth-range-pills .price-range-pill.active", 1)
+
+    # The chart is still rendered after the updates.
     harness.assert_visible("#growth-chart-canvas")
 
     harness.screenshot("final_state")

--- a/tests/ui/implementations/collection_stats_growth_short_history_opens_on_all.py
+++ b/tests/ui/implementations/collection_stats_growth_short_history_opens_on_all.py
@@ -1,16 +1,15 @@
 """
-Hand-written implementation for collection_stats_growth_chart_renders.
+Hand-written implementation for collection_stats_growth_short_history_opens_on_all.
 
-Seeds acquisition history and price history via podman exec, then opens the
-result-stats modal and verifies the "Growth over time" chart actually renders
-instead of falling back to the empty-state placeholder.
+Seeds a collection whose entire history (~20 days) is shorter than the chart's
+default 3-month range, then verifies the chart opens on ALL rather than leaving
+a greyed-out pill selected, and still renders the real series.
 """
 
 import subprocess
 
-# Spread acquired_at over the last 120 days and write price rows every 5th day
-# (deliberate gaps, so the server-side forward-fill is exercised) for both
-# sources in both price_types, plus buylist rows the endpoint must ignore.
+# As collection_stats_growth_chart_renders, but compressed to 20 days with
+# prices every 2nd day.
 #
 # Prices go into /data/shared.sqlite, NOT /data/collection.sqlite: the test
 # container sets MTGC_SHARED_DB and attach_shared() creates temp views that
@@ -23,7 +22,7 @@ sh = sqlite3.connect('/data/shared.sqlite')
 today = dt.date.today()
 ids = [r[0] for r in col.execute("SELECT id FROM collection ORDER BY id")]
 for n, cid in enumerate(ids):
-    d = today - dt.timedelta(days=120 - (n * 120 // max(len(ids), 1)))
+    d = today - dt.timedelta(days=20 - (n * 20 // max(len(ids), 1)))
     col.execute("UPDATE collection SET acquired_at=? WHERE id=?",
                 (d.isoformat() + "T12:00:00.000Z", cid))
 col.commit()
@@ -35,14 +34,13 @@ pairs = [tuple(r) for r in sh.execute(
 rows = []
 for i, (sc, cn) in enumerate(pairs):
     base = 2.0 + (i % 20)
-    for k in range(0, 121, 5):
-        d = (today - dt.timedelta(days=120 - k)).isoformat()
-        grow = 1.0 + k / 240.0
+    for k in range(0, 21, 2):
+        d = (today - dt.timedelta(days=20 - k)).isoformat()
+        grow = 1.0 + k / 40.0
         for src, pt, mult in (('tcgplayer', 'normal', 1.0),
                               ('cardkingdom', 'normal', 0.92),
                               ('tcgplayer', 'foil', 2.4),
-                              ('cardkingdom', 'foil', 2.2),
-                              ('cardkingdom', 'buylist_normal', 0.4)):
+                              ('cardkingdom', 'foil', 2.2)):
             rows.append((sc, cn, src, pt, round(base * grow * mult, 2), d))
 sh.executemany("INSERT OR REPLACE INTO prices "
                "(set_code,collector_number,source,price_type,price,observed_at) "
@@ -69,57 +67,56 @@ def _find_container(base_url):
 
 
 def steps(harness):
-    # The --test fixture has no acquisition spread and almost no prices, so
-    # the chart would otherwise be a single point at $0.
+    # 20 days of history: shorter than every finite range pill.
     container = _find_container(harness.base_url)
     subprocess.run(
         ["podman", "exec", container, "python3", "-c", _SEED],
         capture_output=True, text=True, check=True,
     )
 
-    # Reload so the collection list is served from the seeded DB.
     harness.navigate("/collection")
     harness.wait_for_visible(".collection-table", timeout=15_000)
     harness.wait_for_text("45 cards", timeout=15_000)
 
-    # Open the result-stats modal from the inline result count.
     harness.click_by_selector("#status")
     harness.wait_for_visible("#stats-modal-overlay.active", timeout=10_000)
-
-    # The growth section is the first section in the modal.
-    harness.assert_text_present("Growth over time")
-
-    # The chart is fetched lazily when the modal opens, so wait for the canvas.
     harness.wait_for_visible("#growth-chart-canvas", timeout=15_000)
-    harness.assert_visible("#growth-range-pills")
 
-    # Neither the empty state nor the fetch-failure state may be showing.
+    # Every finite range exceeds the seeded span, so only ALL is selectable.
+    harness.assert_element_count("#growth-range-pills .price-range-pill.disabled", 4)
+    harness.assert_element_count(
+        "#growth-range-pills .price-range-pill:not(.disabled)", 1
+    )
+
+    # The selected pill is ALL, not the greyed-out 3M default.
+    harness.assert_visible("#growth-range-pills .price-range-pill.active[data-range='0']")
+    harness.assert_element_count("#growth-range-pills .price-range-pill.active", 1)
+
+    # A disabled pill is never the selected one.
+    harness.assert_element_count(
+        "#growth-range-pills .price-range-pill.active.disabled", 0
+    )
+    harness.screenshot("opens_on_all")
+
+    # The real 21-day series is drawn, not the empty-state placeholder.
     harness.assert_text_absent("No acquisition history for the current filter")
     harness.assert_text_absent("Failed to load growth history")
-
-    # The canvas element exists in the markup even if Chart.js never drew, so
-    # assert against the live Chart instance. Datasets are arrays of {x, y}
-    # points (there is no labels array): dataset 0 is the card count, dataset 1
-    # is the value series.
     chart = harness.page.evaluate(
         "(() => {"
         "  const c = Chart.getChart('growth-chart-canvas');"
         "  if (!c) return null;"
         "  const ys = i => c.data.datasets[i].data.map(p => Number(p.y));"
-        "  return {datasets: c.data.datasets.length,"
-        "          points: c.data.datasets[0].data.length,"
-        "          firstCount: ys(0)[0], lastCount: ys(0).slice(-1)[0],"
+        "  return {points: c.data.datasets[0].data.length,"
+        "          lastCount: ys(0).slice(-1)[0],"
         "          maxValue: Math.max(...ys(1))};"
         "})()"
     )
     assert chart is not None, "Chart.js never instantiated the growth chart"
-    assert chart["datasets"] == 2, f"expected count + value datasets, got {chart['datasets']}"
-    # The chart opens on the 3M default, so the series is the 90-day window
-    # (91 inclusive days) rather than the full 121 days seeded.
-    assert chart["points"] == 91, f"expected the 91-day 3M window, got {chart['points']}"
-    # The collection grows over the window, and the value series is not flat zero.
-    assert chart["lastCount"] > chart["firstCount"], (
-        f"count series did not grow: {chart['firstCount']} -> {chart['lastCount']}"
+    assert chart["points"] == 21, (
+        f"expected the full 21-day history, got {chart['points']}"
+    )
+    assert chart["lastCount"] == 45, (
+        f"expected all 45 seeded cards by today, got {chart['lastCount']}"
     )
     assert chart["maxValue"] > 0, "value series is flat zero — prices did not resolve"
 

--- a/tests/ui/intents/collection_stats_growth_chart_renders.yaml
+++ b/tests/ui/intents/collection_stats_growth_chart_renders.yaml
@@ -16,7 +16,7 @@
 description: >
   When I open the "Result statistics" modal from the collection page,
   the first section is "Growth over time": a line chart plotting how my
-  collection's card count and total value have changed since my earliest
-  acquisition. With acquisition and price history present I see an actual
-  rendered chart, not the "No acquisition history for the current filter"
-  placeholder.
+  collection's card count and total value have changed over the last three
+  months, which is the range the chart opens on. With acquisition and price
+  history present I see an actual rendered chart, not the "No acquisition
+  history for the current filter" placeholder.

--- a/tests/ui/intents/collection_stats_growth_range_data_consistent.yaml
+++ b/tests/ui/intents/collection_stats_growth_range_data_consistent.yaml
@@ -1,0 +1,22 @@
+# Scenario: Growth chart shows the same history whichever range I pick
+#
+# Related:
+#   issues: [efj-mtgc-655, efj-mtgc-lze]
+#   pull_requests: []
+#
+# Prerequisites:
+#   Same two-database seeding as collection_stats_growth_chart_renders, with
+#   ~120 days of acquisition history and price rows only every 5th day so the
+#   forward-fill (and the carried-in price at a window start that falls in a
+#   gap) is exercised. See that intent for why seeding is required.
+
+description: >
+  The growth chart opens on the last three months, but switching ranges only
+  changes how far back I am looking — not what the chart says. When I widen
+  to ALL the line extends back to my earliest acquisition while today's card
+  count and value stay exactly the same, and the three months I was already
+  looking at are unchanged. When I narrow to 1M and then go back to 3M I see
+  precisely the series I started with. A shorter range never shows my
+  collection as smaller or cheaper than it really was on those days: the
+  cards I already owned when the window opens are counted and priced, not
+  treated as though I had just started collecting.

--- a/tests/ui/intents/collection_stats_growth_range_pills.yaml
+++ b/tests/ui/intents/collection_stats_growth_range_pills.yaml
@@ -11,7 +11,8 @@
 
 description: >
   Above the growth chart there are time-range pills (1M, 3M, 6M, 1Y, ALL)
-  with ALL selected by default. Ranges longer than my actual history are
+  with 3M selected by default. Ranges longer than my actual history are
   greyed out — with about four months of history, 1M and 3M are available
-  but 6M and 1Y are not. Clicking 3M narrows the chart to the last three
-  months and makes 3M the selected pill.
+  but 6M and 1Y are not. Clicking ALL widens the chart to my whole history
+  and makes ALL the selected pill; clicking 1M narrows it to the last month.
+  A greyed-out range cannot be selected at all.

--- a/tests/ui/intents/collection_stats_growth_short_history_opens_on_all.yaml
+++ b/tests/ui/intents/collection_stats_growth_short_history_opens_on_all.yaml
@@ -1,0 +1,18 @@
+# Scenario: A collection younger than the default range opens on ALL
+#
+# Related:
+#   issues: [efj-mtgc-655, efj-mtgc-lze]
+#   pull_requests: []
+#
+# Prerequisites:
+#   Same two-database seeding as collection_stats_growth_chart_renders, but
+#   with every acquisition inside the last ~20 days so the whole collection is
+#   younger than the chart's default 3-month range. See that intent for why
+#   seeding is required.
+
+description: >
+  The growth chart normally opens on the last three months, but I have only
+  been collecting for about three weeks. Rather than showing me a range I do
+  not have, the chart opens on ALL — every shorter range is greyed out, and
+  the one that is selected is never a greyed-out one. The chart still renders
+  my three weeks of history rather than an empty placeholder.


### PR DESCRIPTION
Windows the collection growth chart's data to the selected range instead of fetching the full
history and slicing client-side.

## Measured

| Range | Before | After | |
|---|---|---|---|
| 30d | 5.53s | 1.25s | **4.4×** |
| 90d | 5.55s | 3.31s | 1.7× |

Correctness validated against prod read-only: **8 filters × 5 ranges bit-identical to baseline**,
worst divergence `$0.0000`. 1464 unit tests pass, 5/5 growth UI scenarios pass, ruff clean.

## Decision that wants a human call

This changes the chart's **default range from ALL to 3M**. That is a deliberate UX change, not a
side effect, and it is the reason the branch was held back from a PR originally rather than
anything being unfinished. Reviewer should confirm that default before merging.

`collection_stats_growth_short_history_opens_on_all` covers the case where a collection has less
history than the default window — it opens on ALL rather than showing an empty 3M chart.

## Provenance

Recovered from a retiring workspace where it existed only locally — four commits on no remote
ref. Verified to merge cleanly into current `main` (34 commits behind, zero conflicts).

> ⚠️ **Merging restarts prod.** `.github/workflows/deploy.yml` triggers on push to `main` and
> runs `deploy/deploy.sh prod` on the self-hosted runner, which rebuilds the image and restarts
> the service. Worth choosing when to hit merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)