### PR TITLE
fix(deploy): image prune must not gate the deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
         run: git -C /opt/mtgc-${{ env.INSTANCE }} pull --ff-only origin ${{ github.ref_name }}
 
       - name: Prune dangling images
-        run: podman image prune -f
+        run: podman image prune -f || true
 
       - name: Build and restart
         run: bash /opt/mtgc-${{ env.INSTANCE }}/deploy/deploy.sh ${{ env.INSTANCE }}

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -59,7 +59,7 @@ else
     # which is what historically broke nightly backups (no room to stage
     # the SQLite snapshot).
     echo "==> Pruning dangling images..."
-    podman image prune -f >/dev/null
+    podman image prune -f >/dev/null 2>&1 || true
 fi
 # Wait briefly for the container to start, then discover the assigned port
 sleep 2


### PR DESCRIPTION
`podman image prune -f` exits **125** when any image is held by a container — including
orphaned buildah `*-working-container`s left behind by interrupted builds. The workflow runs
under `bash -e`, so that housekeeping failure aborted the job **after `git pull` but before the
rebuild and restart**: prod's checkout went current while its container stayed stale, and the
run reported failure.

This is what broke the deploys for **#278** and **#280**. 36 orphaned working containers had
accumulated on the runner; clearing them unblocked it — but pruning should never have been able
to gate a deploy.

Two lines, both `|| true`.

> Separately: `deploy-native` requires `[self-hosted, thaen]`, which is not registered on this
> repo, so every run shows "queued" even when the Linux deploy succeeded. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)