### PR TITLE
Collection payload: total ordering, bounded responses, enrichment in one query

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,6 +200,8 @@ SQLite connections use `PRAGMA journal_mode = WAL` (set in `db/connection.py` an
 - **Test fixture goes stale after schema migrations.** Regenerate with `uv run python scripts/build_test_fixture.py`, then recreate the seed volume with `bash deploy/seed.sh --force`. The full fixture (with sealed product contents) requires `~/.mtgc/AllPrintings.json` — run `mtg data fetch` first.
 - **HTML pages share no JS imports (legacy).** Helpers like `getRarityColor()` and `formatPrice()` are inlined in older pages. New pages should use `shared.css` + `shared.js`. Don't introduce a new ad-hoc price formatter — use `formatPrice` (or copy its body verbatim if the page can't load `shared.js`).
 - **Restoring DB snapshots with `cp` under WAL mode is broken.** See the "WAL mode" patterns section. Use `sqlite3.backup()`.
+- **Never use `rowid` on a shared reference table.** Deployed instances ATTACH `shared.sqlite` and shadow every table in `SHARED_TABLES` with a temp `CREATE VIEW … AS SELECT * FROM shared.<t>`. Views have no rowid, and SQLite resolves `rowid` against one to **NULL rather than an error** — so a join keyed on it silently matches nothing instead of failing loudly. Key on a real unique column (`uuid`, `printing_id`, the PK).
+- **`mtgjson_printings.printing_id` is not unique.** The PK is `uuid`; MTGJSON emits one row per face of a double-faced card, and both faces carry the same Scryfall id with a *different* Card Kingdom link. Anything joining on `printing_id` must resolve to a single row first, the way `PackGenerator.get_ck_url()` and `_ENRICH_JOINS` in `crack_pack_server.py` do, or it multiplies rows.
 
 ## Deployment
 

--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -1005,6 +1005,39 @@ _ENRICH_COLUMNS = """COALESCE(_ck_buy.price, _ck_retail.price) as ck_price,
                     COALESCE(NULLIF(CASE WHEN c.finish IN ('foil', 'etched') THEN _mp.ck_url_foil END, ''), _mp.ck_url, '') as ck_url"""
 
 
+# Page bounds for /api/collection. Measured on the real payload (108,630 rows
+# for is:unowned): a 250-row page is 212 KB raw / 28 KB gzipped and 434 round
+# trips to walk the catalog; 1000 is 855 KB / 103 KB and 108 trips. There is no
+# unbounded escape hatch and no sentinel — every caller takes these semantics.
+COLLECTION_LIMIT_DEFAULT = 250
+COLLECTION_LIMIT_MAX = 1000
+
+
+class PageParamError(ValueError):
+    """A limit/offset the caller must fix. Surfaced as a 400, never clamped."""
+
+
+def _parse_page_params(params: dict) -> tuple[int, int]:
+    """Return (limit, offset) from query params, or raise PageParamError."""
+    limit = _page_int(params, "limit", COLLECTION_LIMIT_DEFAULT)
+    offset = _page_int(params, "offset", 0)
+    if not 1 <= limit <= COLLECTION_LIMIT_MAX:
+        raise PageParamError(f"limit must be between 1 and {COLLECTION_LIMIT_MAX}")
+    if offset < 0:
+        raise PageParamError("offset must be 0 or greater")
+    return limit, offset
+
+
+def _page_int(params: dict, name: str, default: int) -> int:
+    raw = params.get(name, [""])[0].strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        raise PageParamError(f"{name} must be an integer") from None
+
+
 class ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
     daemon_threads = True
 
@@ -2166,6 +2199,12 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         """
         from mtg_collector.search import SearchError, compile_query, parse_query
 
+        try:
+            limit, offset = _parse_page_params(params)
+        except PageParamError as e:
+            self._send_json({"error": str(e)}, 400)
+            return
+
         q = params.get("q", [""])[0]
         sort = params.get("sort", [""])[0]
         order = params.get("order", [""])[0]
@@ -2254,7 +2293,7 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         needs_price_join = (compiled and compiled.needs_price_join) or sort_col == "_lp.price"
         needs_wishlist_join = compiled and compiled.needs_wishlist_join
 
-        def _build_extra_joins(*, has_deck_binder_joins: bool) -> str:
+        def _build_extra_joins(*, has_deck_binder_joins: bool, enrich: bool = True) -> str:
             joins = []
             if not has_deck_binder_joins:
                 if compiled and compiled.needs_deck_join:
@@ -2274,12 +2313,13 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                 joins.append(
                     "LEFT JOIN wishlist _wl ON _wl.oracle_id = card.oracle_id AND _wl.fulfilled_at IS NULL"
                 )
-            joins.extend(_ENRICH_JOINS)
+            if enrich:
+                joins.extend(_ENRICH_JOINS)
             return "\n                ".join(joins)
 
         if card_pairs or include_unowned:
             # LEFT JOIN template: shared-link cards or is:unowned queries
-            query = f"""
+            select_sql = f"""
                 SELECT
                     card.oracle_id, card.name, card.type_line, card.mana_cost, card.cmc,
                     card.colors, card.color_identity,
@@ -2301,19 +2341,24 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                     o.order_date as order_date,
                     c.purchase_price,
                     {_ENRICH_COLUMNS}
+            """
+            def _body(joins: str) -> str:
+                return f"""
                 FROM printings p
                 JOIN cards card ON p.oracle_id = card.oracle_id
                 JOIN sets s ON p.set_code = s.set_code
                 LEFT JOIN collection c ON p.printing_id = c.printing_id
                 LEFT JOIN orders o ON c.order_id = o.id
-                {_build_extra_joins(has_deck_binder_joins=False)}
+                {joins}
                 WHERE {where_sql}
                 GROUP BY p.printing_id
-                ORDER BY {sort_col} {order_dir}, card.name ASC, p.printing_id ASC
             """
+            body_sql = _body(_build_extra_joins(has_deck_binder_joins=False))
+            count_body_sql = _body(_build_extra_joins(has_deck_binder_joins=False, enrich=False))
+            order_sql = f"ORDER BY {sort_col} {order_dir}, card.name ASC, p.printing_id ASC"
         elif expand_copies:
             # One row per collection entry (for deck builder picker)
-            query = f"""
+            select_sql = f"""
                 SELECT
                     card.oracle_id, card.name, card.type_line, card.mana_cost, card.cmc,
                     card.colors, card.color_identity,
@@ -2338,6 +2383,9 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                     d.name as deck_name,
                     b.name as binder_name,
                     {_ENRICH_COLUMNS}
+            """
+            def _body(joins: str) -> str:
+                return f"""
                 FROM collection c
                 JOIN printings p ON c.printing_id = p.printing_id
                 JOIN cards card ON p.oracle_id = card.oracle_id
@@ -2346,13 +2394,18 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                 LEFT JOIN deck_cards dc ON dc.collection_id = c.id
                 LEFT JOIN decks d ON dc.deck_id = d.id
                 LEFT JOIN binders b ON c.binder_id = b.id
-                {_build_extra_joins(has_deck_binder_joins=True)}
+                {joins}
                 WHERE {where_sql}
-                ORDER BY {sort_col} {order_dir}, card.name ASC, p.printing_id ASC, c.id ASC, dc.id ASC
             """
+            body_sql = _body(_build_extra_joins(has_deck_binder_joins=True))
+            count_body_sql = _body(_build_extra_joins(has_deck_binder_joins=True, enrich=False))
+            order_sql = (
+                f"ORDER BY {sort_col} {order_dir}, card.name ASC,"
+                " p.printing_id ASC, c.id ASC, dc.id ASC"
+            )
         else:
             # Default: aggregated, one row per (printing, finish, condition, status)
-            query = f"""
+            select_sql = f"""
                 SELECT
                     card.oracle_id, card.name, card.type_line, card.mana_cost, card.cmc,
                     card.colors, card.color_identity,
@@ -2376,6 +2429,9 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                     d.name as deck_name,
                     b.name as binder_name,
                     {_ENRICH_COLUMNS}
+            """
+            def _body(joins: str) -> str:
+                return f"""
                 FROM collection c
                 JOIN printings p ON c.printing_id = p.printing_id
                 JOIN cards card ON p.oracle_id = card.oracle_id
@@ -2384,15 +2440,46 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                 LEFT JOIN deck_cards dc ON dc.collection_id = c.id
                 LEFT JOIN decks d ON dc.deck_id = d.id
                 LEFT JOIN binders b ON c.binder_id = b.id
-                {_build_extra_joins(has_deck_binder_joins=True)}
+                {joins}
                 WHERE {where_sql}
                 GROUP BY p.printing_id, c.finish, c.condition, c.status, c.order_id
-                ORDER BY {sort_col} {order_dir}, card.name ASC,
-                         p.printing_id ASC, c.finish ASC, c.condition ASC, c.status ASC, c.order_id ASC
             """
+            body_sql = _body(_build_extra_joins(has_deck_binder_joins=True))
+            count_body_sql = _body(_build_extra_joins(has_deck_binder_joins=True, enrich=False))
+            order_sql = (
+                f"ORDER BY {sort_col} {order_dir}, card.name ASC,"
+                " p.printing_id ASC, c.finish ASC, c.condition ASC, c.status ASC, c.order_id ASC"
+            )
 
-        cursor = conn.execute(query, sql_params)
+        # order_sql stays per-template: the tiebreak is that template's row
+        # identity, and it differs (the GROUP BY key, or c.id/dc.id per copy).
+        # It is kept out of body_sql so the COUNT below does not sort.
+        #
+        # LIMIT/OFFSET are bound parameters, never formatted into the SQL.
+        cursor = conn.execute(
+            f"{select_sql}{body_sql}{order_sql} LIMIT ? OFFSET ?",
+            [*sql_params, limit, offset],
+        )
         rows = cursor.fetchall()
+
+        # total is the size of the whole result, not the page.
+        #
+        # A short page has already answered the question: the query ran out of
+        # rows, so the result ends here. That covers every query whose result
+        # fits in one page — which is most of them — for no extra query at all.
+        # (Not when the page is empty and the offset is past the end: then the
+        # offset says nothing about where the result stopped.)
+        #
+        # Otherwise count the body, which carries the GROUP BY and so counts
+        # groups, matching what the page returns. The enrichment joins are left
+        # out: a COUNT has no columns to enrich, and each of them matches at
+        # most one row, so they cannot change the count either.
+        if len(rows) < limit and (rows or offset == 0):
+            total = offset + len(rows)
+        else:
+            total = conn.execute(
+                f"SELECT COUNT(*) FROM (SELECT 1 {count_body_sql})", sql_params
+            ).fetchone()[0]
 
         include_unowned = bool(card_pairs) or include_unowned
         results = []
@@ -2460,7 +2547,7 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             results.append(card)
 
         conn.close()
-        self._send_json(results)
+        self._send_json({"rows": results, "total": total, "limit": limit, "offset": offset})
 
     def _api_card(self, printing_id: str):
         """Return full card data for a single printing by printing_id."""

--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -963,6 +963,48 @@ def _recover_pending_images(db_path):
         print(f"[startup] {len(rows)} pending image(s) waiting — ANTHROPIC_API_KEY not set, skipping processing", flush=True)
 
 
+# /api/collection price and Card Kingdom URL enrichment, folded into the main
+# query.  This used to be two follow-up passes whose `IN (...)` clauses were
+# sized by the result set: 112,809 rows built a statement with 225,618 bound
+# parameters, within 11% of this build's SQLITE_MAX_VARIABLE_NUMBER of 250,000.
+# Every join below binds zero parameters and matches at most one row, so neither
+# the SQL text nor the row cardinality depends on how large the result set is.
+#
+# `latest_prices` has PRIMARY KEY (set_code, collector_number, source,
+# price_type), so pinning source and price_type makes each price join
+# single-row.  price_type follows the physical copy's finish (c.finish), not the
+# printing's available finishes, so a foil copy of a printing that also exists
+# in nonfoil gets the foil price; etched copies price as foil.
+_ENRICH_JOINS = [
+    "LEFT JOIN latest_prices _ck_buy ON _ck_buy.set_code = p.set_code"
+    " AND _ck_buy.collector_number = p.collector_number"
+    " AND _ck_buy.source = 'cardkingdom'"
+    " AND _ck_buy.price_type = CASE WHEN c.finish IN ('foil', 'etched') THEN 'buylist_foil' ELSE 'buylist_normal' END",
+    "LEFT JOIN latest_prices _ck_retail ON _ck_retail.set_code = p.set_code"
+    " AND _ck_retail.collector_number = p.collector_number"
+    " AND _ck_retail.source = 'cardkingdom'"
+    " AND _ck_retail.price_type = CASE WHEN c.finish IN ('foil', 'etched') THEN 'foil' ELSE 'normal' END",
+    "LEFT JOIN latest_prices _tcg ON _tcg.set_code = p.set_code"
+    " AND _tcg.collector_number = p.collector_number"
+    " AND _tcg.source = 'tcgplayer'"
+    " AND _tcg.price_type = CASE WHEN c.finish IN ('foil', 'etched') THEN 'foil' ELSE 'normal' END",
+    # printing_id is not unique in mtgjson_printings: MTGJSON emits one row per
+    # face of a double-faced card and both carry the same scryfallId, with a
+    # different Card Kingdom link each.  Resolve to a uuid first so the join
+    # stays single-row, and resolve it the way PackGenerator.get_ck_url() does
+    # — same index seek, same first row — so the collection list and the card
+    # detail page show the same link for the same card.
+    "LEFT JOIN mtgjson_printings _mp ON _mp.uuid ="
+    " (SELECT uuid FROM mtgjson_printings WHERE printing_id = p.printing_id LIMIT 1)",
+]
+
+# Card Kingdom publishes a buylist and a retail price; the buylist wins when
+# present.  A foil copy falls back to the nonfoil URL when there is no foil one.
+_ENRICH_COLUMNS = """COALESCE(_ck_buy.price, _ck_retail.price) as ck_price,
+                    _tcg.price as tcg_price,
+                    COALESCE(NULLIF(CASE WHEN c.finish IN ('foil', 'etched') THEN _mp.ck_url_foil END, ''), _mp.ck_url, '') as ck_url"""
+
+
 class ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
     daemon_threads = True
 
@@ -2232,6 +2274,7 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                 joins.append(
                     "LEFT JOIN wishlist _wl ON _wl.oracle_id = card.oracle_id AND _wl.fulfilled_at IS NULL"
                 )
+            joins.extend(_ENRICH_JOINS)
             return "\n                ".join(joins)
 
         if card_pairs or include_unowned:
@@ -2256,7 +2299,8 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                     o.seller_name as order_seller,
                     o.order_number as order_number,
                     o.order_date as order_date,
-                    c.purchase_price
+                    c.purchase_price,
+                    {_ENRICH_COLUMNS}
                 FROM printings p
                 JOIN cards card ON p.oracle_id = card.oracle_id
                 JOIN sets s ON p.set_code = s.set_code
@@ -2292,7 +2336,8 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                     c.purchase_price,
                     dc.deck_id, dc.zone as deck_zone, c.binder_id,
                     d.name as deck_name,
-                    b.name as binder_name
+                    b.name as binder_name,
+                    {_ENRICH_COLUMNS}
                 FROM collection c
                 JOIN printings p ON c.printing_id = p.printing_id
                 JOIN cards card ON p.oracle_id = card.oracle_id
@@ -2329,7 +2374,8 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                     c.purchase_price,
                     dc.deck_id, dc.zone as deck_zone, c.binder_id,
                     d.name as deck_name,
-                    b.name as binder_name
+                    b.name as binder_name,
+                    {_ENRICH_COLUMNS}
                 FROM collection c
                 JOIN printings p ON c.printing_id = p.printing_id
                 JOIN cards card ON p.oracle_id = card.oracle_id
@@ -2405,54 +2451,13 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                 card["order_number"] = row["order_number"]
                 card["order_date"] = row["order_date"]
                 card["purchase_price"] = row["purchase_price"]
-            card["tcg_price"] = None
-            card["ck_price"] = None
-            card["ck_url"] = ""
+            # Prices and ck_url come from the main query's enrichment joins
+            # (_ENRICH_COLUMNS); the JSON payload has always carried prices as
+            # strings, so keep formatting them here rather than in SQL.
+            card["tcg_price"] = None if row["tcg_price"] is None else str(row["tcg_price"])
+            card["ck_price"] = None if row["ck_price"] is None else str(row["ck_price"])
+            card["ck_url"] = row["ck_url"]
             results.append(card)
-
-        # Bulk price lookup — one query replaces 3600 individual queries
-        if results:
-            price_keys = []
-            for card in results:
-                # Use the physical copy's actual finish (c.finish), not the
-                # printing's available finishes (p.finishes) — otherwise a foil
-                # copy of a printing that also exists in nonfoil shows the
-                # nonfoil price. Etched copies use foil pricing.
-                price_type = "foil" if card["finish"] in ("foil", "etched") else "normal"
-                sc = card["set_code"].lower()
-                cn = card["collector_number"]
-                price_keys.append((sc, cn, price_type))
-
-            # Collect unique (set_code, collector_number) pairs for batch lookup
-            unique_cards = list({(sc, cn) for sc, cn, _ in price_keys})
-            ph = ",".join("(?,?)" for _ in unique_cards)
-            params = [v for pair in unique_cards for v in pair]
-            price_map: dict[tuple[str, str, str, str], str] = {}
-            for r in conn.execute(
-                f"SELECT set_code, collector_number, source, price_type, price "
-                f"FROM latest_prices WHERE (set_code, collector_number) IN ({ph})",
-                params,
-            ).fetchall():
-                price_map[(r["set_code"], r["collector_number"], r["source"], r["price_type"])] = str(r["price"])
-
-            # Bulk CK URL lookup
-            ck_url_map: dict[str, tuple[str, str]] = {}
-            if self.generator:
-                pids = [card["printing_id"] for card in results]
-                ph = ",".join("?" for _ in pids)
-                for r in conn.execute(
-                    f"SELECT printing_id, ck_url, ck_url_foil FROM mtgjson_printings WHERE printing_id IN ({ph})",
-                    pids,
-                ).fetchall():
-                    ck_url_map[r["printing_id"]] = (r["ck_url"] or "", r["ck_url_foil"] or "")
-
-            for i, card in enumerate(results):
-                sc, cn, pt = price_keys[i]
-                card["ck_price"] = price_map.get((sc, cn, "cardkingdom", f"buylist_{pt}")) or price_map.get((sc, cn, "cardkingdom", pt))
-                card["tcg_price"] = price_map.get((sc, cn, "tcgplayer", pt))
-                foil = card["finish"] in ("foil", "etched")
-                urls = ck_url_map.get(card["printing_id"], ("", ""))
-                card["ck_url"] = (urls[1] if foil else urls[0]) or urls[0]
 
         conn.close()
         self._send_json(results)

--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -2177,7 +2177,12 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             card_filter = f"({' OR '.join(pair_clauses)})"
             where_sql = f"{card_filter} AND ({where_sql})" if where_sql != "1=1" else card_filter
 
-        # Sort: use search engine order:/direction: if present, else URL params
+        # Sort: use search engine order:/direction: if present, else URL params.
+        # No sort_map value is unique, and neither is the card.name tiebreak
+        # (~3.2 printings share a name), so every template below closes its
+        # ORDER BY with the columns that identify one output row — the GROUP BY
+        # key where there is one, c.id/dc.id for the per-copy template. Without
+        # that the order is not total and paged responses drop and duplicate rows.
         sort_map = {
             "name": "card.name",
             "cmc": "card.cmc",
@@ -2260,7 +2265,7 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                 {_build_extra_joins(has_deck_binder_joins=False)}
                 WHERE {where_sql}
                 GROUP BY p.printing_id
-                ORDER BY {sort_col} {order_dir}, card.name ASC
+                ORDER BY {sort_col} {order_dir}, card.name ASC, p.printing_id ASC
             """
         elif expand_copies:
             # One row per collection entry (for deck builder picker)
@@ -2298,7 +2303,7 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                 LEFT JOIN binders b ON c.binder_id = b.id
                 {_build_extra_joins(has_deck_binder_joins=True)}
                 WHERE {where_sql}
-                ORDER BY {sort_col} {order_dir}, card.name ASC
+                ORDER BY {sort_col} {order_dir}, card.name ASC, p.printing_id ASC, c.id ASC, dc.id ASC
             """
         else:
             # Default: aggregated, one row per (printing, finish, condition, status)
@@ -2336,7 +2341,8 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                 {_build_extra_joins(has_deck_binder_joins=True)}
                 WHERE {where_sql}
                 GROUP BY p.printing_id, c.finish, c.condition, c.status, c.order_id
-                ORDER BY {sort_col} {order_dir}, card.name ASC
+                ORDER BY {sort_col} {order_dir}, card.name ASC,
+                         p.printing_id ASC, c.finish ASC, c.condition ASC, c.status ASC, c.order_id ASC
             """
 
         cursor = conn.execute(query, sql_params)

--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -2258,6 +2258,19 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             card_filter = f"({' OR '.join(pair_clauses)})"
             where_sql = f"{card_filter} AND ({where_sql})" if where_sql != "1=1" else card_filter
 
+        # The price column the client renders follows the price_sources
+        # setting, so sorting and the totals below follow it too — otherwise
+        # the table would order itself by a number it is not showing.
+        price_sources_row = conn.execute(
+            "SELECT value FROM settings WHERE key = 'price_sources'"
+        ).fetchone()
+        first_source = (
+            price_sources_row["value"] if price_sources_row else "tcg,ck"
+        ).split(",")[0]
+        _CK_PRICE_SQL = "COALESCE(_ck_buy.price, _ck_retail.price)"
+        _TCG_PRICE_SQL = "_tcg.price"
+        display_price_sql = _CK_PRICE_SQL if first_source == "ck" else _TCG_PRICE_SQL
+
         # Sort: use search engine order:/direction: if present, else URL params.
         # No sort_map value is unique, and neither is the card.name tiebreak
         # (~3.2 printings share a name), so every template below closes its
@@ -2274,7 +2287,21 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             "collector_number": "CAST(p.collector_number AS INTEGER)",
             "date_added": "c.acquired_at",
             "added": "c.acquired_at",
-            "price": "_lp.price",
+            # These three are expressions from _ENRICH_COLUMNS, whose joins are
+            # unconditional and single-row, so they need no needs_*_join flag.
+            #
+            # `price` deliberately does NOT use _lp. That join pins price_type
+            # but not source, and latest_prices' key is (set_code,
+            # collector_number, source, price_type) — so with both a TCG and a
+            # Card Kingdom price it matches twice. The GROUP BY templates hide
+            # that by collapsing the duplicate (while making which source you
+            # sorted by a coin toss), but expand=copies has no GROUP BY, and
+            # paging a result with duplicated rows drops and repeats cards.
+            # Nothing sent `sort` before the client began paging, so this was
+            # unreachable rather than fixed.
+            "price": display_price_sql,
+            "tcg_price": _TCG_PRICE_SQL,
+            "ck_price": _CK_PRICE_SQL,
         }
         if compiled and compiled.order_by:
             sort_col = sort_map.get(compiled.order_by, "card.name")
@@ -2290,7 +2317,10 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         # Conditional JOINs from the search engine
         # Note: expand_copies and default templates already include dc/d/b joins.
         # Only the shared-links (card_pairs) template needs them dynamically.
-        needs_price_join = (compiled and compiled.needs_price_join) or sort_col == "_lp.price"
+        # _lp now serves only the search engine's `price:` keyword — no sort
+        # resolves to it any more, so sorting no longer drags in a join that
+        # can match a card twice.
+        needs_price_join = compiled and compiled.needs_price_join
         needs_wishlist_join = compiled and compiled.needs_wishlist_join
 
         def _build_extra_joins(*, has_deck_binder_joins: bool, enrich: bool = True) -> str:
@@ -2356,6 +2386,7 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             body_sql = _body(_build_extra_joins(has_deck_binder_joins=False))
             count_body_sql = _body(_build_extra_joins(has_deck_binder_joins=False, enrich=False))
             order_sql = f"ORDER BY {sort_col} {order_dir}, card.name ASC, p.printing_id ASC"
+            agg_qty_sql = "COALESCE(COUNT(DISTINCT c.id), 0)"
         elif expand_copies:
             # One row per collection entry (for deck builder picker)
             select_sql = f"""
@@ -2403,6 +2434,7 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                 f"ORDER BY {sort_col} {order_dir}, card.name ASC,"
                 " p.printing_id ASC, c.id ASC, dc.id ASC"
             )
+            agg_qty_sql = "1"
         else:
             # Default: aggregated, one row per (printing, finish, condition, status)
             select_sql = f"""
@@ -2450,6 +2482,7 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                 f"ORDER BY {sort_col} {order_dir}, card.name ASC,"
                 " p.printing_id ASC, c.finish ASC, c.condition ASC, c.status ASC, c.order_id ASC"
             )
+            agg_qty_sql = "COUNT(DISTINCT c.id)"
 
         # order_sql stays per-template: the tiebreak is that template's row
         # identity, and it differs (the GROUP BY key, or c.id/dc.id per copy).
@@ -2546,8 +2579,40 @@ class CrackPackHandler(BaseHTTPRequestHandler):
             card["ck_url"] = row["ck_url"]
             results.append(card)
 
+        # total_qty / total_value describe the whole result, like total does.
+        #
+        # They cannot be summed from the page. The client fetches windows as it
+        # scrolls, so a page-scoped aggregate would climb as the user scrolled —
+        # a collection value that grows while you look at it is worse than none.
+        #
+        # Priced the same way the table is (display_price_sql), so the status
+        # line agrees with the price column beside it.
+        if offset == 0 and total == len(results):
+            # The page is the whole result, so the rows in hand are the answer.
+            price_key = "ck_price" if first_source == "ck" else "tcg_price"
+            total_qty = sum(c.get("qty") or 0 for c in results)
+            total_value = sum(
+                float(c[price_key] or 0) * (c.get("qty") or 0) for c in results
+            )
+        else:
+            agg = conn.execute(
+                f"SELECT COALESCE(SUM(qty), 0), COALESCE(SUM(qty * price), 0) FROM ("
+                f"SELECT {agg_qty_sql} as qty, {display_price_sql} as price {body_sql})",
+                sql_params,
+            ).fetchone()
+            total_qty, total_value = agg[0], agg[1]
+
         conn.close()
-        self._send_json({"rows": results, "total": total, "limit": limit, "offset": offset})
+        self._send_json(
+            {
+                "rows": results,
+                "total": total,
+                "total_qty": total_qty,
+                "total_value": round(total_value, 2),
+                "limit": limit,
+                "offset": offset,
+            }
+        )
 
     def _api_card(self, printing_id: str):
         """Return full card data for a single printing by printing_id."""

--- a/mtg_collector/static/binders.html
+++ b/mtg_collector/static/binders.html
@@ -409,7 +409,9 @@ async function searchPickerCards() {
   }
   const res = await fetch(`/api/collection?q=${encodeURIComponent(q)}&status=owned`);
   const data = await res.json();
-  pickerCards = Array.isArray(data) ? data : data.cards || [];
+  // Page envelope: {rows, total, limit, offset}. The picker searches
+  // server-side, so a page is the search result, not a slice of the pool.
+  pickerCards = data.rows;
   const container = document.getElementById('picker-cards');
   if (pickerCards.length === 0) {
     container.innerHTML = '<div style="padding:12px;color:#888;">No matching cards found</div>';

--- a/mtg_collector/static/binders.html
+++ b/mtg_collector/static/binders.html
@@ -229,6 +229,8 @@ let selectedCardIds = new Set();
 let editingBinderId = null;
 let pickerCards = [];
 let pickerSelected = new Set();
+// Matches the server's default page limit.
+const PICKER_PAGE_SIZE = 250;
 
 async function loadBinders() {
   const res = await fetch('/api/binders');
@@ -407,17 +409,23 @@ async function searchPickerCards() {
     document.getElementById('picker-cards').innerHTML = '<div style="padding:12px;color:#888;">Type at least 2 characters...</div>';
     return;
   }
-  const res = await fetch(`/api/collection?q=${encodeURIComponent(q)}&status=owned`);
+  // Same page semantics as the collection. Unlike the deck-builder picker this
+  // one renders every row it fetches — nothing is filtered out afterwards — so
+  // one page always fills the list and there is nothing to keep fetching for.
+  // What is left is honesty: when the search matched more than a page, say so
+  // instead of presenting the page as the whole result.
+  const res = await fetch(`/api/collection?q=${encodeURIComponent(q)}&status=owned&limit=${PICKER_PAGE_SIZE}&offset=0`);
   const data = await res.json();
-  // Page envelope: {rows, total, limit, offset}. The picker searches
-  // server-side, so a page is the search result, not a slice of the pool.
   pickerCards = data.rows;
   const container = document.getElementById('picker-cards');
   if (pickerCards.length === 0) {
     container.innerHTML = '<div style="padding:12px;color:#888;">No matching cards found</div>';
     return;
   }
-  container.innerHTML = pickerCards.map(c => `
+  const countLine = data.total > pickerCards.length
+    ? `<div style="padding:8px 12px;color:#888;font-size:0.85rem">Showing ${pickerCards.length.toLocaleString()} of ${data.total.toLocaleString()} matches — narrow the search to see the rest</div>`
+    : '';
+  container.innerHTML = countLine + pickerCards.map(c => `
     <div class="picker-card ${pickerSelected.has(c.printing_id + '|' + c.finish) ? 'selected' : ''}"
          onclick="togglePickerCard('${c.printing_id}', '${c.finish}', this)">
       <span>${esc(c.name)}</span>

--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -1517,6 +1517,8 @@ let sortOrder = 'asc';
 let sortColumn = 'name';
 let allCards = [];
 let allCardsUnfiltered = [];
+// Rows matching the query server-side, which is >= what a page holds.
+let totalMatches = 0;
 let debounceTimer = null;
 let _settings = {};
 let multiSelectMode = false;
@@ -3288,7 +3290,12 @@ function updateStatusText() {
   const count = useQty ? totalQty : allCards.length;
   const noun = useQty ? (count === 1 ? 'card' : 'cards') : (count === 1 ? 'result' : 'results');
   const valueSuffix = totalValue > 0 ? `, ${formatPrice(totalValue)}` : '';
-  statusEl.textContent = `${count.toLocaleString()} ${noun}${valueSuffix}`;
+  // The response is one page. Say so rather than reporting the page as if it
+  // were the whole result — the counts above are page-scoped.
+  const pageSuffix = totalMatches > allCardsUnfiltered.length
+    ? ` (showing ${allCardsUnfiltered.length.toLocaleString()} of ${totalMatches.toLocaleString()} matches)`
+    : '';
+  statusEl.textContent = `${count.toLocaleString()} ${noun}${valueSuffix}${pageSuffix}`;
   statusEl.classList.toggle('empty', allCards.length === 0);
 }
 
@@ -3322,8 +3329,12 @@ async function fetchCollection() {
     searchErrorEl.textContent = data.error;
     statusEl.textContent = `Search error: ${data.error}`;
     allCardsUnfiltered = [];
+    totalMatches = 0;
   } else {
-    allCardsUnfiltered = Array.isArray(data) ? data : [];
+    // Page envelope: {rows, total, limit, offset}. `total` counts the whole
+    // result, so it is what the status line reports — rows is one page of it.
+    allCardsUnfiltered = data.rows;
+    totalMatches = data.total;
   }
 
   selectedCards.clear();

--- a/mtg_collector/static/collection.html
+++ b/mtg_collector/static/collection.html
@@ -1515,10 +1515,32 @@ const gridSizeWrap = document.getElementById('grid-size-wrap');
 let currentView = 'table';
 let sortOrder = 'asc';
 let sortColumn = 'name';
+// The result is fetched a window at a time, so `allCards` is SPARSE: its
+// length is the full match count and only the pages scrolled into are filled
+// in. Index is the row's absolute position in the server's ordering, which is
+// what the virtual scrollers already address rows by, so a hole is simply a
+// row whose page has not arrived. Iterate with forEach/for..in (which skip
+// holes) rather than a counted loop, or you will act on `undefined`.
 let allCards = [];
-let allCardsUnfiltered = [];
-// Rows matching the query server-side, which is >= what a page holds.
+// Rows matching the query server-side — the length allCards is sized to.
 let totalMatches = 0;
+// Aggregates over the whole result, from the server. Not summable here: the
+// rows in memory grow as the user scrolls, so a local sum would climb with them.
+let resultTotalQty = 0;
+let resultTotalValue = 0;
+// Page bookkeeping. PAGE_SIZE matches the server's default limit.
+const PAGE_SIZE = 250;
+const pageState = new Map();   // page index -> 'loading' | 'loaded'
+let loadedRows = 0;
+// Bumped on every new query/sort. A page response carrying a stale generation
+// belongs to a result the user has already navigated away from.
+let fetchGeneration = 0;
+// The query string the current result was fetched with, pinned so that later
+// pages of it are pages of the SAME result rather than of whatever the search
+// box happens to hold by the time the user scrolls.
+let currentQuery = '';
+// Set by whichever scroller is mounted; lets an arriving page repaint it.
+let repaintVisible = null;
 let debounceTimer = null;
 let _settings = {};
 let multiSelectMode = false;
@@ -1675,7 +1697,7 @@ document.querySelectorAll('#image-display-pills .pill').forEach(pill => {
 });
 
 document.getElementById('sel-all').addEventListener('click', () => {
-  for (let i = 0; i < allCards.length; i++) selectedCards.add(i);
+  selectAllLoaded();
   updateSelectionBar();
   render();
 });
@@ -1804,11 +1826,18 @@ function updateSelectionBar() {
   selShareResult.innerHTML = '';
 }
 
+// Selection is by row index, and only fetched rows have one to act on. Every
+// bulk action below reads allCards[i], so an index whose page has not arrived
+// would reach them as `undefined`.
+function selectAllLoaded() {
+  allCards.forEach((card, i) => { if (card) selectedCards.add(i); });
+}
+
 function toggleCardSelection(idx, shiftKey) {
   if (shiftKey && lastSelectedIdx != null) {
     const lo = Math.min(lastSelectedIdx, idx);
     const hi = Math.max(lastSelectedIdx, idx);
-    for (let i = lo; i <= hi; i++) selectedCards.add(i);
+    for (let i = lo; i <= hi; i++) if (allCards[i]) selectedCards.add(i);
   } else {
     if (selectedCards.has(idx)) selectedCards.delete(idx);
     else selectedCards.add(idx);
@@ -1824,7 +1853,8 @@ function handleSortClick(colKey) {
     sortColumn = colKey;
     sortOrder = 'asc';
   }
-  refilterAndRender();
+  // Re-order the whole result, not the pages that happen to be loaded.
+  fetchCollection();
 }
 
 // --- Rarity/set border colors ---
@@ -2149,14 +2179,22 @@ async function renderGrowthChart(primarySource) {
 }
 
 function openStatsModal() {
-  if (!allCards.length) return;
-  const s = computeResultStats(allCards);
+  if (!totalMatches) return;
+  // These are computed over the rows in memory, which is the pages scrolled
+  // into rather than the whole result. Pass a dense array — computeResultStats
+  // iterates with for..of, which yields undefined for a hole — and say what
+  // the figures cover, rather than presenting a prefix as the whole result.
+  const loaded = allCards.filter(Boolean);
+  const s = computeResultStats(loaded);
   const sources = (_settings.price_sources || 'tcg,ck').split(',');
   const primarySource = sources[0] === 'ck' ? 'ck' : 'tcg';
   const primary = primarySource === 'ck' ? 'Card Kingdom' : 'TCGplayer';
+  const coverage = loaded.length < totalMatches
+    ? ` · over the ${loaded.length.toLocaleString()} of ${totalMatches.toLocaleString()} matches loaded so far`
+    : '';
   statsModalContent.innerHTML = `
     <h2>Result statistics</h2>
-    <div class="stats-subtitle">Default price source: ${primary}</div>
+    <div class="stats-subtitle">Default price source: ${primary}${coverage}</div>
     <div class="modal-section">
       <div class="modal-section-title">Growth over time</div>
       <div class="price-range-pills" id="growth-range-pills">
@@ -3214,6 +3252,11 @@ updateViewButtons();
 // --- Fetch ---
 function getFetchParams() {
   const params = new URLSearchParams();
+  // Sorting is the server's. Only part of the result is ever in memory, so
+  // sorting here would order the loaded rows against each other and leave the
+  // rest of the result sorted by whatever the previous query asked for.
+  params.set('sort', COL_SORT_MAP[sortColumn] || 'name');
+  if (sortOrder === 'desc') params.set('order', 'desc');
   if (_sharedCards) {
     params.set('cards', _sharedCards);
     return params.toString();
@@ -3232,71 +3275,17 @@ function getFetchParams() {
   return params.toString();
 }
 
-function applyClientSort(cards) {
-  const sortKey = COL_SORT_MAP[sortColumn] || 'name';
-  const dir = sortOrder === 'desc' ? -1 : 1;
-
-  cards.sort((a, b) => {
-    let va, vb;
-    switch (sortKey) {
-      case 'name': va = (a.name || '').toLowerCase(); vb = (b.name || '').toLowerCase(); break;
-      case 'cmc': va = a.cmc || 0; vb = b.cmc || 0; break;
-      case 'rarity': {
-        const rm = {common:0, uncommon:1, rare:2, mythic:3};
-        va = rm[a.rarity] ?? 4; vb = rm[b.rarity] ?? 4; break;
-      }
-      case 'set': va = a.set_code || ''; vb = b.set_code || ''; break;
-      case 'color': va = a.color_identity || '[]'; vb = b.color_identity || '[]'; break;
-      case 'qty': va = a.qty || 0; vb = b.qty || 0; break;
-      case 'collector_number': va = parseInt(a.collector_number) || 0; vb = parseInt(b.collector_number) || 0; break;
-      case 'date_added': va = a.acquired_at || ''; vb = b.acquired_at || ''; break;
-      case 'price': {
-        const pf = ((_settings.price_sources || 'tcg,ck').split(',')[0] === 'ck') ? 'ck_price' : 'tcg_price';
-        va = parseFloat(a[pf]) || 0; vb = parseFloat(b[pf]) || 0; break;
-      }
-      default:
-        // Price columns
-        if (sortKey === 'tcg_price' || sortColumn === 'tcg_price') { va = parseFloat(a.tcg_price) || 0; vb = parseFloat(b.tcg_price) || 0; }
-        else if (sortKey === 'ck_price' || sortColumn === 'ck_price') { va = parseFloat(a.ck_price) || 0; vb = parseFloat(b.ck_price) || 0; }
-        else { va = (a.name || '').toLowerCase(); vb = (b.name || '').toLowerCase(); }
-    }
-    if (va < vb) return -1 * dir;
-    if (va > vb) return 1 * dir;
-    // Secondary sort by name
-    const na = (a.name || '').toLowerCase(), nb = (b.name || '').toLowerCase();
-    return na < nb ? -1 : na > nb ? 1 : 0;
-  });
-  return cards;
-}
-
-function refilterAndRender() {
-  allCards = applyClientSort([...allCardsUnfiltered]);
-  updateStatusText();
-  render();
-  serializeFiltersToURL();
-}
-
 function updateStatusText() {
-  const sources = (_settings.price_sources || 'tcg,ck').split(',');
-  const priceField = sources[0] === 'ck' ? 'ck_price' : 'tcg_price';
-  const totalQty = allCards.reduce((s, c) => s + (c.qty || 0), 0);
-  const totalValue = allCards.reduce((s, c) => {
-    const p = parseFloat(c[priceField]) || 0;
-    return s + p * (c.qty || 0);
-  }, 0);
+  // Every figure here describes the whole result and comes from the server, so
+  // the line reads the same before and after scrolling loads more pages.
   // Owned queries: count by qty ("45 cards"). Unowned queries: count by row
   // ("3 results") since qty is always 0 for cards not in the collection.
-  const useQty = totalQty > 0;
-  const count = useQty ? totalQty : allCards.length;
+  const useQty = resultTotalQty > 0;
+  const count = useQty ? resultTotalQty : totalMatches;
   const noun = useQty ? (count === 1 ? 'card' : 'cards') : (count === 1 ? 'result' : 'results');
-  const valueSuffix = totalValue > 0 ? `, ${formatPrice(totalValue)}` : '';
-  // The response is one page. Say so rather than reporting the page as if it
-  // were the whole result — the counts above are page-scoped.
-  const pageSuffix = totalMatches > allCardsUnfiltered.length
-    ? ` (showing ${allCardsUnfiltered.length.toLocaleString()} of ${totalMatches.toLocaleString()} matches)`
-    : '';
-  statusEl.textContent = `${count.toLocaleString()} ${noun}${valueSuffix}${pageSuffix}`;
-  statusEl.classList.toggle('empty', allCards.length === 0);
+  const valueSuffix = resultTotalValue > 0 ? `, ${formatPrice(resultTotalValue)}` : '';
+  statusEl.textContent = `${count.toLocaleString()} ${noun}${valueSuffix}`;
+  statusEl.classList.toggle('empty', totalMatches === 0);
 }
 
 function renderSkeleton() {
@@ -3316,32 +3305,92 @@ function renderSkeleton() {
   main.innerHTML = html;
 }
 
+// --- Windowed fetching ---
+//
+// The first page is fetched here; the rest arrive as the scroller reaches
+// them, so first paint costs one bounded response rather than the catalog.
+
+function pageIndexOf(rowIdx) { return Math.floor(rowIdx / PAGE_SIZE); }
+
+function storePage(rows, offset) {
+  for (let i = 0; i < rows.length; i++) {
+    if (allCards[offset + i] === undefined) loadedRows++;
+    allCards[offset + i] = rows[i];
+  }
+}
+
+async function loadPage(pageIdx, generation) {
+  if (pageState.has(pageIdx)) return;
+  pageState.set(pageIdx, 'loading');
+  const offset = pageIdx * PAGE_SIZE;
+  // currentQuery, not getFetchParams(): the search box may already hold a
+  // query whose fetch is still inside its 300 ms debounce. Reading it here
+  // would page a result that is not the one on screen, and the generation
+  // guard below would wave it through — nothing has bumped the generation yet.
+  const res = await fetch(`/api/collection?${currentQuery}&limit=${PAGE_SIZE}&offset=${offset}`);
+  const data = await res.json();
+  // The query moved on while this was in flight; its rows belong to a result
+  // that is no longer on screen, and allCards has already been replaced.
+  if (generation !== fetchGeneration) return;
+  if (data.error) {
+    pageState.delete(pageIdx);
+    searchErrorEl.textContent = data.error;
+    return;
+  }
+  storePage(data.rows, offset);
+  pageState.set(pageIdx, 'loaded');
+  if (repaintVisible) repaintVisible();
+}
+
+// Request every page the given row range touches, plus one page beyond it so
+// the next screenful is usually already there when the user reaches it.
+function ensurePagesForRange(firstIdx, lastIdx) {
+  if (!totalMatches) return;
+  const first = Math.max(0, firstIdx);
+  const last = Math.min(totalMatches - 1, lastIdx + PAGE_SIZE);
+  for (let p = pageIndexOf(first); p <= pageIndexOf(last); p++) {
+    if (!pageState.has(p)) loadPage(p, fetchGeneration);
+  }
+}
+
 async function fetchCollection() {
   searchErrorEl.textContent = '';
   statusEl.textContent = 'Loading...';
-  if (allCardsUnfiltered.length === 0 && currentView === 'table') renderSkeleton();
+  const hadRows = totalMatches > 0;
+  if (!hadRows && currentView === 'table') renderSkeleton();
 
-  const params = getFetchParams();
-  const res = await fetch(`/api/collection?${params}`);
+  const generation = ++fetchGeneration;
+  pageState.clear();
+  allCards = [];
+  loadedRows = 0;
+  currentQuery = getFetchParams();
+
+  const res = await fetch(`/api/collection?${currentQuery}&limit=${PAGE_SIZE}&offset=0`);
   const data = await res.json();
+  if (generation !== fetchGeneration) return;
 
   if (data.error) {
     searchErrorEl.textContent = data.error;
     statusEl.textContent = `Search error: ${data.error}`;
-    allCardsUnfiltered = [];
-    totalMatches = 0;
+    totalMatches = 0; resultTotalQty = 0; resultTotalValue = 0;
   } else {
-    // Page envelope: {rows, total, limit, offset}. `total` counts the whole
-    // result, so it is what the status line reports — rows is one page of it.
-    allCardsUnfiltered = data.rows;
+    // Page envelope: {rows, total, total_qty, total_value, limit, offset}.
     totalMatches = data.total;
+    resultTotalQty = data.total_qty;
+    resultTotalValue = data.total_value;
+    allCards = new Array(totalMatches);
+    storePage(data.rows, 0);
+    pageState.set(0, 'loaded');
   }
 
   selectedCards.clear();
   lastSelectedIdx = null;
   updateSelectionBar();
 
-  allCards = applyClientSort([...allCardsUnfiltered]);
+  // A new result starts at the top. Holding the old scroll position would drop
+  // the viewport into the middle of a result the user has not seen, and make
+  // the first fetched page one they never look at.
+  window.scrollTo(0, 0);
   updateStatusText();
   render();
   serializeFiltersToURL();
@@ -3364,7 +3413,7 @@ function renderTable() {
 
   const savedScrollX = window.scrollX;
 
-  if (allCards.length === 0) {
+  if (totalMatches === 0) {
     main.innerHTML = '<div class="empty-state">No cards found</div>';
     return;
   }
@@ -3372,13 +3421,17 @@ function renderTable() {
   const visCols = getVisibleColumns();
   let rowHeight = 49; // initial estimate, measured after first render
   const bufferRows = 5;
-  const totalRows = allCards.length;
+  // Sized to the whole result: the spacers reserve height for rows whose page
+  // has not been fetched, so the scrollbar reflects the result rather than the
+  // part of it in memory, and scroll position stays put as pages arrive.
+  const totalRows = totalMatches;
   const colCount = visCols.length + (multiSelectMode ? 1 : 0);
   const _cellOpts = { priceSources: _settings.price_sources };
 
   let theadHtml = '<tr>';
   if (multiSelectMode) {
-    const allChecked = selectedCards.size === allCards.length && allCards.length > 0;
+    // Selection only ever covers fetched rows, so that is what "all" means.
+    const allChecked = loadedRows > 0 && selectedCards.size === loadedRows;
     theadHtml += `<th class="select-col"><input type="checkbox" class="sel-all-cb" ${allChecked ? 'checked' : ''}></th>`;
   }
   for (const col of visCols) {
@@ -3396,8 +3449,23 @@ function renderTable() {
   const bottomSpacer = document.getElementById('vscroll-bottom');
   let renderedRange = [-1, -1];
 
+  // A row whose page has not arrived. Same cell structure and the same
+  // .skeleton-cell sizing the initial skeleton uses, so it occupies exactly the
+  // height its real row will, and swapping one in shifts nothing.
+  function buildPendingRowHtml(idx) {
+    let h = `<tr class="skeleton-row" data-idx="${idx}" data-pending="1">`;
+    if (multiSelectMode) h += '<td class="select-col"></td>';
+    for (const col of visCols) {
+      h += col.key === 'name'
+        ? `<td data-col="${col.key}"><div class="skeleton-cell thumb"></div><div class="skeleton-cell wide"></div></td>`
+        : `<td data-col="${col.key}"><div class="skeleton-cell narrow"></div></td>`;
+    }
+    return h + '</tr>';
+  }
+
   function buildRowHtml(idx) {
     const card = allCards[idx];
+    if (!card) return buildPendingRowHtml(idx);
     const helpers = prepareCardHelpers(card, { isWanted: isCardWanted });
     const isSelected = selectedCards.has(idx);
     const isUnowned = card.owned === false;
@@ -3431,6 +3499,10 @@ function renderTable() {
 
     const firstRow = Math.max(0, Math.floor(offset / rowHeight) - bufferRows);
     const lastRow = Math.min(totalRows - 1, Math.ceil((offset + viewportHeight) / rowHeight) + bufferRows);
+
+    // Ask for whatever this range needs before the early-out below: the range
+    // can be unchanged while its pages are still in flight.
+    ensurePagesForRange(firstRow, lastRow);
 
     if (firstRow === renderedRange[0] && lastRow === renderedRange[1]) return;
     const [pf, pl] = renderedRange;
@@ -3470,9 +3542,10 @@ function renderTable() {
     topSpacer.firstChild.style.height = firstRow * rowHeight + 'px';
     bottomSpacer.firstChild.style.height = Math.max(0, (totalRows - lastRow - 1) * rowHeight) + 'px';
 
-    // Measure actual row height after first render
+    // Measure actual row height after first render. Measure a real row: a
+    // pending row is built to match, but the real one is the authority.
     if (pf === -1) {
-      const sample = tbody.querySelector('tr[data-idx]');
+      const sample = tbody.querySelector('tr[data-idx]:not([data-pending])') || tbody.querySelector('tr[data-idx]');
       if (sample) rowHeight = sample.offsetHeight || rowHeight;
     }
   }
@@ -3480,6 +3553,10 @@ function renderTable() {
   renderVisibleRows();
 
   if (savedScrollX) window.scrollTo(savedScrollX, window.scrollY);
+
+  // An arriving page has to replace the pending rows already on screen, and
+  // the range has not moved, so force the rebuild the range guard would skip.
+  repaintVisible = () => { renderedRange = [-1, -1]; renderVisibleRows(); };
 
   let ticking = false;
   function onScroll() {
@@ -3489,13 +3566,16 @@ function renderTable() {
     }
   }
   window.addEventListener('scroll', onScroll, { passive: true });
-  _tableScrollCleanup = () => window.removeEventListener('scroll', onScroll);
+  _tableScrollCleanup = () => {
+    window.removeEventListener('scroll', onScroll);
+    repaintVisible = null;
+  };
 
   // Delegated click handler for checkboxes, filterable elements and row->modal
   table.addEventListener('click', (e) => {
     if (e.target.classList.contains('sel-all-cb')) {
       if (e.target.checked) {
-        for (let i = 0; i < allCards.length; i++) selectedCards.add(i);
+        selectAllLoaded();
       } else {
         selectedCards.clear();
       }
@@ -3509,7 +3589,7 @@ function renderTable() {
       if (e.shiftKey) { render(); return; }
       e.target.closest('tr').classList.toggle('selected', selectedCards.has(idx));
       const allCb = main.querySelector('.sel-all-cb');
-      if (allCb) allCb.checked = selectedCards.size === allCards.length;
+      if (allCb) allCb.checked = selectedCards.size === loadedRows;
       return;
     }
     if (e.target.closest('a')) return;
@@ -3520,7 +3600,8 @@ function renderTable() {
       return;
     }
     const tr = e.target.closest('tr[data-idx]');
-    if (tr) showCardModal(allCards[parseInt(tr.dataset.idx)]);
+    const clicked = tr && allCards[parseInt(tr.dataset.idx)];
+    if (clicked) showCardModal(clicked);
   });
 
   main.querySelectorAll('.collection-table th[data-col]').forEach(th => {
@@ -3533,6 +3614,12 @@ let _tableScrollCleanup = null;
 let _gridScrollCleanup = null;
 
 function _buildCardHtml(card, idx) {
+  // Page not arrived yet. aspect-ratio holds the tile's height so the grid
+  // does not reflow when the real card replaces it — the img that normally
+  // sets that height is not there to do it.
+  if (!card) {
+    return `<div class="sheet-card" data-idx="${idx}" data-pending="1"><div class="sheet-card-img-wrap" style="--rarity-color:#111;--set-color:#111;aspect-ratio:488/680"><div class="skeleton-cell" style="width:100%;height:100%"></div></div></div>`;
+  }
   const isUnowned = card.owned === false;
   const isWanted = isUnowned && isCardWanted(card);
   const isOrdered = card.status === 'ordered';
@@ -3550,7 +3637,7 @@ function renderGrid() {
   // Clean up previous scroll listener
   if (_gridScrollCleanup) { _gridScrollCleanup(); _gridScrollCleanup = null; }
 
-  if (allCards.length === 0) {
+  if (totalMatches === 0) {
     main.innerHTML = '<div class="empty-state">No cards found</div>';
     return;
   }
@@ -3569,7 +3656,9 @@ function renderGrid() {
   const cols = gridCols;
   const cardWidth = Math.floor((viewportWidth - (cols - 1) * gap) / cols);
   const cardHeight = Math.round(cardWidth * (680 / 488)) + gap; // aspect ratio + gap
-  const totalRows = Math.ceil(allCards.length / cols);
+  // Sized to the whole result, like the table's spacers — unfetched rows still
+  // occupy their place so the scrollbar means what it says.
+  const totalRows = Math.ceil(totalMatches / cols);
   const totalHeight = totalRows * cardHeight;
   const bufferRows = 3;
 
@@ -3585,11 +3674,15 @@ function renderGrid() {
     const firstRow = Math.max(0, Math.floor(scrollTop / cardHeight) - bufferRows);
     const lastRow = Math.min(totalRows - 1, Math.ceil((scrollTop + viewportHeight) / cardHeight) + bufferRows);
 
+    const startIdx = firstRow * cols;
+    const endIdx = Math.min(totalMatches, (lastRow + 1) * cols);
+
+    // Before the early-out: the range can be unchanged with pages in flight.
+    ensurePagesForRange(startIdx, endIdx - 1);
+
     if (firstRow === renderedRange[0] && lastRow === renderedRange[1]) return;
     renderedRange = [firstRow, lastRow];
 
-    const startIdx = firstRow * cols;
-    const endIdx = Math.min(allCards.length, (lastRow + 1) * cols);
     let html = '';
     for (let idx = startIdx; idx < endIdx; idx++) {
       html += _buildCardHtml(allCards[idx], idx);
@@ -3608,6 +3701,9 @@ function renderGrid() {
 
   renderVisible();
 
+  // Same as the table: an arriving page must replace pending tiles in place.
+  repaintVisible = () => { renderedRange = [-1, -1]; renderVisible(); };
+
   // Scroll listener with requestAnimationFrame throttle
   let ticking = false;
   function onScroll() {
@@ -3617,7 +3713,10 @@ function renderGrid() {
     }
   }
   window.addEventListener('scroll', onScroll, { passive: true });
-  _gridScrollCleanup = () => window.removeEventListener('scroll', onScroll);
+  _gridScrollCleanup = () => {
+    window.removeEventListener('scroll', onScroll);
+    repaintVisible = null;
+  };
 
   // Delegated event listeners on sort bar
   document.getElementById('grid-sort-bar').addEventListener('click', (e) => {
@@ -3634,7 +3733,8 @@ function renderGrid() {
       return;
     }
     const cardEl = e.target.closest('.sheet-card');
-    if (cardEl) showCardModal(allCards[parseInt(cardEl.dataset.idx)]);
+    const clicked = cardEl && allCards[parseInt(cardEl.dataset.idx)];
+    if (clicked) showCardModal(clicked);
   });
 }
 
@@ -4038,7 +4138,9 @@ document.getElementById('wishlist-panel-list').addEventListener('click', async (
   // Click on entry name — open card modal
   const printingId = entryEl.dataset.printingId;
   if (!printingId) return;
-  const card = allCards.find(c => c.printing_id === printingId);
+  // find() visits holes rather than skipping them, so guard the row before
+  // reading it. A row whose page has not arrived falls through to the fetch.
+  const card = allCards.find(c => c && c.printing_id === printingId);
   if (card) {
     toggleWishlistPanel(false);
     showCardModal(card);

--- a/mtg_collector/static/deck-builder.js
+++ b/mtg_collector/static/deck-builder.js
@@ -753,7 +753,9 @@
     const isVirtual = window._builderData && window._builderData.deck.state !== 'constructed';
     const res = await fetch('/api/collection?q=' + encodeURIComponent(q) + '&status=owned&expand=copies');
     const data = await res.json();
-    const allCopies = Array.isArray(data) ? data : data.cards || [];
+    // Page envelope: {rows, total, limit, offset}. The picker searches
+    // server-side, so a page is the search result, not a slice of the pool.
+    const allCopies = data.rows;
     // Hypothetical decks: dedup by printing_id (don't care about individual copies)
     // Real decks: only show unassigned copies
     let cards;

--- a/mtg_collector/static/deck-builder.js
+++ b/mtg_collector/static/deck-builder.js
@@ -743,6 +743,40 @@
     document.getElementById('add-cards-modal').classList.add('active');
   }
 
+  // The picker takes the same page semantics as the collection, then filters
+  // what it got: it drops copies already in a deck or binder (or, for a
+  // hypothetical deck, duplicate printings). So a full 250-row page can leave
+  // very few rows to show.
+  //
+  // That is why this keeps fetching until enough rows survive the filter
+  // instead of rendering one page and stopping. Search "Lightning Bolt", own
+  // 300 copies with the first 250 all assigned, and stopping at page one
+  // reports "No unassigned copies found" while a free copy sits on page two —
+  // telling the user they own nothing free when they do, which is the one
+  // question this picker exists to answer. Over-fetching only costs latency;
+  // under-fetching is wrong. The cap bounds the walk, and when it is reached
+  // the count line says what was covered rather than looking complete.
+  const PICKER_PAGE_SIZE = 250;
+  const PICKER_TARGET_ROWS = 100;
+  const PICKER_PAGE_CAP = 8;
+
+  async function fetchFilteredPages(query, keepFrom) {
+    const kept = [];
+    let offset = 0;
+    let total = 0;
+    let exhausted = false;
+    for (let page = 0; page < PICKER_PAGE_CAP; page++) {
+      const res = await fetch(`/api/collection?${query}&limit=${PICKER_PAGE_SIZE}&offset=${offset}`);
+      const data = await res.json();
+      total = data.total;
+      kept.push(...keepFrom(data.rows));
+      offset += data.rows.length;
+      if (!data.rows.length || offset >= total) { exhausted = true; break; }
+      if (kept.length >= PICKER_TARGET_ROWS) break;
+    }
+    return { kept, total, scanned: offset, exhausted };
+  }
+
   async function searchPickerCards() {
     const q = document.getElementById('picker-search').value.trim();
     if (q.length < 2) {
@@ -751,31 +785,33 @@
       return;
     }
     const isVirtual = window._builderData && window._builderData.deck.state !== 'constructed';
-    const res = await fetch('/api/collection?q=' + encodeURIComponent(q) + '&status=owned&expand=copies');
-    const data = await res.json();
-    // Page envelope: {rows, total, limit, offset}. The picker searches
-    // server-side, so a page is the search result, not a slice of the pool.
-    const allCopies = data.rows;
-    // Hypothetical decks: dedup by printing_id (don't care about individual copies)
-    // Real decks: only show unassigned copies
-    let cards;
-    if (isVirtual) {
-      const seen = new Set();
-      cards = allCopies.filter(c => {
-        if (seen.has(c.printing_id)) return false;
-        seen.add(c.printing_id);
-        return true;
-      });
-    } else {
-      cards = allCopies.filter(c => !c.deck_id && !c.binder_id);
-    }
+    const query = 'q=' + encodeURIComponent(q) + '&status=owned&expand=copies';
+    // Hypothetical decks: dedup by printing_id (don't care about individual
+    // copies). Real decks: only show unassigned copies. `seen` lives outside
+    // the per-page filter so dedup holds across pages, not within one.
+    const seen = new Set();
+    const keepFrom = (rows) => rows.filter(c => {
+      if (!isVirtual) return !c.deck_id && !c.binder_id;
+      if (seen.has(c.printing_id)) return false;
+      seen.add(c.printing_id);
+      return true;
+    });
+    const { kept: cards, total, scanned, exhausted } = await fetchFilteredPages(query, keepFrom);
 
     const container = document.getElementById('picker-cards');
     if (cards.length === 0) {
-      container.innerHTML = '<div style="padding:12px;color:var(--text-secondary);">No unassigned copies found</div>';
+      const msg = exhausted
+        ? 'No unassigned copies found'
+        : `No unassigned copies in the first ${scanned.toLocaleString()} of ${total.toLocaleString()} matches — narrow the search`;
+      container.innerHTML = `<div style="padding:12px;color:var(--text-secondary);">${esc(msg)}</div>`;
       return;
     }
-    container.innerHTML = cards.map(c => {
+    // Only when the walk stopped early: otherwise these are all of them, and a
+    // count would just be noise.
+    const countLine = exhausted
+      ? ''
+      : `<div style="padding:8px 12px;color:var(--text-secondary);font-size:0.85rem">Showing ${cards.length.toLocaleString()} available from the first ${scanned.toLocaleString()} of ${total.toLocaleString()} matches</div>`;
+    container.innerHTML = countLine + cards.map(c => {
       const key = isVirtual ? String(c.printing_id) : String(c.collection_id);
       const cond = c.condition ? ` [${esc(c.condition)}]` : '';
       const price = c.purchase_price ? ` ${formatPrice(c.purchase_price)}` : '';

--- a/tests/integration/test_collection_paging.py
+++ b/tests/integration/test_collection_paging.py
@@ -1,0 +1,155 @@
+"""
+Paging contract for /api/collection.
+
+The endpoint returns a page envelope — {rows, total, limit, offset} — never a
+bare array.  `limit` defaults to 250 and caps at 1000; there is no unbounded
+escape hatch and no sentinel, so every caller takes the same semantics.  A bad
+`limit` or `offset` is a 400, not a silent clamp.
+
+Usage:
+    uv run pytest tests/integration/test_collection_paging.py -v --instance <instance>
+"""
+
+import json
+
+import pytest
+
+DEFAULT_LIMIT = 250
+MAX_LIMIT = 1000
+
+# The three query templates behind /api/collection: aggregated default,
+# one-row-per-copy (deck-builder picker), and the LEFT-JOIN unowned template.
+TEMPLATES = [
+    pytest.param("", id="default"),
+    pytest.param("expand=copies", id="expand-copies"),
+    pytest.param("q=is%3Aunowned", id="is-unowned"),
+]
+
+
+def _page(api, query: str, **page_params):
+    """GET one page, asserting the envelope shape. Returns the parsed body."""
+    parts = [p for p in [query, *(f"{k}={v}" for k, v in page_params.items())] if p]
+    path = "/api/collection" + ("?" + "&".join(parts) if parts else "")
+    status, body = api.get(path)
+    assert status == 200, f"{path} -> {status} {body}"
+    assert isinstance(body, dict), f"{path} returned a bare {type(body).__name__}, not an envelope"
+    assert set(body) >= {"rows", "total", "limit", "offset"}, f"{path} envelope keys: {sorted(body)}"
+    assert isinstance(body["rows"], list)
+    return body
+
+
+def _identity(row: dict) -> str:
+    """Stable identity for a result row, for gap/duplicate detection."""
+    return json.dumps(row, sort_keys=True)
+
+
+class TestPageEnvelope:
+    @pytest.mark.parametrize("query", TEMPLATES)
+    def test_default_page_is_bounded(self, api, query):
+        """No paging params: 250 rows at offset 0, with an honest total."""
+        body = _page(api, query)
+
+        assert body["limit"] == DEFAULT_LIMIT
+        assert body["offset"] == 0
+        assert len(body["rows"]) <= DEFAULT_LIMIT
+        assert body["total"] >= len(body["rows"])
+
+    @pytest.mark.parametrize("query", TEMPLATES)
+    def test_limit_bounds_the_page(self, api, query):
+        """`limit` caps the rows returned without changing `total`."""
+        unbounded_total = _page(api, query)["total"]
+        body = _page(api, query, limit=2)
+
+        assert body["limit"] == 2
+        assert len(body["rows"]) <= 2
+        assert body["total"] == unbounded_total, "total must count the whole result, not the page"
+
+    @pytest.mark.parametrize("query", TEMPLATES)
+    def test_total_is_the_unbounded_count(self, api, query):
+        """`total` is independent of the page size."""
+        assert _page(api, query, limit=1)["total"] == _page(api, query, limit=MAX_LIMIT)["total"]
+
+    def test_max_limit_is_accepted(self, api):
+        body = _page(api, "", limit=MAX_LIMIT)
+        assert body["limit"] == MAX_LIMIT
+
+    @pytest.mark.parametrize("query", TEMPLATES)
+    def test_total_agrees_on_every_page_of_a_walk(self, api, query):
+        """A short page lets the server infer the total instead of counting it.
+
+        The inference and the count must agree, including on the last page of
+        a walk (short, non-zero offset) and past the end (empty, so the offset
+        proves nothing) — those take different branches.
+        """
+        counted = _page(api, query, limit=1)["total"]
+        if counted == 0:
+            pytest.skip("no rows for this query in the fixture dataset")
+
+        page_size = 3
+        last_offset = (counted - 1) // page_size * page_size
+        for offset in (0, last_offset, counted, counted + 5):
+            body = _page(api, query, limit=page_size, offset=offset)
+            assert body["total"] == counted, f"total disagrees at offset={offset}"
+
+
+class TestOffsetWalk:
+    @pytest.mark.parametrize("query", TEMPLATES)
+    def test_walk_has_no_gaps_or_repeats(self, api, query):
+        """Paging by offset visits every row exactly once.
+
+        This is what a non-total ORDER BY breaks: ties at a page boundary drop
+        and duplicate rows, which reads as data loss rather than a bug.
+        """
+        first = _page(api, query, limit=1)
+        total = first["total"]
+        if total == 0:
+            pytest.skip("no rows for this query in the fixture dataset")
+        # Keep the walk bounded — a full catalog walk is not the point here.
+        walk_total = min(total, 40)
+        page_size = 3
+
+        seen: list[str] = []
+        for offset in range(0, walk_total, page_size):
+            body = _page(api, query, limit=page_size, offset=offset)
+            assert body["offset"] == offset
+            assert body["total"] == total, "total drifted mid-walk"
+            seen.extend(_identity(r) for r in body["rows"])
+
+        expected = min(walk_total + (-walk_total % page_size), total)
+        assert len(seen) == expected, "walk returned the wrong number of rows"
+        assert len(set(seen)) == len(seen), "walk returned duplicate rows"
+
+        # Same rows as reading the range in one page — no drops at boundaries.
+        one_shot = _page(api, query, limit=expected, offset=0)["rows"]
+        assert [_identity(r) for r in one_shot] == seen, "paged order differs from single-page order"
+
+    def test_offset_past_the_end_is_an_empty_page(self, api):
+        """Past the end is an empty page with an honest total, not an error."""
+        total = _page(api, "")["total"]
+        body = _page(api, "", limit=10, offset=total + 10)
+
+        assert body["rows"] == []
+        assert body["total"] == total
+        assert body["offset"] == total + 10
+
+
+class TestRejectsBadPaging:
+    """A bad limit/offset is a 400, never a silent clamp."""
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            "limit=1001",
+            "limit=-1",
+            "limit=abc",
+            "limit=0",
+            "limit=1.5",
+            "offset=-1",
+            "offset=abc",
+        ],
+    )
+    def test_rejected_with_400(self, api, params):
+        status, body = api.get(f"/api/collection?{params}")
+
+        assert status == 400, f"?{params} -> {status} {body}"
+        assert "error" in body

--- a/tests/integration/test_collection_perf.py
+++ b/tests/integration/test_collection_perf.py
@@ -55,11 +55,13 @@ class TestCollectionApiPerformance:
 
         # Measured request
         elapsed_ms, status, body, _ = _timed_get(url, _ssl_ctx)
-        cards = json.loads(body)
+        page = json.loads(body)
 
         assert status == 200
-        assert isinstance(cards, list)
-        print(f"\n  /api/collection: {len(cards)} cards in {elapsed_ms:.0f} ms")
+        # Page envelope, not a bare array: {rows, total, limit, offset}.
+        assert set(page) >= {"rows", "total", "limit", "offset"}
+        cards = page["rows"]
+        print(f"\n  /api/collection: {len(cards)} of {page['total']} cards in {elapsed_ms:.0f} ms")
         assert elapsed_ms < API_RESPONSE_BUDGET_MS, (
             f"Collection API took {elapsed_ms:.0f} ms (budget: {API_RESPONSE_BUDGET_MS} ms)"
         )
@@ -75,8 +77,8 @@ class TestCollectionApiPerformance:
         if len(raw) > 1024 or encoding == "gzip":
             assert encoding == "gzip", "Expected gzip Content-Encoding"
             body = gzip.decompress(raw)
-            cards = json.loads(body)
-            assert isinstance(cards, list)
+            page = json.loads(body)
+            assert isinstance(page["rows"], list)
             ratio = len(raw) / len(body) if body else 1
             print(f"\n  gzip: {len(body)} -> {len(raw)} bytes ({ratio:.1%})")
 
@@ -84,7 +86,7 @@ class TestCollectionApiPerformance:
         """Cards include price fields (verifies bulk lookup works)."""
         url = f"{base_url}/api/collection"
         _, status, body, _ = _timed_get(url, _ssl_ctx)
-        cards = json.loads(body)
+        cards = json.loads(body)["rows"]
 
         assert status == 200
         if not cards:
@@ -101,7 +103,7 @@ class TestCollectionApiPerformance:
         url = f"{base_url}/api/collection?search=mountain"
         _timed_get(url, _ssl_ctx)  # warm-up
         elapsed_ms, status, body, _ = _timed_get(url, _ssl_ctx)
-        cards = json.loads(body)
+        cards = json.loads(body)["rows"]
 
         assert status == 200
         print(f"\n  /api/collection?search=mountain: {len(cards)} cards in {elapsed_ms:.0f} ms")

--- a/tests/integration/test_decks_binders_api.py
+++ b/tests/integration/test_decks_binders_api.py
@@ -17,12 +17,12 @@ import pytest  # noqa: I001
 def _get_unassigned_entry_ids(api, count=1):
     """Get individual collection entry IDs for unassigned cards via /api/collection/copies."""
     # Get some collection entries (grouped by printing)
-    status, collection = api.get("/api/collection?limit=20")
-    if status != 200 or not collection:
+    status, page = api.get("/api/collection?limit=20")
+    if status != 200 or not page["rows"]:
         return []
 
     entry_ids = []
-    for card in collection:
+    for card in page["rows"]:
         pid = card["printing_id"]
         finish = card.get("finish", "nonfoil")
         status, copies = api.get(f"/api/collection/copies?printing_id={pid}&finish={finish}")
@@ -254,7 +254,7 @@ class TestExpectedListRemoval:
     def _pick_printing(self, api):
         status, data = api.get("/api/collection?limit=5")
         assert status == 200
-        cards = data if isinstance(data, list) else data.get("cards", [])
+        cards = data["rows"]
         assert cards, "No cards in collection — cannot run expected-list test"
         card = cards[0]
         return card["printing_id"], card["oracle_id"], card["name"]
@@ -620,7 +620,7 @@ class TestDeleteCascade:
         # Cards should still be in collection (total count should not decrease)
         status, collection = api.get("/api/collection")
         assert status == 200
-        assert len(collection) > 0  # Collection is not empty
+        assert collection["total"] > 0  # Collection is not empty
 
     def test_delete_binder_preserves_cards(self, api):
         card_ids = _get_unassigned_entry_ids(api, count=2)
@@ -638,7 +638,7 @@ class TestDeleteCascade:
         # Cards should still be in collection
         status, collection = api.get("/api/collection")
         assert status == 200
-        assert len(collection) > 0
+        assert collection["total"] > 0
 
 
 # =============================================================================
@@ -725,7 +725,7 @@ class TestCollectionDeckBinderFilters:
     def test_unassigned_filter(self, api):
         status, data = api.get("/api/collection?q=is%3Aunassigned&limit=5")
         assert status == 200
-        for card in data:
+        for card in data["rows"]:
             assert card.get("deck_id") is None
             assert card.get("binder_id") is None
 
@@ -745,8 +745,8 @@ class TestCollectionDeckBinderFilters:
             q = quote(f'deck:"{deck["name"]}"')
             status, filtered = api.get(f"/api/collection?q={q}")
             assert status == 200
-            assert len(filtered) >= 1
-            for card in filtered:
+            assert filtered["total"] >= 1
+            for card in filtered["rows"]:
                 assert card.get("deck_id") == deck["id"]
         finally:
             api.delete(f"/api/decks/{deck['id']}")
@@ -766,8 +766,8 @@ class TestCollectionDeckBinderFilters:
             q = quote(f'binder:"{binder["name"]}"')
             status, filtered = api.get(f"/api/collection?q={q}")
             assert status == 200
-            assert len(filtered) >= 1
-            for card in filtered:
+            assert filtered["total"] >= 1
+            for card in filtered["rows"]:
                 assert card.get("binder_id") == binder["id"]
         finally:
             api.delete(f"/api/binders/{binder['id']}")

--- a/tests/test_collection_enrichment.py
+++ b/tests/test_collection_enrichment.py
@@ -166,7 +166,8 @@ def _collection(db_path, **params):
     handler._api_collection({k: [v] for k, v in params.items()})
     status, body = handler._responses[-1]
     assert status == 200, body
-    return {c["name"]: c for c in body}
+    # Page envelope: {rows, total, limit, offset}.
+    return {c["name"]: c for c in body["rows"]}
 
 
 # ── Enrichment values ──
@@ -283,8 +284,8 @@ def test_enrichment_applies_to_expand_copies_template(enriched_db):
     handler = _make_handler(enriched_db)
     handler._api_collection({"expand": ["copies"]})
     _, body = handler._responses[-1]
-    assert len(body) == 4, [c["name"] for c in body]
-    cards = {c["name"]: c for c in body}
+    assert body["total"] == 4, [c["name"] for c in body["rows"]]
+    cards = {c["name"]: c for c in body["rows"]}
     assert cards["Bravo"]["ck_price"] == "9.0"
     assert cards["Bravo"]["ck_url"] == "https://ck/bravo-front-foil"
 
@@ -294,7 +295,7 @@ def test_enrichment_joins_do_not_multiply_rows(enriched_db):
     handler = _make_handler(enriched_db)
     handler._api_collection({})
     _, body = handler._responses[-1]
-    assert len(body) == 4, [c["name"] for c in body]
+    assert body["total"] == 4, [c["name"] for c in body["rows"]]
 
 
 # ── The assertion that keeps it fixed ──
@@ -305,7 +306,8 @@ def _max_params(db_path, **params):
     handler._api_collection({k: [v] for k, v in params.items()})
     status, body = handler._responses[-1]
     assert status == 200, body
-    return max(c for conn in handler._conns for c in conn.param_counts), len(body)
+    # `total` counts the whole result; the page itself is capped at `limit`.
+    return max(c for conn in handler._conns for c in conn.param_counts), body["total"]
 
 
 def test_no_statement_binds_params_proportional_to_the_result_set(enriched_db):

--- a/tests/test_collection_enrichment.py
+++ b/tests/test_collection_enrichment.py
@@ -1,0 +1,331 @@
+"""
+Price and Card Kingdom URL enrichment on /api/collection.
+
+The enrichment used to be two follow-up passes after the main query, each
+building an `IN (...)` clause sized by the result set.  It is now LEFT JOINs on
+the main query.  These tests pin the enrichment values that refactor had to
+preserve, and — more durably — assert that no statement in the path binds a
+number of parameters that grows with the result set.
+
+To run: uv run pytest tests/test_collection_enrichment.py -v
+"""
+
+import os
+import sqlite3
+import tempfile
+
+import pytest
+
+from mtg_collector.db.schema import init_db, refresh_latest_prices
+
+NOW = "2025-01-01T00:00:00.000Z"
+
+
+def _add_card(conn, n, name, set_code="tst"):
+    """Insert card + printing #n and return its printing_id."""
+    conn.execute(
+        "INSERT INTO cards (oracle_id, name, mana_cost, type_line, colors, color_identity) "
+        "VALUES (?, ?, '{R}', 'Creature', '[\"R\"]', '[\"R\"]')",
+        (f"oracle-{n}", name),
+    )
+    conn.execute(
+        "INSERT INTO printings (printing_id, oracle_id, set_code, collector_number, rarity, finishes) "
+        "VALUES (?, ?, ?, ?, 'R', '[\"nonfoil\", \"foil\"]')",
+        (f"print-{n}", f"oracle-{n}", set_code, str(n)),
+    )
+    return f"print-{n}"
+
+
+def _own(conn, n, finish):
+    conn.execute(
+        "INSERT INTO collection (printing_id, finish, acquired_at, source, status) "
+        "VALUES (?, ?, ?, 'manual', 'owned')",
+        (f"print-{n}", finish, NOW),
+    )
+
+
+def _price(conn, cn, source, price_type, price):
+    conn.execute(
+        "INSERT INTO prices (set_code, collector_number, source, price_type, price, observed_at) "
+        "VALUES ('tst', ?, ?, ?, ?, '2025-01-01')",
+        (str(cn), source, price_type, price),
+    )
+
+
+def _mtgjson(conn, n, ck_url, ck_url_foil, uuid_suffix=""):
+    conn.execute(
+        "INSERT INTO mtgjson_printings (uuid, printing_id, name, set_code, number, ck_url, ck_url_foil, imported_at) "
+        "VALUES (?, ?, 'x', 'tst', ?, ?, ?, '2025-01-01')",
+        (f"uuid-{n}{uuid_suffix}", f"print-{n}", str(n), ck_url, ck_url_foil),
+    )
+
+
+@pytest.fixture
+def enriched_db():
+    """A DB exercising every branch of the price / ck_url enrichment."""
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        path = f.name
+
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    conn.execute("INSERT INTO sets (set_code, set_name) VALUES ('tst', 'Test Set')")
+
+    # 1 — nonfoil, both a CK buylist and a CK retail price: buylist wins.
+    _add_card(conn, 1, "Alpha")
+    _own(conn, 1, "nonfoil")
+    _price(conn, 1, "tcgplayer", "normal", 5.99)
+    _price(conn, 1, "cardkingdom", "buylist_normal", 3.0)
+    _price(conn, 1, "cardkingdom", "normal", 4.0)
+    _price(conn, 1, "tcgplayer", "foil", 99.0)  # must NOT be picked for a nonfoil copy
+    _mtgjson(conn, 1, "https://ck/alpha", "https://ck/alpha-foil")
+
+    # 2 — foil, no CK buylist: falls back to the CK retail foil price.  Two
+    # mtgjson rows share the printing_id, as MTGJSON emits for a double-faced
+    # card.  The uuids are ordered against insertion order on purpose, so a
+    # join that sorted by uuid would pick the back face and fail the test.
+    _add_card(conn, 2, "Bravo")
+    _own(conn, 2, "foil")
+    _price(conn, 2, "tcgplayer", "foil", 12.5)
+    _price(conn, 2, "cardkingdom", "foil", 9.0)
+    _price(conn, 2, "tcgplayer", "normal", 1.0)  # must NOT be picked for a foil copy
+    _mtgjson(conn, 2, "https://ck/bravo-front", "https://ck/bravo-front-foil", uuid_suffix="-z")
+    _mtgjson(conn, 2, "https://ck/bravo-back", "https://ck/bravo-back-foil", uuid_suffix="-a")
+
+    # 3 — etched prices as foil, and falls back to the nonfoil URL when there
+    # is no foil one.
+    _add_card(conn, 3, "Charlie")
+    _own(conn, 3, "etched")
+    _price(conn, 3, "tcgplayer", "foil", 20.0)
+    _price(conn, 3, "cardkingdom", "buylist_foil", 15.0)
+    _price(conn, 3, "tcgplayer", "normal", 2.0)  # must NOT be picked for an etched copy
+    _mtgjson(conn, 3, "https://ck/charlie", "")
+
+    # 4 — no prices and no mtgjson row at all.
+    _add_card(conn, 4, "Delta")
+    _own(conn, 4, "nonfoil")
+
+    # 5 — not owned: c.finish is NULL, so it prices as normal.
+    _add_card(conn, 5, "Echo")
+    _price(conn, 5, "tcgplayer", "normal", 7.25)
+    _price(conn, 5, "tcgplayer", "foil", 70.0)
+    _mtgjson(conn, 5, "https://ck/echo", "https://ck/echo-foil")
+
+    refresh_latest_prices(conn)
+    conn.commit()
+    conn.close()
+    yield path
+    os.unlink(path)
+
+
+class _RecordingConn:
+    """sqlite3.Connection proxy that records the parameter count of each execute."""
+
+    def __init__(self, conn):
+        self._conn = conn
+        self.param_counts = []
+
+    def execute(self, sql, params=()):
+        self.param_counts.append(len(params))
+        return self._conn.execute(sql, params)
+
+    def __getattr__(self, name):
+        return getattr(self._conn, name)
+
+
+def _make_handler(db_path, recording=False):
+    """Build a minimal mock CrackPackHandler that captures _send_json output."""
+    from mtg_collector.cli.crack_pack_server import CrackPackHandler
+
+    handler = object.__new__(CrackPackHandler)
+    handler.db_path = db_path
+    handler.generator = object()  # truthy, never called by this path
+    handler._responses = []
+    handler._conns = []
+
+    def fake_send_json(obj, status=200):
+        handler._responses.append((status, obj))
+
+    handler._send_json = fake_send_json
+
+    if recording:
+        real_get_conn = handler._get_conn
+
+        def recording_get_conn():
+            wrapped = _RecordingConn(real_get_conn())
+            handler._conns.append(wrapped)
+            return wrapped
+
+        handler._get_conn = recording_get_conn
+
+    return handler
+
+
+def _collection(db_path, **params):
+    handler = _make_handler(db_path)
+    handler._api_collection({k: [v] for k, v in params.items()})
+    status, body = handler._responses[-1]
+    assert status == 200, body
+    return {c["name"]: c for c in body}
+
+
+# ── Enrichment values ──
+
+
+def test_buylist_price_wins_over_retail(enriched_db):
+    """CK buylist is preferred; TCG price follows the copy's finish."""
+    cards = _collection(enriched_db)
+    assert cards["Alpha"]["ck_price"] == "3.0"
+    assert cards["Alpha"]["tcg_price"] == "5.99"
+
+
+def test_foil_copy_falls_back_to_retail_and_uses_foil_prices(enriched_db):
+    """No buylist_foil row, so the CK retail foil price is used — never normal."""
+    cards = _collection(enriched_db)
+    assert cards["Bravo"]["ck_price"] == "9.0"
+    assert cards["Bravo"]["tcg_price"] == "12.5"
+
+
+def test_etched_prices_as_foil(enriched_db):
+    """Etched copies price as foil, not normal."""
+    cards = _collection(enriched_db)
+    assert cards["Charlie"]["ck_price"] == "15.0"
+    assert cards["Charlie"]["tcg_price"] == "20.0"
+
+
+def test_missing_prices_are_none(enriched_db):
+    cards = _collection(enriched_db)
+    assert cards["Delta"]["ck_price"] is None
+    assert cards["Delta"]["tcg_price"] is None
+
+
+def test_ck_url_follows_finish(enriched_db):
+    """Nonfoil gets ck_url, foil gets ck_url_foil."""
+    cards = _collection(enriched_db)
+    assert cards["Alpha"]["ck_url"] == "https://ck/alpha"
+    assert cards["Bravo"]["ck_url"] == "https://ck/bravo-front-foil"
+
+
+def test_ck_url_foil_falls_back_to_nonfoil(enriched_db):
+    """An etched copy with an empty ck_url_foil uses the nonfoil URL."""
+    cards = _collection(enriched_db)
+    assert cards["Charlie"]["ck_url"] == "https://ck/charlie"
+
+
+def test_ck_url_missing_is_empty_string(enriched_db):
+    cards = _collection(enriched_db)
+    assert cards["Delta"]["ck_url"] == ""
+
+
+def test_duplicate_mtgjson_printing_id_agrees_with_get_ck_url(enriched_db):
+    """printing_id is not unique in mtgjson_printings — MTGJSON emits a row per
+    face of a double-faced card, each with its own Card Kingdom link.
+
+    The list must resolve the same row the card detail page does, or the two
+    pages link the same card to different products.
+    """
+    from mtg_collector.services.pack_generator import PackGenerator
+
+    cards = _collection(enriched_db)
+    gen = PackGenerator(enriched_db)
+    assert cards["Bravo"]["ck_url"] == gen.get_ck_url("print-2", foil=True)
+    assert cards["Bravo"]["ck_url"] == "https://ck/bravo-front-foil"
+
+
+def test_enrichment_survives_the_shared_reference_db(enriched_db, tmp_path):
+    """Deployed instances read cards/prices/mtgjson through ATTACHed shadow views.
+
+    Those views have no rowid, so an enrichment join that leans on one resolves
+    to NULL and silently drops every price and URL.
+    """
+    from mtg_collector.db.schema import SHARED_TABLES
+
+    shared = str(tmp_path / "shared.sqlite")
+    user = str(tmp_path / "user.sqlite")
+    __import__("shutil").copy(enriched_db, shared)
+    conn = sqlite3.connect(shared)
+    conn.execute("DELETE FROM collection")
+    conn.commit()
+    conn.close()
+
+    conn = sqlite3.connect(user)
+    init_db(conn)
+    conn.close()
+    conn = sqlite3.connect(user)
+    conn.execute("ATTACH DATABASE ? AS full", (enriched_db,))
+    conn.execute("INSERT INTO collection SELECT * FROM full.collection")
+    for table in SHARED_TABLES:
+        conn.execute(f"DELETE FROM {table}")
+    conn.commit()
+    conn.close()
+
+    from mtg_collector.cli import crack_pack_server
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(crack_pack_server, "_shared_db_path", shared)
+        cards = _collection(user)
+
+    assert cards["Alpha"]["ck_price"] == "3.0"
+    assert cards["Alpha"]["tcg_price"] == "5.99"
+    assert cards["Alpha"]["ck_url"] == "https://ck/alpha"
+    assert cards["Bravo"]["ck_url"] == "https://ck/bravo-front-foil"
+
+
+def test_enrichment_applies_to_unowned_template(enriched_db):
+    """The is:unowned LEFT JOIN template enriches too, pricing a NULL finish as normal."""
+    cards = _collection(enriched_db, q="is:unowned")
+    assert cards["Echo"]["tcg_price"] == "7.25"
+    assert cards["Echo"]["ck_url"] == "https://ck/echo"
+
+
+def test_enrichment_applies_to_expand_copies_template(enriched_db):
+    """The one-row-per-copy template enriches too, without duplicating rows."""
+    handler = _make_handler(enriched_db)
+    handler._api_collection({"expand": ["copies"]})
+    _, body = handler._responses[-1]
+    assert len(body) == 4, [c["name"] for c in body]
+    cards = {c["name"]: c for c in body}
+    assert cards["Bravo"]["ck_price"] == "9.0"
+    assert cards["Bravo"]["ck_url"] == "https://ck/bravo-front-foil"
+
+
+def test_enrichment_joins_do_not_multiply_rows(enriched_db):
+    """One row per owned card, despite four enrichment joins."""
+    handler = _make_handler(enriched_db)
+    handler._api_collection({})
+    _, body = handler._responses[-1]
+    assert len(body) == 4, [c["name"] for c in body]
+
+
+# ── The assertion that keeps it fixed ──
+
+
+def _max_params(db_path, **params):
+    handler = _make_handler(db_path, recording=True)
+    handler._api_collection({k: [v] for k, v in params.items()})
+    status, body = handler._responses[-1]
+    assert status == 200, body
+    return max(c for conn in handler._conns for c in conn.param_counts), len(body)
+
+
+def test_no_statement_binds_params_proportional_to_the_result_set(enriched_db):
+    """Growing the result set must not grow any statement's parameter count.
+
+    The enrichment used to build `IN (...)` clauses from the result set: at
+    112,809 rows that was 225,618 bound parameters against a
+    SQLITE_MAX_VARIABLE_NUMBER of 250,000.  A future "bulk lookup" that
+    reintroduces the shape fails here.
+    """
+    small_max, small_rows = _max_params(enriched_db)
+
+    conn = sqlite3.connect(enriched_db)
+    for n in range(100, 160):
+        _add_card(conn, n, f"Extra {n:03d}")
+        _own(conn, n, "nonfoil")
+    conn.commit()
+    conn.close()
+
+    large_max, large_rows = _max_params(enriched_db)
+
+    assert large_rows > small_rows * 10
+    assert large_max == small_max

--- a/tests/test_collection_ordering.py
+++ b/tests/test_collection_ordering.py
@@ -143,17 +143,21 @@ def _call_collection(db_path, params):
     handler._send_json = lambda obj, status=200: sent.append((obj, status))
 
     handler._api_collection(params)
-    rows, status = sent[0]
-    assert status == 200, rows
+    page, status = sent[0]
+    assert status == 200, page
     ordered = [(sql, p) for sql, p in calls if "ORDER BY" in sql]
     assert len(ordered) == 1, f"expected one ordered query, got {len(ordered)}"
-    return rows, ordered[0][0], ordered[0][1]
+    # Page envelope: {rows, total, limit, offset}. The fixture is 20 rows, so
+    # the default page holds all of them unless the caller asked for fewer.
+    return page["rows"], ordered[0][0], ordered[0][1]
 
 
 def _order_terms(sql):
     """The ORDER BY expressions of the emitted query, stripped of direction."""
     terms = []
-    for term in sql.rsplit("ORDER BY", 1)[1].split(","):
+    # The query is paged, so the ORDER BY runs to the LIMIT clause, not the end.
+    tail = sql.rsplit("ORDER BY", 1)[1].rsplit("LIMIT", 1)[0]
+    for term in tail.split(","):
         term = " ".join(term.split())
         for suffix in (" ASC", " DESC"):
             if term.endswith(suffix):
@@ -268,20 +272,15 @@ def test_paging_returns_every_row_exactly_once(db_path, template):
     ties consistently while the plan is unchanged — but it is the failure the
     total order exists to prevent, so it stays as a regression guard.
     """
-    rows, sql, sql_params = _call_collection(db_path, _params(template, "cmc"))
-    conn = sqlite3.connect(db_path)
-    conn.row_factory = sqlite3.Row
-    try:
-        unpaged = [r["printing_id"] for r in conn.execute(sql, sql_params)]
-        page = 7
-        paged = []
-        for offset in range(0, len(unpaged), page):
-            paged += [
-                r["printing_id"]
-                for r in conn.execute(f"{sql} LIMIT {page} OFFSET {offset}", sql_params)
-            ]
-    finally:
-        conn.close()
+    rows, _sql, _p = _call_collection(db_path, _params(template, "cmc"))
+    unpaged = [r["printing_id"] for r in rows]
+
+    page = 7
+    paged = []
+    for offset in range(0, _TOTAL, page):
+        window = _params(template, "cmc") | {"limit": [str(page)], "offset": [str(offset)]}
+        paged += [r["printing_id"] for r in _call_collection(db_path, window)[0]]
+
     assert len(rows) == _TOTAL
     assert paged == unpaged
     assert len(paged) == _TOTAL

--- a/tests/test_collection_ordering.py
+++ b/tests/test_collection_ordering.py
@@ -199,6 +199,13 @@ def _key_value(term, row, conn):
         return row["acquired_at"]
     if term == "_lp.price":
         return row["tcg_price"]
+    # The sortable price columns resolve to the enrichment expressions rather
+    # than _lp, which pins price_type but not source and so can match a card
+    # once per source. Each of these is exactly the value the payload carries.
+    if term == "_tcg.price":
+        return row["tcg_price"]
+    if term == "COALESCE(_ck_buy.price, _ck_retail.price)":
+        return row["ck_price"]
     if term == "p.printing_id":
         return row["printing_id"]
     if term in ("c.finish", "c.condition", "c.status"):

--- a/tests/test_collection_ordering.py
+++ b/tests/test_collection_ordering.py
@@ -1,0 +1,294 @@
+"""`/api/collection` must sort by a total order (de-3qg).
+
+Every sort column the collection page offers is non-unique, and so is the
+`card.name` tiebreak — a card with five printings gives five rows with the
+same name. Rows that tie on the whole ORDER BY key come back in whatever
+order the query plan happens to produce, which is why paging such a result
+drops and duplicates rows.
+
+The load-bearing test is `test_order_key_is_total`: it reads the ORDER BY the
+server actually emitted and asserts the key values are distinct across the
+response. `test_fixture_ties_on_the_old_key` proves that assertion has teeth —
+before each template's row identity was appended to its ORDER BY, every
+parametrisation of `test_order_key_is_total` failed on this fixture.
+"""
+
+import sqlite3
+from collections import Counter
+
+import pytest
+
+from mtg_collector.cli.crack_pack_server import CrackPackHandler
+from mtg_collector.db.schema import init_db
+
+# Sort options offered by the collection page (keys of the handler's sort_map).
+SORTS = [
+    "name", "cmc", "rarity", "set", "color", "qty",
+    "collector_number", "date_added", "added", "price",
+]
+
+TEMPLATES = ["default", "expand_copies", "card_pairs"]
+
+_NAMES = ["Aa Card", "Bb Card", "Cc Card", "Dd Card"]
+_SETS = ["aaa", "bbb", "ccc"]
+_PRINTINGS_PER_CARD = 5
+_ACQUIRED = "2026-01-02T03:04:05.000Z"
+_ALPHABET = "abcdefghijklmnopqrstuvwxyz"
+
+
+def _fixture_printings():
+    """(index, name, set_code, collector_number, printing_id) for every printing.
+
+    Each card is printed five times across three sets, so cards repeat within
+    a set — that makes `p.set_code` ambiguous even combined with `card.name`.
+    Collector numbers are '42', '42a', '42b', … : unique per set, but all
+    equal under the `CAST(collector_number AS INTEGER)` the sort uses.
+    """
+    rows = []
+    for i, name in enumerate(_NAMES):
+        for k in range(_PRINTINGS_PER_CARD):
+            idx = i * _PRINTINGS_PER_CARD + k
+            set_code = _SETS[k % len(_SETS)]
+            collector_number = "42" + _ALPHABET[idx]
+            rows.append((i, name, set_code, collector_number, f"printing-{idx}"))
+    return rows
+
+
+@pytest.fixture(scope="module")
+def db_path(tmp_path_factory):
+    """A collection where every sort column is one big tie."""
+    path = str(tmp_path_factory.mktemp("ordering") / "collection.sqlite")
+    conn = sqlite3.connect(path)
+    init_db(conn)
+    for set_code in _SETS:
+        conn.execute(
+            "INSERT INTO sets (set_code, set_name, released_at, cards_fetched_at)"
+            " VALUES (?, ?, '2020-01-01', '2020-01-01T00:00:00Z')",
+            (set_code, f"Set {set_code.upper()}"),
+        )
+    conn.execute(
+        "INSERT INTO decks (id, name, format, created_at, updated_at)"
+        " VALUES (1, 'Test Deck', 'commander', ?, ?)",
+        (_ACQUIRED, _ACQUIRED),
+    )
+    for i, name in enumerate(_NAMES):
+        conn.execute(
+            "INSERT INTO cards (oracle_id, name, type_line, mana_cost, cmc, colors, color_identity)"
+            ' VALUES (?, ?, \'Creature — Elf\', \'{G}\', 1.0, \'["G"]\', \'["G"]\')',
+            (f"oracle-{i}", name),
+        )
+    for i, _name, set_code, collector_number, printing_id in _fixture_printings():
+        conn.execute(
+            "INSERT INTO printings (printing_id, oracle_id, set_code, collector_number,"
+            ' rarity, finishes, layout) VALUES (?, ?, ?, ?, \'rare\', \'["nonfoil"]\', \'normal\')',
+            (printing_id, f"oracle-{i}", set_code, collector_number),
+        )
+        # Same price for every printing, so sort=price ties too.
+        conn.execute(
+            "INSERT INTO latest_prices (set_code, collector_number, source, price_type,"
+            " price, observed_at) VALUES (?, ?, 'tcgplayer', 'normal', 1.5, '2026-01-01')",
+            (set_code, collector_number),
+        )
+        cursor = conn.execute(
+            "INSERT INTO collection (printing_id, finish, condition, acquired_at, source, status)"
+            " VALUES (?, 'nonfoil', 'Near Mint', ?, 'manual', 'owned')",
+            (printing_id, _ACQUIRED),
+        )
+        # Half the copies sit in a deck, so expand=copies exercises its
+        # deck_cards join with both matched and unmatched rows.
+        if i % 2 == 0:
+            conn.execute(
+                "INSERT INTO deck_cards (deck_id, printing_id, collection_id, zone, quantity)"
+                " VALUES (1, ?, ?, 'mainboard', 1)",
+                (printing_id, cursor.lastrowid),
+            )
+    conn.commit()
+    conn.close()
+    return path
+
+
+def _params(template, sort):
+    params = {"sort": [sort]}
+    if template == "expand_copies":
+        params["expand"] = ["copies"]
+    elif template == "card_pairs":
+        pairs = ",".join(f"{sc}:{cn}" for _i, _n, sc, cn, _p in _fixture_printings())
+        params["cards"] = [pairs]
+    return params
+
+
+class _RecordingConnection(sqlite3.Connection):
+    """Records every (sql, params) so the test can replay the main query."""
+
+    def execute(self, sql, params=()):
+        self.calls.append((sql, params))
+        return super().execute(sql, params)
+
+
+def _call_collection(db_path, params):
+    """Invoke the real handler method; return (rows, sql, sql_params)."""
+    calls: list = []
+
+    def _get_conn():
+        conn = sqlite3.connect(db_path, factory=_RecordingConnection)
+        conn.calls = calls
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    sent: list = []
+    handler = object.__new__(CrackPackHandler)
+    handler.generator = None
+    handler.db_path = db_path
+    handler._get_conn = _get_conn
+    handler._send_json = lambda obj, status=200: sent.append((obj, status))
+
+    handler._api_collection(params)
+    rows, status = sent[0]
+    assert status == 200, rows
+    ordered = [(sql, p) for sql, p in calls if "ORDER BY" in sql]
+    assert len(ordered) == 1, f"expected one ordered query, got {len(ordered)}"
+    return rows, ordered[0][0], ordered[0][1]
+
+
+def _order_terms(sql):
+    """The ORDER BY expressions of the emitted query, stripped of direction."""
+    terms = []
+    for term in sql.rsplit("ORDER BY", 1)[1].split(","):
+        term = " ".join(term.split())
+        for suffix in (" ASC", " DESC"):
+            if term.endswith(suffix):
+                term = term[: -len(suffix)]
+        terms.append(term)
+    return terms
+
+
+_RARITY_ORDER = {"common": 0, "uncommon": 1, "rare": 2, "mythic": 3}
+
+
+def _cast_int(collector_number):
+    """SQLite's CAST(text AS INTEGER): the leading integer prefix, else 0."""
+    digits = ""
+    for ch in collector_number:
+        if not ch.isdigit():
+            break
+        digits += ch
+    return int(digits) if digits else 0
+
+
+def _key_value(term, row, conn):
+    """The value one ORDER BY term produced for one response row."""
+    if term == "card.name":
+        return row.get("oracle_name") or row["name"]
+    if term == "card.cmc":
+        return row["cmc"]
+    if term.startswith("CASE p.rarity"):
+        return _RARITY_ORDER.get(row["rarity"], 4)
+    if term == "p.set_code":
+        return row["set_code"]
+    if term == "card.color_identity":
+        return row["color_identity"]
+    if term == "qty":
+        return row["qty"]
+    if term == "CAST(p.collector_number AS INTEGER)":
+        return _cast_int(row["collector_number"])
+    if term == "c.acquired_at":
+        return row["acquired_at"]
+    if term == "_lp.price":
+        return row["tcg_price"]
+    if term == "p.printing_id":
+        return row["printing_id"]
+    if term in ("c.finish", "c.condition", "c.status"):
+        return row[term.split(".")[1]]
+    if term == "c.order_id":
+        return row.get("order_id")
+    if term == "c.id":
+        return row.get("collection_id")
+    if term == "dc.id":
+        # Not in the payload; the fixture gives a copy at most one deck_cards row.
+        ids = [
+            r[0]
+            for r in conn.execute(
+                "SELECT id FROM deck_cards WHERE collection_id = ?",
+                (row.get("collection_id"),),
+            )
+        ]
+        assert len(ids) <= 1, "fixture gives each copy at most one deck_cards row"
+        return ids[0] if ids else None
+    raise AssertionError(f"ORDER BY term not observable in the response: {term!r}")
+
+
+def _keys(rows, terms, db_path):
+    conn = sqlite3.connect(db_path)
+    try:
+        return [tuple(_key_value(t, row, conn) for t in terms) for row in rows]
+    finally:
+        conn.close()
+
+
+_TOTAL = len(_NAMES) * _PRINTINGS_PER_CARD
+
+
+@pytest.mark.parametrize("template", TEMPLATES)
+@pytest.mark.parametrize("sort", SORTS)
+def test_order_key_is_total(db_path, template, sort):
+    """No two rows may share an ORDER BY key — otherwise paging is unsafe."""
+    rows, sql, _ = _call_collection(db_path, _params(template, sort))
+    assert len(rows) == _TOTAL
+    keys = _keys(rows, _order_terms(sql), db_path)
+    tied = [k for k, n in Counter(keys).items() if n > 1]
+    assert not tied, (
+        f"{len(keys) - len(set(keys))} rows tie on the full ORDER BY key for "
+        f"sort={sort} ({template}); the order is not total: {tied[:3]}"
+    )
+
+
+@pytest.mark.parametrize("template", TEMPLATES)
+@pytest.mark.parametrize("sort", SORTS)
+def test_fixture_ties_on_the_old_key(db_path, template, sort):
+    """The sort column plus `card.name` really is ambiguous on this fixture.
+
+    Without this, `test_order_key_is_total` could pass on a fixture that has
+    no ties at all and prove nothing.
+    """
+    rows, sql, _ = _call_collection(db_path, _params(template, sort))
+    old_key = _order_terms(sql)[:2]
+    assert old_key[1] == "card.name", old_key
+    keys = _keys(rows, old_key, db_path)
+    assert len(set(keys)) < len(keys), (
+        f"fixture has no ties for sort={sort} ({template}) — "
+        "the totality test would be vacuous"
+    )
+
+
+@pytest.mark.parametrize("template", TEMPLATES)
+def test_paging_returns_every_row_exactly_once(db_path, template):
+    """Slicing the emitted query into pages must cover the result exactly once.
+
+    A weaker check than `test_order_key_is_total` — SQLite happens to resolve
+    ties consistently while the plan is unchanged — but it is the failure the
+    total order exists to prevent, so it stays as a regression guard.
+    """
+    rows, sql, sql_params = _call_collection(db_path, _params(template, "cmc"))
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        unpaged = [r["printing_id"] for r in conn.execute(sql, sql_params)]
+        page = 7
+        paged = []
+        for offset in range(0, len(unpaged), page):
+            paged += [
+                r["printing_id"]
+                for r in conn.execute(f"{sql} LIMIT {page} OFFSET {offset}", sql_params)
+            ]
+    finally:
+        conn.close()
+    assert len(rows) == _TOTAL
+    assert paged == unpaged
+    assert len(paged) == _TOTAL
+
+
+def test_repeated_query_returns_identical_order(db_path):
+    """Two runs of the same query must agree on the order of tied rows."""
+    first, _sql, _p = _call_collection(db_path, _params("default", "rarity"))
+    second, _sql2, _p2 = _call_collection(db_path, _params("default", "rarity"))
+    assert [r["printing_id"] for r in first] == [r["printing_id"] for r in second]

--- a/tests/test_collection_page_params.py
+++ b/tests/test_collection_page_params.py
@@ -1,0 +1,65 @@
+"""
+Unit tests for /api/collection's limit/offset parsing.
+
+The HTTP contract is covered by tests/integration/test_collection_paging.py;
+these run in the fast tier with no container, and pin the part that decides
+between a page and a 400.
+"""
+
+import pytest
+
+from mtg_collector.cli.crack_pack_server import (
+    COLLECTION_LIMIT_DEFAULT,
+    COLLECTION_LIMIT_MAX,
+    PageParamError,
+    _parse_page_params,
+)
+
+
+def _params(**kw):
+    """Query params in the shape parse_qs hands the handler."""
+    return {k: [str(v)] for k, v in kw.items()}
+
+
+class TestDefaults:
+    def test_absent_params_are_bounded(self):
+        assert _parse_page_params({}) == (COLLECTION_LIMIT_DEFAULT, 0)
+
+    def test_blank_params_fall_back_to_defaults(self):
+        assert _parse_page_params(_params(limit="", offset="")) == (COLLECTION_LIMIT_DEFAULT, 0)
+
+
+class TestAccepted:
+    @pytest.mark.parametrize("limit", [1, 250, COLLECTION_LIMIT_MAX])
+    def test_limit_in_range(self, limit):
+        assert _parse_page_params(_params(limit=limit)) == (limit, 0)
+
+    def test_offset(self):
+        assert _parse_page_params(_params(limit=10, offset=990)) == (10, 990)
+
+    def test_offset_may_run_past_the_end(self):
+        """A too-large offset is an empty page, not an error — the caller
+        cannot know the total before asking."""
+        assert _parse_page_params(_params(offset=10**9)) == (COLLECTION_LIMIT_DEFAULT, 10**9)
+
+
+class TestRejected:
+    """Out-of-range is a 400, never a silent clamp — a clamped limit would let
+    a caller believe it had walked the whole result."""
+
+    @pytest.mark.parametrize(
+        "kw",
+        [
+            {"limit": COLLECTION_LIMIT_MAX + 1},
+            {"limit": 0},
+            {"limit": -1},
+            {"limit": "abc"},
+            {"limit": "1.5"},
+            {"limit": "250; DROP TABLE collection"},
+            {"offset": -1},
+            {"offset": "abc"},
+        ],
+    )
+    def test_raises(self, kw):
+        with pytest.raises(PageParamError):
+            _parse_page_params(_params(**kw))

--- a/tests/test_collection_totals.py
+++ b/tests/test_collection_totals.py
@@ -1,0 +1,301 @@
+"""
+Whole-result figures and price sorting on /api/collection.
+
+The client fetches windows as it scrolls, so the rows it holds are a growing
+prefix of the result rather than the result.  Two things have to come from the
+server for that to work:
+
+  * `total_qty` / `total_value`, because a status line summed from the rows in
+    memory would climb as the user scrolled.
+  * an ordering for every sortable column, because sorting in the browser would
+    order the loaded rows against each other and leave the rest of the result in
+    the previous query's order.
+
+To run: uv run pytest tests/test_collection_totals.py -v
+"""
+
+import os
+import sqlite3
+import tempfile
+
+import pytest
+
+from mtg_collector.db.schema import init_db, refresh_latest_prices
+
+NOW = "2025-01-01T00:00:00.000Z"
+
+
+def _add_card(conn, n, name):
+    conn.execute(
+        "INSERT INTO cards (oracle_id, name, mana_cost, type_line, colors, color_identity) "
+        "VALUES (?, ?, '{R}', 'Creature', '[\"R\"]', '[\"R\"]')",
+        (f"oracle-{n}", name),
+    )
+    conn.execute(
+        "INSERT INTO printings (printing_id, oracle_id, set_code, collector_number, rarity, finishes) "
+        "VALUES (?, ?, 'tst', ?, 'R', '[\"nonfoil\", \"foil\"]')",
+        (f"print-{n}", f"oracle-{n}", str(n)),
+    )
+
+
+def _own(conn, n, finish, copies):
+    for _ in range(copies):
+        conn.execute(
+            "INSERT INTO collection (printing_id, finish, acquired_at, source, status) "
+            "VALUES (?, ?, ?, 'manual', 'owned')",
+            (f"print-{n}", finish, NOW),
+        )
+
+
+def _price(conn, cn, source, price_type, price):
+    conn.execute(
+        "INSERT INTO prices (set_code, collector_number, source, price_type, price, observed_at) "
+        "VALUES ('tst', ?, ?, ?, ?, '2025-01-01')",
+        (str(cn), source, price_type, price),
+    )
+
+
+# Four groups, 7 copies.  Quantities differ from row counts on purpose: a
+# total_qty that merely counted rows would read 4 and pass a weaker test.
+#
+# The two price sources rank the cards differently (Alpha is the cheapest by
+# TCG and the dearest by CK), so a test that sorts or sums by one cannot pass
+# while silently using the other.
+#
+#   printing  copies  finish   tcg    ck buylist   tcg value   ck value
+#   1         3       nonfoil  2.00   6.00          6.00       18.00
+#   2         1       nonfoil  10.00  4.00         10.00        4.00
+#   3         2       foil      5.00  3.00         10.00        6.00
+#   4         1       nonfoil   —      —             0.00        0.00
+TOTAL_ROWS = 4
+TOTAL_QTY = 7
+TOTAL_VALUE_TCG = 26.00
+TOTAL_VALUE_CK = 28.00
+# Ascending. NULL sorts first in SQLite, so the unpriced card leads both.
+ORDER_BY_TCG = ["Delta", "Alpha", "Charlie", "Bravo"]
+ORDER_BY_CK = ["Delta", "Charlie", "Bravo", "Alpha"]
+
+
+@pytest.fixture
+def priced_db():
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        path = f.name
+
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    conn.execute("INSERT INTO sets (set_code, set_name) VALUES ('tst', 'Test Set')")
+
+    _add_card(conn, 1, "Alpha")
+    _own(conn, 1, "nonfoil", 3)
+    _price(conn, 1, "tcgplayer", "normal", 2.0)
+    _price(conn, 1, "cardkingdom", "buylist_normal", 6.0)
+
+    _add_card(conn, 2, "Bravo")
+    _own(conn, 2, "nonfoil", 1)
+    _price(conn, 2, "tcgplayer", "normal", 10.0)
+    _price(conn, 2, "cardkingdom", "buylist_normal", 4.0)
+
+    _add_card(conn, 3, "Charlie")
+    _own(conn, 3, "foil", 2)
+    _price(conn, 3, "tcgplayer", "foil", 5.0)
+    _price(conn, 3, "cardkingdom", "buylist_foil", 3.0)
+    _price(conn, 3, "tcgplayer", "normal", 999.0)  # wrong finish, must not count
+
+    _add_card(conn, 4, "Delta")
+    _own(conn, 4, "nonfoil", 1)
+
+    refresh_latest_prices(conn)
+    conn.commit()
+    conn.close()
+    yield path
+    os.unlink(path)
+
+
+def _set_price_source(db_path, value):
+    conn = sqlite3.connect(db_path)
+    conn.execute("UPDATE settings SET value = ? WHERE key = 'price_sources'", (value,))
+    conn.commit()
+    conn.close()
+
+
+def _page(db_path, **params):
+    """Call /api/collection and return the whole envelope."""
+    from mtg_collector.cli.crack_pack_server import CrackPackHandler
+
+    handler = object.__new__(CrackPackHandler)
+    handler.db_path = db_path
+    handler.generator = object()  # truthy, never called by this path
+    responses = []
+    handler._send_json = lambda obj, status=200: responses.append((status, obj))
+    handler._api_collection({k: [str(v)] for k, v in params.items()})
+    status, body = responses[-1]
+    assert status == 200, body
+    return body
+
+
+class TestWholeResultTotals:
+    """The figures describe the result, not the page."""
+
+    def test_full_result_in_one_page(self, priced_db):
+        body = _page(priced_db)
+        assert body["total"] == TOTAL_ROWS
+        assert body["total_qty"] == TOTAL_QTY
+        assert body["total_value"] == TOTAL_VALUE_TCG
+
+    @pytest.mark.parametrize("limit", [1, 2, 3])
+    def test_a_page_does_not_shrink_the_totals(self, priced_db, limit):
+        """The reason this exists: a status line summed from the page would
+        report a fraction of the collection and grow as the user scrolled."""
+        body = _page(priced_db, limit=limit)
+        assert len(body["rows"]) == limit
+        assert body["total"] == TOTAL_ROWS
+        assert body["total_qty"] == TOTAL_QTY
+        assert body["total_value"] == TOTAL_VALUE_TCG
+
+    def test_totals_hold_while_walking_the_result(self, priced_db):
+        """Every window reports the same totals, so the line does not move as
+        pages arrive."""
+        seen = []
+        for offset in range(0, TOTAL_ROWS + 1):
+            body = _page(priced_db, limit=1, offset=offset)
+            seen.append((body["total"], body["total_qty"], body["total_value"]))
+        assert set(seen) == {(TOTAL_ROWS, TOTAL_QTY, TOTAL_VALUE_TCG)}
+
+    def test_short_page_and_counted_page_agree(self, priced_db):
+        """A page that holds the whole result is summed from the rows in hand;
+        a bounded one is summed in SQL.  The two paths must not disagree."""
+        whole = _page(priced_db, limit=TOTAL_ROWS + 1)
+        bounded = _page(priced_db, limit=1)
+        assert (whole["total_qty"], whole["total_value"]) == (
+            bounded["total_qty"],
+            bounded["total_value"],
+        )
+
+    def test_value_follows_the_configured_price_source(self, priced_db):
+        """The status line sits beside the price column, so it prices the
+        collection the same way."""
+        _set_price_source(priced_db, "ck,tcg")
+        for limit in (1, TOTAL_ROWS + 1):  # both the SQL and the in-hand path
+            assert _page(priced_db, limit=limit)["total_value"] == TOTAL_VALUE_CK
+
+    def test_query_narrows_the_totals(self, priced_db):
+        body = _page(priced_db, q="Alpha")
+        assert (body["total"], body["total_qty"], body["total_value"]) == (1, 3, 6.0)
+
+    def test_empty_result(self, priced_db):
+        body = _page(priced_db, q="Nonexistent")
+        assert (body["total"], body["total_qty"], body["total_value"]) == (0, 0, 0)
+
+
+class TestPriceSorting:
+    """tcg_price and ck_price are offered as sortable columns by the collection
+    table.  Before windowing they were sorted in the browser; over pages that
+    would only order the rows already loaded."""
+
+    def _walk(self, db_path, sort, order="asc", limit=1):
+        names = []
+        offset = 0
+        while True:
+            body = _page(db_path, sort=sort, order=order, limit=limit, offset=offset)
+            if not body["rows"]:
+                return names
+            names.extend(r["name"] for r in body["rows"])
+            offset += len(body["rows"])
+
+    def test_sort_by_tcg_price(self, priced_db):
+        assert self._walk(priced_db, "tcg_price") == ORDER_BY_TCG
+
+    def test_sort_by_tcg_price_desc(self, priced_db):
+        assert self._walk(priced_db, "tcg_price", order="desc") == ORDER_BY_TCG[::-1]
+
+    def test_sort_by_ck_price(self, priced_db):
+        """The two sources rank the cards differently, so this cannot pass by
+        sorting on the other price — or by falling back to the default sort."""
+        assert self._walk(priced_db, "ck_price") == ORDER_BY_CK
+        assert ORDER_BY_CK != ORDER_BY_TCG
+
+    def test_price_sorted_walk_has_no_gaps_or_repeats(self, priced_db):
+        """Paging a non-total order silently drops and duplicates rows, so the
+        tiebreak has to hold under a sort whose column repeats."""
+        walked = self._walk(priced_db, "tcg_price", limit=1)
+        assert sorted(walked) == ["Alpha", "Bravo", "Charlie", "Delta"]
+
+    def test_page_size_does_not_change_the_order(self, priced_db):
+        """The window the client happens to ask for cannot change what is in
+        it — that is what makes scrolling equivalent to one long list."""
+        for limit in (2, 3, 4):
+            assert self._walk(priced_db, "tcg_price", limit=limit) == self._walk(
+                priced_db, "tcg_price", limit=1
+            )
+
+
+class TestPriceSortDoesNotDuplicateRows:
+    """`sort=price` must not multiply rows.
+
+    latest_prices is keyed (set_code, collector_number, source, price_type), so
+    a card with both a TCG and a Card Kingdom price at the same price_type has
+    two rows there.  A sort join that pins only price_type matches both.  The
+    GROUP BY templates collapse the duplicate — while leaving which source you
+    sorted by undecided — but expand=copies has no GROUP BY, and paging a
+    result whose rows are duplicated drops and repeats cards.
+
+    Nothing sent `sort` until the client began fetching windows, so this was
+    unreachable rather than absent.
+    """
+
+    @pytest.fixture
+    def two_source_db(self, priced_db):
+        """Give every card a Card Kingdom *retail* price alongside its TCG one,
+        at the same price_type — the shape that makes a source-blind join
+        match twice."""
+        conn = sqlite3.connect(priced_db)
+        for cn, price in ((1, 1.5), (2, 2.5), (3, 3.5)):
+            _price(conn, cn, "cardkingdom", "normal", price)
+            _price(conn, cn, "cardkingdom", "foil", price)
+        refresh_latest_prices(conn)
+        conn.commit()
+        conn.close()
+        return priced_db
+
+    def test_fixture_really_has_two_sources(self, two_source_db):
+        """Guard the guard: if this stops holding, the tests below pass for the
+        wrong reason."""
+        conn = sqlite3.connect(two_source_db)
+        worst = conn.execute(
+            "SELECT MAX(n) FROM (SELECT COUNT(DISTINCT source) n FROM latest_prices "
+            "GROUP BY set_code, collector_number, price_type)"
+        ).fetchone()[0]
+        conn.close()
+        assert worst > 1, "fixture no longer has one price_type served by two sources"
+
+    @pytest.mark.parametrize("sort", ["price", "tcg_price", "ck_price"])
+    def test_expand_copies_page_is_not_multiplied(self, two_source_db, sort):
+        body = _page(two_source_db, expand="copies", sort=sort)
+        ids = [r["collection_id"] for r in body["rows"]]
+        assert len(ids) == len(set(ids)), f"sort={sort} duplicated rows: {ids}"
+        assert len(ids) == TOTAL_QTY == body["total"]
+
+    @pytest.mark.parametrize("sort", ["price", "tcg_price", "ck_price"])
+    def test_offset_walk_covers_each_copy_once(self, two_source_db, sort):
+        """The property paging actually depends on."""
+        seen = []
+        offset = 0
+        while True:
+            body = _page(two_source_db, expand="copies", sort=sort, limit=2, offset=offset)
+            if not body["rows"]:
+                break
+            seen.extend(r["collection_id"] for r in body["rows"])
+            offset += len(body["rows"])
+            if offset >= body["total"]:
+                break
+        assert sorted(seen) == sorted(set(seen)), f"sort={sort} repeated copies while paging"
+        assert len(seen) == TOTAL_QTY
+
+    def test_price_sort_follows_the_displayed_source(self, two_source_db):
+        """Sorting by the Price column must order by the number that column
+        shows, not by whichever source the join happened to reach first."""
+        _set_price_source(two_source_db, "ck,tcg")
+        by_price = [r["name"] for r in _page(two_source_db, sort="price")["rows"]]
+        by_ck = [r["name"] for r in _page(two_source_db, sort="ck_price")["rows"]]
+        assert by_price == by_ck

--- a/tests/ui/hints/collection_sort_orders_whole_result.yaml
+++ b/tests/ui/hints/collection_sort_orders_whole_result.yaml
@@ -1,0 +1,21 @@
+start_page: /collection?q=is%3Aunowned
+involves:
+  - 'sortable column headers (.collection-table th[data-col]) — name, type, mana, set, collector_number, price'
+  - 'card name cell (.card-name) in each row'
+  - 'status text (#status)'
+fixture_data:
+  unowned_total_rows: 7603
+  first_row_ascending: "A Killer Among Us"
+  first_row_descending: "Zur's Weirding"
+  page_size: 250
+notes: >
+  The page loads sorted by name ascending, so the first row is "A Killer
+  Among Us". One click on th[data-col="name"] toggles to descending and
+  refetches from the server at offset 0.
+  This is the discriminating case: the loaded window is the first 250 rows,
+  every one of them an early-alphabet name. Reversing those in the browser
+  would leave another "A..." name on top. Only an ordering applied across all
+  7,603 rows can put "Zur's Weirding" there, so that string is the assertion.
+  Do not use the price column for this — the fixture has no prices at all for
+  unowned printings (0 of 7,603), so every row ties and asc and desc return
+  the identical order.

--- a/tests/ui/hints/collection_stats_modal_states_loaded_coverage.yaml
+++ b/tests/ui/hints/collection_stats_modal_states_loaded_coverage.yaml
@@ -1,0 +1,20 @@
+start_page: /collection?q=is%3Aunowned
+involves:
+  - 'status text (#status) — clicking it opens the stats modal'
+  - 'stats modal overlay (#stats-modal-overlay.active)'
+  - 'modal subtitle (.stats-subtitle)'
+fixture_data:
+  unowned_total_rows: 7603
+  owned_total_rows: 43
+  page_size: 250
+  coverage_phrase: "of 7,603 matches loaded so far"
+notes: >
+  Card-level statistics are computed in the browser from the rows in memory,
+  which for a windowed result is a prefix rather than the whole thing. The
+  subtitle then reads "Default price source: TCGplayer · over the N of 7,603
+  matches loaded so far". N depends on how many pages have been prefetched,
+  so assert only on the invariant tail "of 7,603 matches loaded so far", never
+  on N.
+  The owned default is 43 rows, which fits in one 250-row page, so everything
+  is loaded and the caveat must be absent — that half is what proves the
+  clause is conditional rather than always printed.

--- a/tests/ui/hints/collection_unowned_scroll_reaches_end.yaml
+++ b/tests/ui/hints/collection_unowned_scroll_reaches_end.yaml
@@ -1,0 +1,19 @@
+start_page: /collection?q=is%3Aunowned
+involves:
+  - 'virtual scroll body (#vtbody) with tr[data-idx] rows'
+  - 'placeholder rows carrying data-pending="1" while their page is in flight'
+  - 'status text (#status)'
+fixture_data:
+  unowned_total_rows: 7603
+  last_row_index: 7602
+  page_size: 250
+notes: >
+  Jump to the bottom with window.scrollTo(0, document.body.scrollHeight). The
+  row range there belongs to a page that has never been fetched, so the rows
+  render first as data-pending placeholders and are replaced when the page
+  arrives — wait on a real row at the final index rather than a fixed sleep.
+  `totalMatches` is a top-level binding in collection.html's script and is
+  readable from page.evaluate. The last row's index is totalMatches-1 (7602);
+  reaching it is what proves paging walks the whole result rather than
+  stopping at the first 250. Keep the DOM bound assertion here too: arriving
+  pages must replace the window, not accumulate into it.

--- a/tests/ui/hints/collection_unowned_windowed_first_page.yaml
+++ b/tests/ui/hints/collection_unowned_windowed_first_page.yaml
@@ -1,0 +1,21 @@
+start_page: /collection?q=is%3Aunowned
+involves:
+  - 'search input (#search-input) with placeholder "Search (e.g. t:creature c:r mv>=3)"'
+  - 'status text (#status) showing the whole-result count'
+  - 'virtual scroll body (#vtbody) holding one window of tr[data-idx] rows'
+  - 'bottom spacer (#vscroll-bottom) reserving height for rows not yet fetched'
+fixture_data:
+  unowned_total_rows: 7603
+  page_size: 250
+  status_text: "7,603 results"
+notes: >
+  /api/collection is bounded at 250 rows per response, so the first paint is
+  one page of a 7,603-row result. The status line reads "7,603 results" from
+  the envelope's `total`, not from the rows in hand. Rows carrying
+  data-pending="1" are placeholders for a page still in flight, so assert on
+  tr[data-idx]:not([data-pending]) to mean "a real rendered row". The number
+  of rows in the DOM is a viewport-sized window (a few dozen at 1280x720),
+  never the 7,603 the result contains — that is the whole point of the
+  scenario, so assert a bound rather than an exact count. #vscroll-bottom's
+  inline height reserves the space of every row not currently rendered, which
+  is what keeps the scrollbar honest about the size of the result.

--- a/tests/ui/implementations/collection_sort_orders_whole_result.py
+++ b/tests/ui/implementations/collection_sort_orders_whole_result.py
@@ -1,0 +1,32 @@
+"""
+Hand-written implementation for collection_sort_orders_whole_result.
+
+Reversing the sort on a windowed result must reorder all 7,603 rows, not the
+250 the browser happens to be holding.
+"""
+
+
+def steps(harness):
+    harness.navigate("/collection?q=is%3Aunowned")
+    harness.wait_for_visible("#vtbody tr[data-idx]:not([data-pending])", timeout=15_000)
+
+    # Ascending by name: the result opens at the top of the alphabet.
+    harness.assert_text_present("A Killer Among Us")
+    harness.screenshot("ascending")
+
+    # Toggle to descending.
+    harness.click_by_selector(".collection-table th[data-col='name']")
+    harness.wait_for_visible("#vtbody tr[data-idx]:not([data-pending])", timeout=15_000)
+
+    # The end of the alphabet is now first. Sorting the loaded window instead
+    # of the result would have left another "A..." name here.
+    harness.wait_for_text("Zur's Weirding", timeout=15_000)
+    first_row = harness.page.eval_on_selector(
+        "#vtbody tr[data-idx] .card-name", "el => el.textContent.trim()"
+    )
+    assert first_row == "Zur's Weirding", f"expected the last card of the result first, got {first_row!r}"
+
+    # Re-sorting kept the same result, so the count is unchanged.
+    harness.assert_text_present("7,603 results")
+
+    harness.screenshot("final_state")

--- a/tests/ui/implementations/collection_stats_modal_states_loaded_coverage.py
+++ b/tests/ui/implementations/collection_stats_modal_states_loaded_coverage.py
@@ -1,0 +1,29 @@
+"""
+Hand-written implementation for collection_stats_modal_states_loaded_coverage.
+
+The stats modal computes from the rows in memory, so when those are only part
+of the result it has to say so — and when they are all of it, it must not.
+"""
+
+
+def steps(harness):
+    # A result far larger than one page: the caveat belongs here.
+    harness.navigate("/collection?q=is%3Aunowned")
+    harness.wait_for_visible("#vtbody tr[data-idx]:not([data-pending])", timeout=15_000)
+    harness.click_by_selector("#status")
+    harness.wait_for_visible("#stats-modal-overlay.active", timeout=10_000)
+
+    # Assert the invariant tail only — the number of rows loaded depends on
+    # how far the prefetch got.
+    harness.assert_text_present("of 7,603 matches loaded so far")
+    harness.screenshot("windowed_result_states_coverage")
+
+    # The owned collection is 43 rows and fits in a single page, so the
+    # figures are the whole result and the caveat must not appear.
+    harness.navigate("/collection")
+    harness.wait_for_visible("#vtbody tr[data-idx]:not([data-pending])", timeout=15_000)
+    harness.click_by_selector("#status")
+    harness.wait_for_visible("#stats-modal-overlay.active", timeout=10_000)
+    harness.assert_text_absent("loaded so far")
+
+    harness.screenshot("final_state")

--- a/tests/ui/implementations/collection_unowned_scroll_reaches_end.py
+++ b/tests/ui/implementations/collection_unowned_scroll_reaches_end.py
@@ -1,0 +1,47 @@
+"""
+Hand-written implementation for collection_unowned_scroll_reaches_end.
+
+Scrolling to the bottom of a 7,603-row result must reach the last row, which
+lives in a page the first response never contained.
+"""
+
+
+def steps(harness):
+    harness.navigate("/collection?q=is%3Aunowned")
+    harness.wait_for_visible("#vtbody tr[data-idx]:not([data-pending])", timeout=15_000)
+    status_before = harness.page.inner_text("#status")
+
+    # Jump past everything the first page held.
+    harness.page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
+
+    # The last row is only reachable if its page was fetched on the way. Wait
+    # for a real row at the final index — placeholders do not count.
+    harness.page.wait_for_function(
+        """() => {
+             const rows = [...document.querySelectorAll('#vtbody tr[data-idx]:not([data-pending])')];
+             return rows.length && Math.max(...rows.map(r => +r.dataset.idx)) === totalMatches - 1;
+           }""",
+        timeout=25_000,
+    )
+
+    # That last row is real content, not an empty shell.
+    last_text = harness.page.evaluate(
+        """() => {
+             const rows = [...document.querySelectorAll('#vtbody tr[data-idx]:not([data-pending])')];
+             const last = rows.sort((a, b) => +a.dataset.idx - +b.dataset.idx).pop();
+             return last ? last.innerText.trim() : '';
+           }"""
+    )
+    assert last_text, "the final row rendered without any content"
+
+    # Pages replaced the window rather than piling up in it.
+    rendered = harness.page.eval_on_selector_all("#vtbody tr[data-idx]", "els => els.length")
+    assert 0 < rendered < 200, f"expected the window to stay bounded, got {rendered} rows"
+
+    # The count described the whole result from the first paint, so scrolling
+    # gave it nothing to correct.
+    assert harness.page.inner_text("#status") == status_before, (
+        f"status drifted while scrolling: {status_before!r} -> {harness.page.inner_text('#status')!r}"
+    )
+
+    harness.screenshot("final_state")

--- a/tests/ui/implementations/collection_unowned_windowed_first_page.py
+++ b/tests/ui/implementations/collection_unowned_windowed_first_page.py
@@ -1,0 +1,29 @@
+"""
+Hand-written implementation for collection_unowned_windowed_first_page.
+
+A 7,603-row result must paint as one bounded window: the count describes the
+whole result while the DOM holds only what fits on screen.
+"""
+
+
+def steps(harness):
+    harness.navigate("/collection?q=is%3Aunowned")
+    harness.wait_for_visible("#vtbody tr[data-idx]:not([data-pending])", timeout=15_000)
+
+    # The count describes the whole result, not the page that was fetched.
+    harness.assert_text_present("7,603 results")
+
+    # ...while the DOM holds only a windowful. A page fetched whole would put
+    # thousands of rows here; the bound is generous so a viewport change
+    # cannot make this flap.
+    rendered = harness.page.eval_on_selector_all("#vtbody tr[data-idx]", "els => els.length")
+    assert 0 < rendered < 200, f"expected a bounded window of rows, got {rendered} in the DOM"
+
+    # The scrollbar still spans the whole result: the bottom spacer reserves
+    # the height of every row that has not been fetched.
+    spacer = harness.page.eval_on_selector(
+        "#vscroll-bottom td", "el => parseInt(el.style.height) || 0"
+    )
+    assert spacer > 100_000, f"expected the spacer to reserve the whole result, got {spacer}px"
+
+    harness.screenshot("final_state")

--- a/tests/ui/implementations/deck_builder_swap_printing_execution.py
+++ b/tests/ui/implementations/deck_builder_swap_printing_execution.py
@@ -16,7 +16,7 @@ def steps(harness):
         });
         const deck = await res.json();
         const colRes = await fetch('/api/collection?limit=50');
-        const cards = await colRes.json();
+        const cards = (await colRes.json()).rows;  // page envelope: {rows, total, limit, offset}
         // Find a card with multiple printings by checking the by-oracle endpoint
         for (const card of cards) {
             const pRes = await fetch('/api/printings/by-oracle/' + card.oracle_id);

--- a/tests/ui/implementations/deck_builder_swap_printing_modal.py
+++ b/tests/ui/implementations/deck_builder_swap_printing_modal.py
@@ -16,7 +16,7 @@ def steps(harness):
         });
         const deck = await res.json();
         const colRes = await fetch('/api/collection?limit=50');
-        const cards = await colRes.json();
+        const cards = (await colRes.json()).rows;  // page envelope: {rows, total, limit, offset}
         if (cards.length > 0) {
             await fetch('/api/decks/' + deck.id + '/expected-cards/add', {
                 method: 'POST',

--- a/tests/ui/implementations/deck_builder_swap_unavailable_constructed.py
+++ b/tests/ui/implementations/deck_builder_swap_unavailable_constructed.py
@@ -16,7 +16,7 @@ def steps(harness):
         });
         const deck = await res.json();
         const colRes = await fetch('/api/collection?limit=50');
-        const cards = await colRes.json();
+        const cards = (await colRes.json()).rows;  // page envelope: {rows, total, limit, offset}
         if (cards.length > 0) {
             await fetch('/api/decks/' + deck.id + '/expected-cards/add', {
                 method: 'POST',

--- a/tests/ui/intents/collection_sort_orders_whole_result.yaml
+++ b/tests/ui/intents/collection_sort_orders_whole_result.yaml
@@ -1,0 +1,12 @@
+# Scenario: Sorting orders the whole result, not the part already fetched
+#
+# Related:
+#   issues: [de-6f4]
+#   pull_requests: []
+
+description: >
+  When I sort a search that matched far more cards than are on screen, I get
+  the first card of the whole result. Searching "is:unowned" and clicking the
+  Card header to reverse the order puts a card at the very end of the
+  alphabet at the top — not merely the last of the batch that happened to be
+  loaded, which would still be a card near the start of the alphabet.

--- a/tests/ui/intents/collection_stats_modal_states_loaded_coverage.yaml
+++ b/tests/ui/intents/collection_stats_modal_states_loaded_coverage.yaml
@@ -1,0 +1,12 @@
+# Scenario: Result stats say how much of the result they cover
+#
+# Related:
+#   issues: [de-6f4]
+#   pull_requests: []
+
+description: >
+  When I open the result statistics for a search far larger than one screen,
+  the modal tells me it is describing only the cards fetched so far rather
+  than quietly presenting them as the whole result. When the result is small
+  enough that everything is already loaded, no such caveat appears, because
+  the figures really are the whole thing.

--- a/tests/ui/intents/collection_unowned_scroll_reaches_end.yaml
+++ b/tests/ui/intents/collection_unowned_scroll_reaches_end.yaml
@@ -1,0 +1,12 @@
+# Scenario: Scrolling reaches the end of a result far larger than one page
+#
+# Related:
+#   issues: [de-6f4]
+#   pull_requests: []
+
+description: >
+  When I scroll down through the thousands of cards an "is:unowned" search
+  matches, more of them keep arriving as I go, and I can reach the very last
+  one instead of hitting an invisible wall where the first batch ran out. The
+  count beside the search box does not change while I scroll — it described
+  the whole result from the start, so it has nothing to revise.

--- a/tests/ui/intents/collection_unowned_windowed_first_page.yaml
+++ b/tests/ui/intents/collection_unowned_windowed_first_page.yaml
@@ -1,0 +1,12 @@
+# Scenario: A huge result paints one window, not the whole catalog
+#
+# Related:
+#   issues: [de-6f4]
+#   pull_requests: []
+
+description: >
+  When I search "is:unowned", which matches thousands of printings I don't
+  own, the table appears straight away rather than making me wait for the
+  whole catalog. The count beside the search box tells me how many cards
+  matched in total, and the scrollbar is sized for all of them, but the page
+  has only fetched and rendered the screenful I am actually looking at.


### PR DESCRIPTION
`is:unowned` took **7.47 s** and returned **94.57 MB** for 108,630 rows, because the
endpoint returned every matching row and then enriched them twice with SQL built
from the result set.

Alignment verdict (`de-z8g`, review-only): **MERGE IT** — six of seven Verify
items pass, and the one that misses is reported honestly below rather than
rounded up.

## Measured

| | before | after | |
|---|---:|---:|---|
| response, raw | 96,955,922 B | **227,641 B** | **426×** |
| response, gzipped | 9,657,852 B | **28,973 B** | |
| first paint | ~15.07 s* | **~4.56 s** | 3.3× |

\* main measured on the same box and data as the branch, so the 3.3× is
like-for-like.

**Bytes goal met by 426× against a required 10×. The first-paint goal is MISSED:
~4.56 s median against a <1 s target.** A real miss, not a rounding error, and the
cause is understood.

## What's in it

- **`de-3qg` — the ordering was not total.** `ORDER BY {sort_col}, card.name` with
  no unique tiebreak, against 112,809 printings sharing only 34,881 distinct
  names. Paging that silently drops and duplicates rows at window boundaries.
  Now verified: a **110-page walk of a tie-heavy 109,974-row result returned every
  row exactly once, zero duplicates.**
- **`de-zwv` — bounded responses.** `limit`/`offset`, default 250, max 1000, page
  envelope `{rows, total, limit, offset}`, 400 on bad input. All five call sites
  updated together.
- **`de-6f4` — the client fetches windows as it scrolls**, reusing the existing
  virtual scroller rather than replacing it.
- **`de-ckq` — enrichment folded into the main query.** The two follow-up passes
  are gone, and with them a statement carrying **225,618 bound parameters against
  a 250,000 limit** — a catalog 12% larger returned an error, not a slow page.

## Why first paint still misses, and what it is not

It is **not** the payload, which is 426× smaller. The dominant remaining cost is
`ORDER BY card.name` with no supporting index: SQLite builds a temp B-tree over
all 110k rows to return 250. Second is `total`/`total_qty`/`total_value` being
recomputed on **every** page rather than only the first.

Both filed rather than smuggled into this PR:

- **`de-8nd`** (P1) — first paint is 4.2 s; the sort is the cost
- **`de-962`** (P1) — page totals recomputed on every page
- **`de-fb1`** (P1) — `price:` keyword fans out rows; the `_lp` join pins
  `price_type` but not `source`
- **`de-33j`** (P2) — **`/api/search` is still unbounded** and still builds
  result-set-proportional SQL via `_bulk_attach_prices`

`de-33j` deserves your attention: fixing one endpoint surfaced that its sibling
has the identical defect, still live.

## Where to look

1. **The `ORDER BY` change** — small, and the reason paging is safe at all
2. **The page envelope and the four calling files** — none checked the response
   type before, so a missed call site would have rendered an empty collection
   rather than throwing
3. **`_bulk_attach_prices`' removal from this path** — check nothing rebuilt an
   `IN` clause from the result set

**Safe to skim:** the UI intent fixtures.

Reminder: merging deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)