### PR TITLE
ci: run CI on push to main, not only on pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,15 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  # Also on push to main. Branch protection now requires the `test` check and
+  # enforces it for admins, so normally everything reaching main has already
+  # been tested as a PR and this is redundant. It exists for the case that
+  # actually happened on 2026-08-11 (de-x5c): a Gas Town refinery merge landed
+  # a whole epic on main directly, CI never ran because there was no push
+  # trigger, and prod deployed content whose last CI run was RED.
+  # Protection is the lock; this is the smoke alarm. Keep both.
+  push:
+    branches: [main]
   workflow_dispatch:
 
 # After merging, enable branch protection on `main` in GitHub repo settings:


### PR DESCRIPTION
Second layer of the `de-x5c` fix. Branch protection on `main` is the actual lock — it now
requires the `test` check with `enforce_admins: true`, applied 2026-08-11. This adds the
smoke alarm.

## Why

`ci.yml` triggered on `pull_request` and `workflow_dispatch` only, so anything reaching
`main` by another route ran no CI at all.

That is not hypothetical. On 2026-08-11 a Gas Town refinery merge landed
`polecat/furiosa/de-ear` directly on `main`, carrying the entire collection-payload round-2
epic with it — its base was the round-2 integration branch, so one merge brought the whole
thing. PR #283 existed for exactly that content and was never merged. **Prod then deployed
it while the last CI run on that content had failed.**

Prod turned out healthy (235/235 UI scenarios pass locally), but that was luck, not process.

## Why keep both layers

Protection prevents the push. This trigger means that if protection is ever relaxed,
bypassed, or misconfigured again, `main` still gets tested instead of silently shipping.
It costs one CI run per merge and fails loudly in exactly the case where the lock has
already failed quietly.

## Consequence worth knowing

With `enforce_admins: true`, the Gas Town refinery can no longer land on `main`. Epics must
reach it through an integration branch and a PR merged at your discretion — the intended
workflow, now enforced rather than assumed. pokedumpster hit the same wall from the other
direction (`pd-56tq`).