### PR TITLE
Add S3 backup-freshness dead-man's switch (de-9uu)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -232,11 +232,61 @@ systemctl --user restart mtgc-<name>
 
 The instance regenerates and serves the self-signed certificate again — browsers warn, `curl -ks` works, nothing else changes. To also drop the mount, re-run `setup.sh` without `--tls-certs` and `systemctl --user daemon-reload`.
 
+## Backup freshness check
+
+`backup.sh` can exit 0 having uploaded nothing — bad credentials, a full disk, an
+empty tarball — and the cron log reads "success" every night regardless. Checking
+that the job *ran* proves the thing that was never in doubt. `backup-check.sh`
+asks S3 what actually landed:
+
+```bash
+bash deploy/backup-check.sh <instance>
+```
+
+It lists `s3://$MTGC_BACKUP_S3_BUCKET/mtgc-<instance>/daily/` (the tier
+`backup.sh` writes to every night — `weekly/` and `monthly/` are promotion tiers
+and go long stretches untouched), then fails if the listing errors, if there are
+no objects, if the newest is older than the threshold, or if it is implausibly
+small in absolute terms or against the previous night's. It is **read-only**:
+list plus object metadata, no put and no delete, so read-only credentials are
+enough and it cannot damage what it is watching.
+
+Configure in `~/.config/mtgc/<instance>.env` — the same file `backup.sh`'s cron
+entry sources:
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `MTGC_BACKUP_S3_BUCKET` | — | Unset means no off-site backup to verify: the check exits 0 without doing anything, so dev/test instances stay silent |
+| `MTGC_BACKUP_PING_URL` | — | healthchecks.io-style monitor. Pinged **only** when genuinely fresh; `<url>/fail` on staleness. Unset just skips the ping — the freshness assertions still run |
+| `MTGC_BACKUP_MAX_AGE_HOURS` | `36` | Clears one 24h interval plus the run itself plus margin, so one late night doesn't false-alarm but two consecutive misses do |
+| `MTGC_BACKUP_MIN_SIZE_PCT` | `50` | Fail if the newest object is under this percentage of the previous one |
+| `MTGC_BACKUP_MIN_SIZE_BYTES` | `1048576` | Absolute floor, for when there is no previous object to compare against |
+
+Alerts go to Pushover via `alert.sh`, reading `PUSHOVER_TOKEN` / `PUSHOVER_USER`
+from host-wide `~/.config/mtgc/alerts.env`. Unset means no push — nothing else
+changes. `mtgc-alert-<instance>@.service` is a generic `OnFailure=` handler that
+pushes any failed unit's journal tail; `setup.sh` installs it alongside the
+timers.
+
+The monitor is the part that survives the box: a dead checker, a dead host or a
+disabled timer all stop the pings and trip it. Pushover is the fast, detailed
+signal while the box is still up.
+
+`setup.sh` installs `mtgc-backup-check-<instance>.{service,timer}` but does not
+enable them — arming is deliberate:
+
+```bash
+systemctl --user enable --now mtgc-backup-check-<name>.timer
+systemctl --user start mtgc-backup-check-<name>.service   # run once by hand
+```
+
 ## Scripts
 
 | Script | Purpose |
 |---|---|
 | `seed.sh [--force]` | Create reusable seed data volume. Run once, all future `--init` clones from it |
+| `backup-check.sh <name>` | Verify the newest S3 backup is fresh and plausibly sized. Read-only — see [Backup freshness check](#backup-freshness-check) |
+| `alert.sh "<title>" ["<message>"]` | Push a Pushover notification (message on stdin if omitted). No-op when creds are unset |
 | `setup.sh <name> [port] [--init] [--test] [--http-port <p>] [--tls-certs <dir>]` | Create instance. `--test` uses pre-built fixture (fast, no network). `--init` clones seed volume. Port auto-assigned if omitted. `--http-port` adds a loopback-only plaintext publish — see [Cloudflare Tunnel origin](#cloudflare-tunnel-origin). `--tls-certs` mounts a host cert directory read-only at `/certs` — see [Trusted certificates](#trusted-certificates) |
 | `render-quadlet.sh <name> <port-mapping> <http-port> <tls-certs> [template]` | Render the Quadlet unit to stdout. Called by `setup.sh`; standalone for testing |
 | `deploy.sh <name>` | Rebuild image and restart one instance. Regenerates the Quadlet via `setup.sh` if it has gone missing — `--http-port` / `--tls-certs` are re-applied from the env file, so the unit is reproduced rather than downgraded |

--- a/deploy/alert.sh
+++ b/deploy/alert.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Push a notification via Pushover. The shared notification sink for anything
+# that needs to reach a human while the box is up:
+#   - backup-check.sh          (staleness detected on a live box)
+#   - mtgc-alert@.service      (a failed unit's journal tail, via OnFailure=)
+#
+# Reads PUSHOVER_TOKEN / PUSHOVER_USER from the environment — load the host-wide
+# ~/.config/mtgc/alerts.env first. No-op (exit 0) when unset, so dev/test and
+# unconfigured boxes are unaffected. No new runtime deps beyond curl.
+#
+# Usage:
+#   alert.sh "<title>" "<message>"     # message as an argument
+#   some_cmd | alert.sh "<title>"      # message on stdin (e.g. a journal tail)
+set -euo pipefail
+
+TITLE="${1:-MTGC alert}"
+# Second arg is the message; if absent, read it from stdin (pipe form).
+if [ "$#" -ge 2 ]; then
+    MSG="$2"
+else
+    MSG="$(cat)"
+fi
+
+if [ -z "${PUSHOVER_TOKEN:-}" ] || [ -z "${PUSHOVER_USER:-}" ]; then
+    echo "alert.sh: PUSHOVER_TOKEN/USER unset — skipping push (title: ${TITLE})" >&2
+    exit 0
+fi
+
+# Pushover caps message length at 1024 chars; trim to stay well under.
+MSG="$(printf '%s' "$MSG" | tail -c 900)"
+
+curl -fsS -m 15 \
+    --form-string "token=${PUSHOVER_TOKEN}" \
+    --form-string "user=${PUSHOVER_USER}" \
+    --form-string "title=${TITLE}" \
+    --form-string "message=${MSG}" \
+    --form-string "priority=${PUSHOVER_PRIORITY:-0}" \
+    https://api.pushover.net/1/messages.json >/dev/null

--- a/deploy/backup-check.sh
+++ b/deploy/backup-check.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+#
+# Backup-freshness dead-man's switch (de-d8v).
+#
+# backup.sh runs nightly and syncs tarballs to S3. It can exit 0 having uploaded
+# nothing — bad credentials, a full disk, an empty tarball, a truncated dump —
+# and the cron log will read "success" every night forever. The lesson is
+# pokedumpster's, learned during a Jun 2026 key rotation where a replicator
+# showed systemd `active` while error-looping on AccessDenied:
+#
+#     liveness is NOT freshness
+#
+# So this checker asks S3 what actually landed, never the local job:
+#   1. List s3://<bucket>/mtgc-<instance>/daily/ (read-only). backup.sh writes a
+#      new object there every night; weekly/ and monthly/ are promotion tiers and
+#      go long stretches untouched, so daily/ is the only tier whose age means
+#      anything.
+#   2. Listing FAILS (broken creds, network, missing bucket) -> NOT fresh. This
+#      is the failure that killed pokedumpster's replication: the same creds the
+#      uploader uses are the ones being exercised here.
+#   3. Newest object older than the threshold -> NOT fresh.
+#   4. Newest object implausibly small, in absolute terms or against the previous
+#      night's -> NOT fresh. A 0-byte object is a silent failure, not a backup.
+#   5. Fresh -> ping the off-box monitor (it expects a ping every run; a miss
+#      alerts). Stale -> ping <url>/fail to trip it immediately, plus a Pushover
+#      push with the detail.
+#
+# Because the monitor lives OFF the box, a dead checker / dead box / disabled
+# timer ALSO stops the pings and trips the alert. The Pushover push is the fast,
+# detailed signal while the box is up; the monitor is the backstop for box-down.
+#
+# Read-only by design: it lists objects and reads their metadata. It never puts
+# or deletes, so it cannot damage the thing it is watching, and read-only
+# credentials are enough.
+#
+# Silent unless a bucket is configured: MTGC_BACKUP_S3_BUCKET unset means the
+# instance has no off-site backup to verify, so there is nothing to check and
+# dev/test boxes are unaffected. MTGC_BACKUP_PING_URL is independently optional —
+# unset just means no monitor to ping; the freshness assertions still run and
+# still alert, which is what you want on a box whose backups are real but whose
+# monitor is not wired up yet.
+#
+# Usage: backup-check.sh <instance>
+set -euo pipefail
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+
+INSTANCE="${1:?usage: backup-check.sh <instance>}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Host-wide Pushover creds, then the per-instance env (bucket, AWS profile, ping
+# URL, thresholds). The instance env wins — it is the same file backup.sh's cron
+# entry sources.
+[ -f "${HOME}/.config/mtgc/alerts.env" ]        && { set -a; . "${HOME}/.config/mtgc/alerts.env";        set +a; }
+[ -f "${HOME}/.config/mtgc/${INSTANCE}.env" ]   && { set -a; . "${HOME}/.config/mtgc/${INSTANCE}.env";   set +a; }
+
+BUCKET="${MTGC_BACKUP_S3_BUCKET:-}"
+PING="${MTGC_BACKUP_PING_URL:-}"
+# The backup runs once a day at 03:00 and takes minutes to build and sync a
+# multi-GB tarball. 36h clears a full interval plus the run itself plus margin,
+# so one late night doesn't false-alarm but two consecutive misses do.
+MAX_AGE_HOURS="${MTGC_BACKUP_MAX_AGE_HOURS:-36}"
+# The dataset grows monotonically (~13 MB/night at present), so any drop is
+# suspicious; 50% is the point past which it is not explicable as churn.
+MIN_SIZE_PCT="${MTGC_BACKUP_MIN_SIZE_PCT:-50}"
+# Absolute floor, for the case where there is no previous object to compare
+# against. A real tarball is gigabytes; anything under 1 MiB is a failed dump.
+MIN_SIZE_BYTES="${MTGC_BACKUP_MIN_SIZE_BYTES:-1048576}"
+
+PREFIX="mtgc-${INSTANCE}/daily/"
+
+# No off-site backup configured -> nothing to verify. Keeps dev/test silent.
+if [ -z "$BUCKET" ]; then
+    echo "backup-check: MTGC_BACKUP_S3_BUCKET unset — skipping (instance: ${INSTANCE})"
+    exit 0
+fi
+
+stale() {
+    local reason="$1"
+    echo "backup-check: STALE — ${reason}" >&2
+    # Trip the off-box dead-man immediately rather than waiting out its grace
+    # window on a missed ping.
+    [ -n "$PING" ] && { curl -fsS -m 10 "${PING}/fail" >/dev/null 2>&1 || true; }
+    "${SCRIPT_DIR}/alert.sh" "MTGC backup STALE (${INSTANCE})" \
+        "S3 freshness check failed for s3://${BUCKET}/${PREFIX} — ${reason}" || true
+    exit 1
+}
+
+command -v aws >/dev/null 2>&1 || stale "aws CLI not found on PATH"
+
+# --- List the daily tier (read-only) --------------------------------------
+# list-objects-v2 is a pure read. Broken creds surface here exactly as they
+# would for the uploader, which is the whole point.
+LIST_OUT="$(aws s3api list-objects-v2 \
+    --bucket "$BUCKET" \
+    --prefix "$PREFIX" \
+    --query 'Contents[].[LastModified,Size,Key]' \
+    --output text 2>&1)" \
+    || stale "S3 list failed (creds/network/bucket): $(printf '%s' "$LIST_OUT" | tail -n1)"
+
+# No objects at all: --output text renders an absent Contents as "None".
+OBJECTS="$(printf '%s\n' "$LIST_OUT" | grep -v '^None$' | grep -v '^$' || true)"
+[ -n "$OBJECTS" ] || stale "no objects under s3://${BUCKET}/${PREFIX}"
+
+# LastModified is RFC3339 Zulu, so lexicographic sort == chronological.
+SORTED="$(printf '%s\n' "$OBJECTS" | sort)"
+NEWEST_LINE="$(printf '%s\n' "$SORTED" | tail -n1)"
+PREV_LINE="$(printf '%s\n' "$SORTED" | tail -n2 | head -n1)"
+
+NEWEST_TS="$(printf '%s' "$NEWEST_LINE" | cut -f1)"
+NEWEST_SIZE="$(printf '%s' "$NEWEST_LINE" | cut -f2)"
+NEWEST_KEY="$(printf '%s' "$NEWEST_LINE" | cut -f3)"
+
+NEWEST_EPOCH="$(date -d "$NEWEST_TS" +%s 2>/dev/null)" || stale "could not parse LastModified: ${NEWEST_TS}"
+AGE_H=$(( ( $(date +%s) - NEWEST_EPOCH ) / 3600 ))
+
+# --- Age ------------------------------------------------------------------
+
+if [ "$AGE_H" -gt "$MAX_AGE_HOURS" ]; then
+    stale "newest object ${NEWEST_KEY} is ${AGE_H}h old (> ${MAX_AGE_HOURS}h threshold)"
+fi
+
+# --- Size -----------------------------------------------------------------
+
+if [ "$NEWEST_SIZE" -lt "$MIN_SIZE_BYTES" ]; then
+    stale "newest object ${NEWEST_KEY} is ${NEWEST_SIZE} bytes (< ${MIN_SIZE_BYTES} byte floor)"
+fi
+
+if [ "$NEWEST_LINE" != "$PREV_LINE" ]; then
+    PREV_SIZE="$(printf '%s' "$PREV_LINE" | cut -f2)"
+    PREV_KEY="$(printf '%s' "$PREV_LINE" | cut -f3)"
+    # Integer percentage of the previous night's size. PREV_SIZE cleared the
+    # same floor when it was the newest, so it is never 0 here in practice —
+    # but a 0 would divide, so guard it.
+    if [ "$PREV_SIZE" -gt 0 ]; then
+        SIZE_PCT=$(( NEWEST_SIZE * 100 / PREV_SIZE ))
+        if [ "$SIZE_PCT" -lt "$MIN_SIZE_PCT" ]; then
+            stale "newest object ${NEWEST_KEY} is ${NEWEST_SIZE} bytes, ${SIZE_PCT}% of the previous ${PREV_KEY} (${PREV_SIZE} bytes) — below the ${MIN_SIZE_PCT}% floor"
+        fi
+    fi
+fi
+
+# --- Fresh: ping the monitor ----------------------------------------------
+
+echo "backup-check: OK — ${NEWEST_KEY} is ${AGE_H}h old (<= ${MAX_AGE_HOURS}h), ${NEWEST_SIZE} bytes"
+if [ -n "$PING" ]; then
+    curl -fsS -m 10 "$PING" >/dev/null 2>&1 \
+        || echo "backup-check: WARNING — monitor ping failed (will retry next run)" >&2
+else
+    echo "backup-check: MTGC_BACKUP_PING_URL unset — no monitor to ping"
+fi

--- a/deploy/mtgc-alert@.service
+++ b/deploy/mtgc-alert@.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=MTGC failure alert for %i
+# Generic OnFailure= handler: pushes the failed unit's journal tail to Pushover
+# the moment it fails. Fast, detailed, on-box — it does NOT catch never-ran or
+# box-down, which is what the off-box monitor in backup-check.sh is for.
+#
+# %i is the FULL failed unit name (units reference it as mtgc-alert-<inst>@%n.service),
+# so one template alerts for any unit. deploy/setup.sh substitutes the instance
+# into the checkout path below and installs this as mtgc-alert-<instance>@.service:
+# the '@' slot is already spent on the failed unit's name, so the per-instance
+# checkout path has to be carried by the unit's own filename instead.
+
+[Service]
+Type=oneshot
+# '-' makes the file optional so the unit installs cleanly before alerts.env
+# exists (alert.sh then no-ops on unset creds).
+EnvironmentFile=-%h/.config/mtgc/alerts.env
+ExecStart=/bin/sh -c 'journalctl --user -u %i -n 20 --no-pager | /opt/mtgc-{{INSTANCE}}/deploy/alert.sh "MTGC unit FAILED: %i"'

--- a/deploy/mtgc-backup-check.service
+++ b/deploy/mtgc-backup-check.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=MTGC backup freshness check ({{INSTANCE}})
+# Verifies what actually landed in S3, not that the nightly job ran — see
+# deploy/backup-check.sh. Needs the network to reach S3.
+After=network-online.target
+Wants=network-online.target
+# The script alerts on staleness itself; this catches the checker erroring out
+# some other way (missing env, a bug), which would otherwise be silent.
+OnFailure=mtgc-alert-{{INSTANCE}}@%n.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/mtgc-{{INSTANCE}}/deploy/backup-check.sh {{INSTANCE}}
+TimeoutStartSec=120

--- a/deploy/mtgc-backup-check.timer
+++ b/deploy/mtgc-backup-check.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=MTGC backup freshness check timer ({{INSTANCE}})
+
+[Timer]
+# Every 6h — deliberately more frequent than the nightly backup. A credentials
+# break makes the freshness query itself fail, and that is worth catching the
+# same day rather than at the next 03:00 run.
+OnCalendar=*-*-* 00,06,12,18:00:00
+RandomizedDelaySec=300
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -234,7 +234,7 @@ fi
 SYSTEMD_USER_DIR="$HOME/.config/systemd/user"
 mkdir -p "$SYSTEMD_USER_DIR"
 
-for UNIT_PREFIX in mtgc-prices mtgc-sealed-catalog mtgc-backup mtgc-edhrec; do
+for UNIT_PREFIX in mtgc-prices mtgc-sealed-catalog mtgc-backup mtgc-backup-check mtgc-edhrec; do
     echo "==> Installing ${UNIT_PREFIX} timer"
     for EXT in service timer; do
         sed -e "s|{{INSTANCE}}|${INSTANCE}|g" \
@@ -242,6 +242,15 @@ for UNIT_PREFIX in mtgc-prices mtgc-sealed-catalog mtgc-backup mtgc-edhrec; do
             > "${SYSTEMD_USER_DIR}/${UNIT_PREFIX}-${INSTANCE}.${EXT}"
     done
 done
+
+# The OnFailure= alert handler is a systemd template unit, so it can't join the
+# loop above: its '@' instance slot carries the FAILED unit's name, leaving the
+# instance name to be baked into the filename. No timer — it only ever fires
+# from another unit's OnFailure=.
+echo "==> Installing mtgc-alert handler"
+sed -e "s|{{INSTANCE}}|${INSTANCE}|g" \
+    "$REPO_DIR/deploy/mtgc-alert@.service" \
+    > "${SYSTEMD_USER_DIR}/mtgc-alert-${INSTANCE}@.service"
 
 systemctl --user daemon-reload
 
@@ -370,5 +379,6 @@ echo "  Logs:       journalctl --user -u $SERVICE_NAME -f"
 echo "  Prices:     systemctl --user enable --now mtgc-prices-${INSTANCE}.timer"
 echo "  Sealed:     systemctl --user enable --now mtgc-sealed-catalog-${INSTANCE}.timer"
 echo "  Backup:     systemctl --user enable --now mtgc-backup-${INSTANCE}.timer"
+echo "  Bkp check:  systemctl --user enable --now mtgc-backup-check-${INSTANCE}.timer"
 echo "  EDHREC:     systemctl --user enable --now mtgc-edhrec-${INSTANCE}.timer"
 echo "  Teardown:   bash deploy/teardown.sh $INSTANCE"

--- a/deploy/teardown.sh
+++ b/deploy/teardown.sh
@@ -35,12 +35,13 @@ echo "==> Tearing down $SERVICE_NAME..."
 
 # Stop and disable timers
 SYSTEMD_USER_DIR="$HOME/.config/systemd/user"
-for PREFIX in mtgc-prices mtgc-sealed-catalog mtgc-backup mtgc-edhrec; do
+for PREFIX in mtgc-prices mtgc-sealed-catalog mtgc-backup mtgc-backup-check mtgc-edhrec; do
     systemctl --user stop "${PREFIX}-${INSTANCE}.timer" 2>/dev/null || true
     systemctl --user disable "${PREFIX}-${INSTANCE}.timer" 2>/dev/null || true
     rm -f "${SYSTEMD_USER_DIR}/${PREFIX}-${INSTANCE}.service" \
           "${SYSTEMD_USER_DIR}/${PREFIX}-${INSTANCE}.timer"
 done
+rm -f "${SYSTEMD_USER_DIR}/mtgc-alert-${INSTANCE}@.service"
 
 # Stop and disable
 systemctl --user stop "$SERVICE_NAME" 2>/dev/null || true


### PR DESCRIPTION
`backup.sh` can exit 0 having uploaded nothing — bad credentials, a full disk, an empty tarball — and the cron log reads "success" every night regardless. Nothing verified that mtgc-prod-data's nightly upload was still landing. The lesson is pokedumpster's, from a Jun 2026 key rotation where a replicator showed systemd `active` while error-looping on AccessDenied:

> liveness is NOT freshness

## What this adds

- **`deploy/backup-check.sh <instance>`** — lists `s3://$MTGC_BACKUP_S3_BUCKET/mtgc-<instance>/daily/` and goes red on a failed listing (the credentials failure mode), zero objects, an age over `MTGC_BACKUP_MAX_AGE_HOURS` (36), or a size that is implausible in absolute terms (`MTGC_BACKUP_MIN_SIZE_BYTES`, 1 MiB) or against the previous night's (`MTGC_BACKUP_MIN_SIZE_PCT`, 50%). `daily/` is the only tier whose age means anything — `weekly/` and `monthly/` are promotion tiers and go long stretches untouched.
- **`deploy/alert.sh`** — Pushover push, mirroring pokedumpster's 1:1. Reads `~/.config/mtgc/alerts.env`, no-op when unset.
- **`deploy/mtgc-backup-check.{service,timer}`** — `{{INSTANCE}}`-substituted like the existing `mtgc-*` units, every 6h (deliberately more frequent than the nightly backup, so a credentials break is caught same-day), `OnFailure=mtgc-alert-{{INSTANCE}}@%n.service`.
- **`deploy/mtgc-alert@.service`** — generic `OnFailure=` handler that pushes any failed unit's journal tail.
- Wired into `setup.sh`'s install loop and `teardown.sh`'s cleanup loop; documented in `deploy/README.md`.

Fresh pings an off-box healthchecks.io-style monitor; stale trips it immediately via `<url>/fail` and pushes Pushover detail. Because the monitor lives off the box, a dead checker, dead host or disabled timer also stop the pings and alert.

## Two judgement calls worth a look

**The whole run is gated on `MTGC_BACKUP_S3_BUCKET`, not on the ping URL** as pokedumpster gates its own. Dev and test instances have no bucket, so they stay silent either way — but prod has a bucket and no monitor wired up yet, and gating on the ping URL would make the check a no-op exactly where it is needed. The ping is independently optional.

**`mtgc-alert@.service` cannot join the `{{INSTANCE}}` loop.** Its `@` slot carries the failed unit's name, so the per-instance checkout path rides in the filename instead: it installs as `mtgc-alert-<instance>@.service`.

## Verification

Everything below is read-only against the real `gantt-mtgc-backup` bucket. The only AWS call the script makes is `aws s3api list-objects-v2` — no put, no delete — so read-only credentials suffice.

**Pass**, against the real bucket:

```
backup-check: OK — mtgc-prod/daily/mtgc-prod-20260812-030001.tar.gz is 1h old (<= 36h), 3216229803 bytes
```

**Fail**, five ways. Each exited 1, pinged `<url>/fail` (captured on a local listener) and invoked `alert.sh`:

| Case | Output |
|---|---|
| Empty prefix | `STALE — no objects under s3://gantt-mtgc-backup/mtgc-nosuchinstance/daily/` |
| Broken credentials | `STALE — S3 list failed (creds/network/bucket): The config profile (no-such-profile) could not be found` |
| Age | `STALE — newest object … is 1h old (> 0h threshold)` |
| Size vs previous | `STALE — … 3216229803 bytes, 101% of the previous mtgc-prod-20260810-030001.tar.gz (3183156942 bytes) — below the 102% floor` |
| Absolute size floor | `STALE — … is 3216229803 bytes (< 99999999999 byte floor)` |

The age and size cases used deliberately impossible thresholds to drive the real data across the branch, since proving them otherwise would need write access to the bucket.

**End-to-end under systemd** on a `--test` instance named `capable`, whose `mtgc-capable/daily/` prefix has never held an object:

```
mtgc-backup-check-capable.service: Result=exit-code ExecMainStatus=1
backup-check: STALE — no objects under s3://gantt-mtgc-backup/mtgc-capable/daily/
mtgc-backup-check-capable.service: Triggering OnFailure= dependencies.
Starting mtgc-alert-capable@mtgc-backup-check-capable.service.service …
```

The alert unit then made a real Pushover POST (HTTP 400 on a dummy token — the push path executed). The same unit against the prod prefix gave `Result=success ExecMainStatus=0`. `teardown.sh capable --purge` removed all five new unit files.

**Nothing touched prod**: no `systemd-mtgc-prod`, no `mtgc-prod-data` volume, no `/opt/mtgc-prod`. `prod.env` was read for the bucket name and AWS profile, which is what the bead authorised.

The timer is installed but **not enabled**. Arming it on prod is yours to decide.

## Incidental finding — worth its own bead

`mtgc-prod/daily/` has gaps: **no object for 2026-08-08 or 2026-08-11**. The nightly backup missed at least two nights in the last month. That is precisely what this check exists to catch, and it went unnoticed until now.

Closes de-9uu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)