### PR TITLE
Backup freshness check for mtgc-prod-data (de-d8v)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -232,6 +232,73 @@ systemctl --user restart mtgc-<name>
 
 The instance regenerates and serves the self-signed certificate again — browsers warn, `curl -ks` works, nothing else changes. To also drop the mount, re-run `setup.sh` without `--tls-certs` and `systemctl --user daemon-reload`.
 
+## Backup freshness check
+
+The nightly backup is a cron job. A cron job can exit 0 having uploaded nothing —
+bad credentials, a full disk, an empty tarball, a truncated dump — and log success
+every night forever. The bucket already carries the evidence: `gantt-mtgc-backup`
+has no object at all for 2026-08-08 or 2026-08-11, and nothing said so.
+
+`backup-check.sh` is the dead-man's switch. It does not ask whether the job ran;
+it asks S3 what is actually there, and goes red when:
+
+| Condition | Why it is a failure |
+|---|---|
+| the bucket cannot be listed | broken credentials or network. "We could not ask" is not "the answer is fine" |
+| the prefix is empty | the instance is not backed up |
+| newest object older than `MTGC_BACKUP_MAX_AGE_HOURS` (30) | the upload stopped |
+| newest object under `MTGC_BACKUP_MIN_BYTES` (1 MiB) | a 0-byte object is not a backup |
+| newest object >`MTGC_BACKUP_MAX_SHRINK_PCT`% (10) smaller than the previous one | content went missing; a truncated dump has a plausible mtime and a plausible size |
+| `MTGC_BACKUP_S3_BUCKET` unset | nothing off-box to be fresh — a failure, never a skip |
+
+Only when all of those pass does it ping the off-box monitor. The ping lives here
+rather than in `backup.sh` because pinging from inside the backup job proves the
+job ran, which is the thing already not in question — and because a monitor that
+lives off the box also catches a dead box or a timer nobody enabled.
+
+**Nothing in the configuration can turn it into a pass.** An unset
+`MTGC_BACKUP_PING_URL` disables the ping and nothing else: freshness is still
+verified and a stale backup still exits 1, it just cannot arm the dead-man.
+
+### Arming an instance
+
+`setup.sh` installs `mtgc-backup-check-<instance>.{service,timer}` (6-hourly) and
+`mtgc-alert-<instance>@.service`, but enables nothing. To arm one:
+
+```bash
+# 1. Pushover credentials for the alert channel (host-wide).
+cat > ~/.config/mtgc/alerts.env <<'EOF'
+PUSHOVER_TOKEN=CHANGE_ME
+PUSHOVER_USER=CHANGE_ME
+EOF
+chmod 600 ~/.config/mtgc/alerts.env
+
+# 2. A healthchecks.io check with period ~6h and a few hours of grace, so one
+#    missed run alerts. Put its ping URL in the instance env file:
+#      MTGC_BACKUP_PING_URL=https://hc-ping.com/<uuid>
+
+# 3. Enable the timer.
+systemctl --user enable --now mtgc-backup-check-<instance>.timer
+
+# 4. Prove it goes RED before trusting it green — point it at a prefix with no
+#    recent object and confirm the failure and the alert:
+MTGC_BACKUP_S3_PREFIX=mtgc-<instance>/no-such-prefix/ bash deploy/backup-check.sh <instance>
+```
+
+Arming **prod** is Ryan's decision, not an agent's.
+
+### Credentials
+
+The check needs `s3:ListBucket` on the backup bucket and nothing else — verified
+by running it under an STS session scoped to exactly that, which passes the check
+and still gets 403 on `HeadObject`. Give it read-only credentials: a checker that
+could damage what it watches is a liability, and the only AWS call in the script
+is `s3api list-objects-v2`.
+
+```json
+{ "Effect": "Allow", "Action": "s3:ListBucket", "Resource": "arn:aws:s3:::gantt-mtgc-backup" }
+```
+
 ## Scripts
 
 | Script | Purpose |
@@ -241,6 +308,8 @@ The instance regenerates and serves the self-signed certificate again — browse
 | `render-quadlet.sh <name> <port-mapping> <http-port> <tls-certs> [template]` | Render the Quadlet unit to stdout. Called by `setup.sh`; standalone for testing |
 | `deploy.sh <name>` | Rebuild image and restart one instance. Regenerates the Quadlet via `setup.sh` if it has gone missing — `--http-port` / `--tls-certs` are re-applied from the env file, so the unit is reproduced rather than downgraded |
 | `teardown.sh <name> [--purge]` | Stop and remove instance. `--purge` deletes data volume and env file |
+| `backup-check.sh [name]` | Verify the newest S3 backup is recent and plausibly sized, then ping the off-box monitor. Read-only; exits 1 on any doubt — see [Backup freshness check](#backup-freshness-check) |
+| `alert.sh "<title>" "<message>"` | Push to Pushover. Shared by `backup-check.sh` and `mtgc-alert-<name>@.service`. Exits 1 if the channel is unconfigured, so a dropped alert cannot pass as sent |
 
 ## CI
 

--- a/deploy/alert.sh
+++ b/deploy/alert.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Push a notification via Pushover — the notification sink shared by
+# deploy/backup-check.sh (a stale backup on a live box) and
+# deploy/mtgc-alert@.service (any unit's journal tail on failure).
+#
+# Mirrors pokedumpster:deploy/alert.sh, including its central decision: asked to
+# alert and unable to alert is a FAILURE (exit 1), not a no-op. Nothing calls
+# this speculatively — every caller has already concluded something is wrong, so
+# an unconfigured channel means that conclusion reached nobody. Exiting non-zero
+# makes the calling unit fail, which is the only remaining way to see it.
+#
+# Reads PUSHOVER_TOKEN / PUSHOVER_USER from the environment; the host-wide file
+# is ~/.config/mtgc/alerts.env. No runtime deps beyond curl.
+#
+# Usage:
+#   alert.sh "<title>" "<message>"     # message as an argument
+#   some_cmd | alert.sh "<title>"      # message on stdin (e.g. a journal tail)
+set -euo pipefail
+
+# Production never sets this; tests point it at a local sink to prove the push
+# actually leaves the script.
+PUSHOVER_API_URL="${PUSHOVER_API_URL:-https://api.pushover.net/1/messages.json}"
+
+TITLE="${1:-MTGC alert}"
+if [ "$#" -ge 2 ]; then
+    MSG="$2"
+else
+    MSG="$(cat)"
+fi
+
+# CHANGE_ME is the scaffolded placeholder. A placeholder that reached curl would
+# fail the request anyway, just later and less legibly.
+if [ -z "${PUSHOVER_TOKEN:-}" ] || [ -z "${PUSHOVER_USER:-}" ] \
+   || [ "${PUSHOVER_TOKEN}" = CHANGE_ME ] || [ "${PUSHOVER_USER}" = CHANGE_ME ]; then
+    echo "alert.sh: FAILED — PUSHOVER_TOKEN/USER unset or still CHANGE_ME; this alert reached nobody." >&2
+    echo "  Dropped alert: ${TITLE}" >&2
+    echo "  Fix: fill ~/.config/mtgc/alerts.env (see deploy/README.md)." >&2
+    exit 1
+fi
+
+# Pushover caps messages at 1024 chars; trim to stay well under.
+MSG="$(printf '%s' "$MSG" | tail -c 900)"
+
+curl -fsS -m 15 \
+    --form-string "token=${PUSHOVER_TOKEN}" \
+    --form-string "user=${PUSHOVER_USER}" \
+    --form-string "title=${TITLE}" \
+    --form-string "message=${MSG}" \
+    --form-string "priority=${PUSHOVER_PRIORITY:-0}" \
+    "$PUSHOVER_API_URL" >/dev/null

--- a/deploy/backup-check.sh
+++ b/deploy/backup-check.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+#
+# Backup-freshness dead-man's switch for an MTGC instance (de-d8v).
+#
+# Modelled on pokedumpster:deploy/backup-check.sh, which exists because of a real
+# Jun 2026 key rotation: the Litestream sidecar showed systemd `active` while
+# error-looping on AccessDenied and replicating nothing. The lesson, quoted:
+#
+#     liveness is NOT freshness
+#
+# A nightly cron has the same failure shape and a worse one besides. backup.sh
+# can exit 0 having uploaded nothing — bad credentials, a full disk, an empty
+# tarball, a silently truncated dump — and cron logs success every night forever.
+# The first sign would be needing a restore. This bucket already carries the
+# evidence: 2026-08-08 and 2026-08-11 have no object at all, and nothing said so.
+#
+# So this script does not ask whether the job ran. It asks S3 what is actually
+# there:
+#   1. List the instance's backup prefix (read-only, s3:ListBucket only).
+#   2. If the list itself FAILS -> STALE. "We could not ask" and "the answer is
+#      fine" must never be the same outcome.
+#   3. No objects at all -> STALE.
+#   4. Newest object older than the threshold -> STALE.
+#   5. Newest object below an absolute byte floor -> STALE. A 0-byte or
+#      implausibly small object is a silent failure, not a backup.
+#   6. Newest object materially SMALLER than the one before it -> STALE. A
+#      truncated dump still has a plausible mtime and a plausible-looking size;
+#      only the comparison catches it.
+#   7. All of the above pass -> ping the off-box monitor (healthchecks.io).
+#
+# The ping happens HERE and only on a verified-fresh result. Pinging from inside
+# backup.sh would prove the job ran, which is the thing that is already not in
+# question. And because the monitor lives off the box, a dead checker, a dead
+# box or a disabled timer also stops the pings and trips the alert.
+#
+# ── NO CHECK MAY PASS BY SKIPPING ───────────────────────────────────────────
+# There is no configuration of this script that makes it exit 0 without asking
+# S3. An unset monitor URL disables the PING and nothing else: freshness is
+# still verified and a stale backup still fails, it just cannot arm the off-box
+# dead-man. A missing bucket is a failure outright — an instance with no
+# off-site target has no backup to be fresh.
+#
+# READ-ONLY BY CONSTRUCTION: the only AWS call below is `s3api list-objects-v2`.
+# A checker that could damage what it watches is a liability; the minimal policy
+# is s3:ListBucket on the bucket, and nothing else. See deploy/README.md.
+#
+# Usage: backup-check.sh [instance]        (default: prod)
+set -euo pipefail
+
+INSTANCE="${1:-prod}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# The config directory. Production never sets MTGC_CONFIG_DIR; only tests point
+# it elsewhere, so a gate can exercise the shipped script without reading — or
+# depending on — the operator's real credentials.
+CONF_DIR="${MTGC_CONFIG_DIR:-${HOME}/.config/mtgc}"
+
+# Host-wide alert channel first, then the instance's own env (the same file the
+# nightly cron sources), so per-instance settings win.
+[ -f "${CONF_DIR}/alerts.env" ]         && { set -a; . "${CONF_DIR}/alerts.env";         set +a; }
+[ -f "${CONF_DIR}/${INSTANCE}.env" ]    && { set -a; . "${CONF_DIR}/${INSTANCE}.env";    set +a; }
+
+BUCKET="${MTGC_BACKUP_S3_BUCKET:-}"
+PREFIX="${MTGC_BACKUP_S3_PREFIX:-mtgc-${INSTANCE}/}"
+PING="${MTGC_BACKUP_PING_URL:-}"
+
+# Backups are nightly at 03:00 and take ~7 minutes to upload. The threshold has
+# to clear one full interval plus margin so a single late night is not an alarm;
+# 30h means a genuinely missed night is red within 6h of crossing it.
+MAX_AGE_HOURS="${MTGC_BACKUP_MAX_AGE_HOURS:-30}"
+# Absolute floor. The real tarball is ~3 GB; anything under a megabyte is not a
+# backup by any reading, whatever produced it.
+MIN_BYTES="${MTGC_BACKUP_MIN_BYTES:-1048576}"
+# The tarball grows monotonically (~13 MB/night on prod). A drop of this much
+# against the previous backup means content went missing, not that the data did.
+MAX_SHRINK_PCT="${MTGC_BACKUP_MAX_SHRINK_PCT:-10}"
+
+# Only tests set this (a local MinIO); production talks to real S3.
+ENDPOINT_ARGS=()
+[ -n "${MTGC_BACKUP_S3_ENDPOINT:-}" ] && ENDPOINT_ARGS=(--endpoint-url "${MTGC_BACKUP_S3_ENDPOINT}")
+
+# --- Failure path -----------------------------------------------------------
+#
+# Trip the off-box dead-man immediately rather than waiting out the monitor's
+# grace window, then push the detail. Only if there is a monitor to trip: an
+# unarmed channel changes what this failure can NOTIFY, never whether it is a
+# failure, so the exit status belongs to the verdict alone.
+stale() {
+    local reason="$1"
+    echo "backup-check: STALE — ${reason}" >&2
+    if [ -n "$PING" ]; then
+        curl -fsS -m 10 "${PING}/fail" >/dev/null 2>&1 || true
+    fi
+    "${SCRIPT_DIR}/alert.sh" "MTGC backup STALE (${INSTANCE})" \
+        "S3 freshness check failed: ${reason}" || true
+    exit 1
+}
+
+# --- Configuration ----------------------------------------------------------
+
+# Not a skip. An instance with no off-site bucket has nothing off-box to be
+# fresh, and reporting that as OK is the defect this whole script exists to
+# remove.
+if [ -z "$BUCKET" ]; then
+    echo "backup-check: FAILED — MTGC_BACKUP_S3_BUCKET is unset for instance '${INSTANCE}';" \
+         "there is no off-site backup to verify. Set it in ${CONF_DIR}/${INSTANCE}.env." >&2
+    exit 1
+fi
+
+# The verification below runs either way; this only says which half is armed.
+if [ -z "$PING" ]; then
+    echo "backup-check: MTGC_BACKUP_PING_URL unset — verifying freshness anyway;" \
+         "the off-box dead-man's switch is NOT armed (instance: ${INSTANCE})." \
+         "To arm it: put the healthchecks.io ping URL in ${CONF_DIR}/${INSTANCE}.env."
+fi
+
+command -v aws >/dev/null 2>&1 \
+    || stale "the 'aws' CLI is not installed — the backup target cannot be queried at all"
+
+# --- Ask S3 what is actually there ------------------------------------------
+#
+# Every object's timestamp, size and key. Deliberately NOT `--query
+# 'sort_by(...)[-1]'`: the CLI paginates automatically and applies --query per
+# page, so a bucket that outgrows one page would silently return the newest
+# object OF EACH PAGE and the sort would be meaningless. A plain projection
+# concatenates correctly, and the sorting happens here.
+LISTING="$(aws s3api list-objects-v2 \
+    "${ENDPOINT_ARGS[@]}" \
+    --bucket "$BUCKET" \
+    --prefix "$PREFIX" \
+    --query 'Contents[].[LastModified,Size,Key]' \
+    --output text 2>&1)" \
+    || stale "could not list s3://${BUCKET}/${PREFIX} (credentials, network or bucket policy): $(printf '%s' "$LISTING" | tail -n1)"
+
+# LastModified is RFC3339 with a fixed +00:00 offset, so lexicographic order is
+# chronological order.
+LISTING="$(printf '%s\n' "$LISTING" | grep -E '^[0-9]{4}-[0-9]{2}-[0-9]{2}T' | sort || true)"
+
+if [ -z "$LISTING" ]; then
+    stale "s3://${BUCKET}/${PREFIX} contains NO objects — this instance is not backed up"
+fi
+
+NEWEST_LINE="$(printf '%s\n' "$LISTING" | tail -n1)"
+PREV_LINE="$(printf '%s\n' "$LISTING" | tail -n2 | head -n1)"
+
+read -r NEWEST_TS NEWEST_BYTES NEWEST_KEY <<<"$NEWEST_LINE"
+
+NEWEST_EPOCH="$(date -d "$NEWEST_TS" +%s 2>/dev/null)" \
+    || stale "could not parse the newest object's timestamp: ${NEWEST_TS}"
+AGE_HOURS=$(( ( $(date +%s) - NEWEST_EPOCH ) / 3600 ))
+
+# --- Freshness --------------------------------------------------------------
+
+if [ "$AGE_HOURS" -gt "$MAX_AGE_HOURS" ]; then
+    stale "newest backup ${NEWEST_KEY} is ${AGE_HOURS}h old (> ${MAX_AGE_HOURS}h threshold)"
+fi
+
+# --- Size: an absolute floor, then the comparison ---------------------------
+
+if [ "$NEWEST_BYTES" -lt "$MIN_BYTES" ]; then
+    stale "newest backup ${NEWEST_KEY} is only ${NEWEST_BYTES} bytes (< ${MIN_BYTES} floor) — not a backup"
+fi
+
+if [ "$NEWEST_LINE" != "$PREV_LINE" ]; then
+    read -r _ PREV_BYTES PREV_KEY <<<"$PREV_LINE"
+    # Integer arithmetic, so compute the allowed floor rather than a percentage
+    # of the observed drop.
+    MIN_ALLOWED=$(( PREV_BYTES * (100 - MAX_SHRINK_PCT) / 100 ))
+    if [ "$NEWEST_BYTES" -lt "$MIN_ALLOWED" ]; then
+        stale "newest backup ${NEWEST_KEY} is ${NEWEST_BYTES} bytes, down from ${PREV_BYTES} in ${PREV_KEY} (> ${MAX_SHRINK_PCT}% smaller) — content is missing from it"
+    fi
+    SIZE_NOTE="$(( NEWEST_BYTES / 1048576 )) MiB, previous $(( PREV_BYTES / 1048576 )) MiB"
+else
+    # One object total: nothing to compare against yet. Said out loud rather
+    # than passed over, because "the shrink check ran" and "there was only ever
+    # one backup" look identical in a green log otherwise.
+    SIZE_NOTE="$(( NEWEST_BYTES / 1048576 )) MiB, no previous backup to compare against"
+fi
+
+# --- Fresh: ping the monitor ------------------------------------------------
+
+echo "backup-check: OK — ${NEWEST_KEY} is ${AGE_HOURS}h old (<= ${MAX_AGE_HOURS}h), ${SIZE_NOTE}"
+if [ -z "$PING" ]; then
+    echo "backup-check: no monitor to ping — a dead box or a disabled timer would go unnoticed"
+else
+    curl -fsS -m 10 "$PING" >/dev/null 2>&1 \
+        || echo "backup-check: WARNING — monitor ping failed (will retry next run)" >&2
+fi

--- a/deploy/mtgc-alert@.service
+++ b/deploy/mtgc-alert@.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=MTGC failure alert for %i ({{INSTANCE}})
+# Fired via OnFailure= from the units worth hearing about. Pushes the failed
+# unit's journal tail to Pushover the moment it fails — fast, detailed, on-box.
+# It does NOT catch never-ran or box-down; that is the freshness check's
+# off-box monitor.
+#
+# %i is the FULL failed unit name (passed as mtgc-alert-{{INSTANCE}}@%n.service),
+# so one template alerts for any unit. It is rendered per instance, like every
+# other unit here, so a test instance's setup cannot repoint prod's alerting at
+# a test checkout.
+
+[Service]
+Type=oneshot
+# '-' makes the file optional so the unit installs cleanly before alerts.env
+# exists. alert.sh then fails loudly rather than dropping the alert silently.
+EnvironmentFile=-%h/.config/mtgc/alerts.env
+ExecStart=/bin/sh -c 'journalctl --user -u %i -n 20 --no-pager | bash {{REPO_DIR}}/deploy/alert.sh "MTGC unit FAILED: %i"'

--- a/deploy/mtgc-backup-check.service
+++ b/deploy/mtgc-backup-check.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=MTGC backup freshness check ({{INSTANCE}})
+# The dead-man's switch for the nightly backup (de-d8v). Verifies against S3
+# that a recent, plausibly-sized object actually landed, then pings the off-box
+# monitor. It does NOT run the backup and never writes to the bucket.
+After=network-online.target
+Wants=network-online.target
+# If the checker itself errors out — as opposed to finding a stale backup, which
+# it reports through its own channels — push the journal tail too.
+OnFailure=mtgc-alert-{{INSTANCE}}@%n.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'exec bash {{REPO_DIR}}/deploy/backup-check.sh {{INSTANCE}}'
+# One S3 list plus two curls. Generous, but a hung network call must eventually
+# fail the unit rather than sit there looking like a run in progress.
+TimeoutStartSec=120

--- a/deploy/mtgc-backup-check.timer
+++ b/deploy/mtgc-backup-check.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=MTGC backup freshness check timer ({{INSTANCE}})
+
+[Timer]
+# Every 6h. The off-box monitor expects a ping each run, so configure its period
+# at ~6h with a few hours of grace: one missed run — or a dead box, or a timer
+# nobody enabled — then alerts on its own. More frequent than the nightly backup
+# so a credentials break, which makes the freshness query itself fail, surfaces
+# within 6h instead of at the next 03:00.
+OnCalendar=*-*-* 00,06,12,18:30:00
+RandomizedDelaySec=300
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -234,14 +234,25 @@ fi
 SYSTEMD_USER_DIR="$HOME/.config/systemd/user"
 mkdir -p "$SYSTEMD_USER_DIR"
 
-for UNIT_PREFIX in mtgc-prices mtgc-sealed-catalog mtgc-backup mtgc-edhrec; do
+for UNIT_PREFIX in mtgc-prices mtgc-sealed-catalog mtgc-backup mtgc-backup-check mtgc-edhrec; do
     echo "==> Installing ${UNIT_PREFIX} timer"
     for EXT in service timer; do
         sed -e "s|{{INSTANCE}}|${INSTANCE}|g" \
+            -e "s|{{REPO_DIR}}|${REPO_DIR}|g" \
             "$REPO_DIR/deploy/${UNIT_PREFIX}.${EXT}" \
             > "${SYSTEMD_USER_DIR}/${UNIT_PREFIX}-${INSTANCE}.${EXT}"
     done
 done
+
+# The alert unit is a systemd instance template, not a timer: its %i is the name
+# of the unit that failed, supplied by the OnFailure= that fires it. Rendered
+# per MTGC instance like everything else, so setting up a test instance cannot
+# repoint prod's alerting at a test checkout.
+echo "==> Installing mtgc-alert template"
+sed -e "s|{{INSTANCE}}|${INSTANCE}|g" \
+    -e "s|{{REPO_DIR}}|${REPO_DIR}|g" \
+    "$REPO_DIR/deploy/mtgc-alert@.service" \
+    > "${SYSTEMD_USER_DIR}/mtgc-alert-${INSTANCE}@.service"
 
 systemctl --user daemon-reload
 
@@ -370,5 +381,6 @@ echo "  Logs:       journalctl --user -u $SERVICE_NAME -f"
 echo "  Prices:     systemctl --user enable --now mtgc-prices-${INSTANCE}.timer"
 echo "  Sealed:     systemctl --user enable --now mtgc-sealed-catalog-${INSTANCE}.timer"
 echo "  Backup:     systemctl --user enable --now mtgc-backup-${INSTANCE}.timer"
+echo "  Bkp check:  systemctl --user enable --now mtgc-backup-check-${INSTANCE}.timer"
 echo "  EDHREC:     systemctl --user enable --now mtgc-edhrec-${INSTANCE}.timer"
 echo "  Teardown:   bash deploy/teardown.sh $INSTANCE"

--- a/deploy/teardown.sh
+++ b/deploy/teardown.sh
@@ -35,12 +35,15 @@ echo "==> Tearing down $SERVICE_NAME..."
 
 # Stop and disable timers
 SYSTEMD_USER_DIR="$HOME/.config/systemd/user"
-for PREFIX in mtgc-prices mtgc-sealed-catalog mtgc-backup mtgc-edhrec; do
+for PREFIX in mtgc-prices mtgc-sealed-catalog mtgc-backup mtgc-backup-check mtgc-edhrec; do
     systemctl --user stop "${PREFIX}-${INSTANCE}.timer" 2>/dev/null || true
     systemctl --user disable "${PREFIX}-${INSTANCE}.timer" 2>/dev/null || true
     rm -f "${SYSTEMD_USER_DIR}/${PREFIX}-${INSTANCE}.service" \
           "${SYSTEMD_USER_DIR}/${PREFIX}-${INSTANCE}.timer"
 done
+# The alert template has no timer of its own — it is only ever fired by an
+# OnFailure=, so removing the units above leaves nothing that can start it.
+rm -f "${SYSTEMD_USER_DIR}/mtgc-alert-${INSTANCE}@.service"
 
 # Stop and disable
 systemctl --user stop "$SERVICE_NAME" 2>/dev/null || true

--- a/tests/test_backup_check.py
+++ b/tests/test_backup_check.py
@@ -1,0 +1,390 @@
+"""The backup freshness check must be seen going RED, not just green.
+
+`deploy/backup-check.sh` is the dead-man's switch for the nightly backup of
+mtgc-prod-data. A check that has only ever been observed passing is not known to
+work — that is the whole defect it exists to remove — so most of what is below
+drives it into each failure it claims to catch and asserts on the exit status,
+the message, and the requests that left the script.
+
+`aws` and `curl` are the script's only external calls, so both are stubbed with
+PATH shims that record their argv. That keeps the suite in the unit tier: no
+network, no bucket, no credentials, and no way for a test to touch the real
+backup target.
+"""
+
+import os
+import subprocess
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CHECK = REPO_ROOT / "deploy" / "backup-check.sh"
+ALERT = REPO_ROOT / "deploy" / "alert.sh"
+
+# Records argv, then replays a canned listing and exit code. AWS_STUB_RC is how
+# a broken-credentials / unreachable-S3 run is expressed.
+AWS_STUB = """#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$AWS_CALL_LOG"
+cat "$AWS_STUB_OUT"
+exit "${AWS_STUB_RC:-0}"
+"""
+
+CURL_STUB = """#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$CURL_CALL_LOG"
+exit 0
+"""
+
+PING_URL = "https://hc.example/deadbeef"
+PUSHOVER_URL = "https://pushover.example/messages.json"
+
+
+def s3_line(age_hours, size, key):
+    ts = datetime.now(timezone.utc) - timedelta(hours=age_hours)
+    return f"{ts.strftime('%Y-%m-%dT%H:%M:%S')}+00:00\t{size}\t{key}"
+
+
+# A healthy bucket: last night's backup and the one before it, both ~3 GB.
+HEALTHY = "\n".join(
+    [
+        s3_line(30, 3_183_156_942, "mtgc-prod/daily/mtgc-prod-20260810-030001.tar.gz"),
+        s3_line(6, 3_216_229_803, "mtgc-prod/daily/mtgc-prod-20260812-030001.tar.gz"),
+    ]
+)
+
+
+@pytest.fixture
+def check(tmp_path):
+    """Drive the real script against stubbed aws/curl and a throwaway config."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for name, body in (("aws", AWS_STUB), ("curl", CURL_STUB)):
+        stub = bin_dir / name
+        stub.write_text(body)
+        stub.chmod(0o755)
+
+    conf = tmp_path / "config"
+    conf.mkdir()
+    (conf / "alerts.env").write_text(
+        f"PUSHOVER_TOKEN=tok\nPUSHOVER_USER=usr\nPUSHOVER_API_URL={PUSHOVER_URL}\n"
+    )
+
+    aws_log = tmp_path / "aws.log"
+    curl_log = tmp_path / "curl.log"
+    aws_out = tmp_path / "aws.out"
+    aws_log.touch()
+    curl_log.touch()
+
+    class Check:
+        def __init__(self):
+            self.conf = conf
+
+        def configure(self, instance="prod", **settings):
+            """Write the instance env file the script reads."""
+            defaults = {
+                "MTGC_BACKUP_S3_BUCKET": "gantt-mtgc-backup",
+                "MTGC_BACKUP_PING_URL": PING_URL,
+            }
+            defaults.update(settings)
+            lines = [f"{k}={v}" for k, v in defaults.items() if v is not None]
+            (conf / f"{instance}.env").write_text("\n".join(lines) + "\n")
+
+        def run(self, listing=HEALTHY, rc=0, instance="prod"):
+            aws_out.write_text(listing + ("\n" if listing else ""))
+            if not (conf / "prod.env").exists():
+                self.configure()
+            env = dict(os.environ)
+            env.update(
+                PATH=f"{bin_dir}:{env['PATH']}",
+                MTGC_CONFIG_DIR=str(conf),
+                AWS_CALL_LOG=str(aws_log),
+                CURL_CALL_LOG=str(curl_log),
+                AWS_STUB_OUT=str(aws_out),
+                AWS_STUB_RC=str(rc),
+            )
+            return subprocess.run(
+                ["bash", str(CHECK), instance],
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+        @property
+        def aws_calls(self):
+            return aws_log.read_text().splitlines()
+
+        @property
+        def curl_calls(self):
+            return curl_log.read_text().splitlines()
+
+        def pinged(self, suffix=""):
+            return any(PING_URL + suffix in c for c in self.curl_calls)
+
+        @property
+        def alerted(self):
+            return any(PUSHOVER_URL in c for c in self.curl_calls)
+
+    return Check()
+
+
+# --- The green path ---------------------------------------------------------
+
+
+def test_fresh_backup_passes_and_pings_the_monitor(check):
+    result = check.run()
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "backup-check: OK" in result.stdout
+    assert check.pinged()
+    assert not check.pinged("/fail")
+    assert not check.alerted
+
+
+def test_the_ping_reports_the_object_it_actually_verified(check):
+    """The log has to name the object, or a green run says nothing checkable."""
+    result = check.run()
+
+    assert "mtgc-prod-20260812-030001.tar.gz" in result.stdout
+    assert "3067 MiB" in result.stdout
+
+
+# --- Every way it must go red ----------------------------------------------
+
+
+def test_stale_backup_fails_and_trips_the_dead_man(check):
+    """The failure this bead exists for: the upload silently stopped."""
+    result = check.run(listing=s3_line(70, 3_216_229_803, "mtgc-prod/daily/old.tar.gz"))
+
+    assert result.returncode == 1
+    assert "STALE" in result.stderr
+    assert "70h old" in result.stderr
+    assert check.pinged("/fail")
+    assert check.alerted
+
+
+def test_empty_prefix_fails(check):
+    """A bucket with nothing in it is the loudest possible failure, and the one
+    a job-ran check would call success."""
+    result = check.run(listing="")
+
+    assert result.returncode == 1
+    assert "NO objects" in result.stderr
+    assert check.pinged("/fail")
+
+
+def test_unreadable_bucket_fails_rather_than_passing_quietly(check):
+    """Broken credentials — the Jun 2026 pokedumpster failure. 'We could not
+    ask' must never land on the same side of the line as 'the answer is fine'."""
+    result = check.run(listing="An error occurred (AccessDenied)", rc=255)
+
+    assert result.returncode == 1
+    assert "could not list" in result.stderr
+    assert check.pinged("/fail")
+    assert check.alerted
+
+
+def test_zero_byte_backup_fails_the_size_floor(check):
+    result = check.run(
+        listing="\n".join(
+            [
+                s3_line(30, 3_183_156_942, "mtgc-prod/daily/yesterday.tar.gz"),
+                s3_line(6, 0, "mtgc-prod/daily/today.tar.gz"),
+            ]
+        )
+    )
+
+    assert result.returncode == 1
+    assert "0 bytes" in result.stderr
+    assert check.pinged("/fail")
+
+
+def test_truncated_backup_fails_against_the_previous_one(check):
+    """Fresh, non-trivially sized, and missing two thirds of the collection —
+    invisible to an age check and to any fixed floor low enough to be safe."""
+    result = check.run(
+        listing="\n".join(
+            [
+                s3_line(30, 3_183_156_942, "mtgc-prod/daily/yesterday.tar.gz"),
+                s3_line(6, 1_000_000_000, "mtgc-prod/daily/today.tar.gz"),
+            ]
+        )
+    )
+
+    assert result.returncode == 1
+    assert "content is missing" in result.stderr
+    assert check.pinged("/fail")
+
+
+def test_ordinary_growth_is_not_a_shrink(check):
+    """The shrink check must not fire on the normal night-to-night delta, or it
+    gets muted and stops being a check at all."""
+    result = check.run()
+
+    assert result.returncode == 0
+
+
+def test_a_single_backup_passes_but_says_it_had_nothing_to_compare(check):
+    result = check.run(listing=s3_line(6, 3_216_229_803, "mtgc-prod/daily/only.tar.gz"))
+
+    assert result.returncode == 0
+    assert "no previous backup to compare against" in result.stdout
+
+
+# --- No configuration may turn the check into a pass ------------------------
+
+
+def test_missing_bucket_fails_instead_of_skipping(check):
+    """An instance with no off-site target has no backup to be fresh. Printing
+    'skipping' and exiting 0 is indistinguishable, in a green unit, from a
+    verified backup — the exact regression pokedumpster booked as pd-1717."""
+    check.configure(MTGC_BACKUP_S3_BUCKET=None)
+    result = check.run()
+
+    assert result.returncode == 1
+    assert "MTGC_BACKUP_S3_BUCKET is unset" in result.stderr
+    assert check.aws_calls == []
+
+
+def test_an_unarmed_monitor_still_verifies_freshness(check):
+    """The ping URL gates the PING, never the verification."""
+    check.configure(MTGC_BACKUP_PING_URL=None)
+    result = check.run(listing=s3_line(70, 3_216_229_803, "mtgc-prod/daily/old.tar.gz"))
+
+    assert result.returncode == 1
+    assert "STALE" in result.stderr
+    assert check.alerted
+    assert not check.pinged("/fail")
+
+
+def test_an_unarmed_monitor_says_so_on_the_green_path(check):
+    check.configure(MTGC_BACKUP_PING_URL=None)
+    result = check.run()
+
+    assert result.returncode == 0
+    assert "NOT armed" in result.stdout
+    assert not check.pinged()
+
+
+def test_a_dropped_alert_does_not_hide_the_stale_backup(check):
+    """Pushover unconfigured: alert.sh fails, and the verdict is unaffected."""
+    (check.conf / "alerts.env").write_text(f"PUSHOVER_API_URL={PUSHOVER_URL}\n")
+    result = check.run(listing=s3_line(70, 3_216_229_803, "mtgc-prod/daily/old.tar.gz"))
+
+    assert result.returncode == 1
+    assert "reached nobody" in result.stderr
+    assert check.pinged("/fail")
+
+
+# --- It must not be able to damage what it watches --------------------------
+
+
+def test_the_only_aws_call_is_a_read(check):
+    check.run()
+
+    assert len(check.aws_calls) == 1
+    call = check.aws_calls[0]
+    assert call.startswith("s3api list-objects-v2 ")
+    assert "--bucket gantt-mtgc-backup" in call
+    assert "--prefix mtgc-prod/" in call
+
+
+def test_the_script_names_no_mutating_s3_operation(check):
+    """Belt and braces on the above: the shipped source contains no write."""
+    source = CHECK.read_text()
+    for verb in ("put-object", "delete-object", "s3 cp", "s3 mv", "s3 rm", "s3 sync"):
+        assert verb not in source
+
+
+def test_the_prefix_is_scoped_to_the_instance(check):
+    """A default prefix that reached the whole bucket would let one instance's
+    fresh backup vouch for another's."""
+    check.configure(instance="staging")
+    result = check.run(instance="staging")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "--prefix mtgc-staging/" in check.aws_calls[0]
+
+
+def test_a_missing_instance_config_is_not_a_pass(check):
+    """No env file at all — nothing configured, nothing to verify, not green."""
+    result = check.run(instance="staging")
+
+    assert result.returncode == 1
+    assert "instance 'staging'" in result.stderr
+
+
+# --- alert.sh ---------------------------------------------------------------
+
+
+def test_alert_fails_when_it_cannot_reach_anyone(tmp_path):
+    """Asked to alert and unable to alert is a failure, not a no-op."""
+    result = subprocess.run(
+        ["bash", str(ALERT), "title", "message"],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PUSHOVER_TOKEN": "", "PUSHOVER_USER": ""},
+    )
+
+    assert result.returncode == 1
+    assert "reached nobody" in result.stderr
+
+
+def test_alert_treats_the_scaffolded_placeholder_as_unset(tmp_path):
+    result = subprocess.run(
+        ["bash", str(ALERT), "title", "message"],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PUSHOVER_TOKEN": "CHANGE_ME", "PUSHOVER_USER": "CHANGE_ME"},
+    )
+
+    assert result.returncode == 1
+    assert "reached nobody" in result.stderr
+
+
+# --- The units ---------------------------------------------------------------
+
+
+def test_units_are_installed_and_rendered(tmp_path):
+    """setup.sh must actually install the check, or it ships inert."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    (bin_dir / "podman").write_text(
+        "#!/usr/bin/env bash\ncase \"$1\" in volume) exit 1 ;; esac\nexit 0\n"
+    )
+    for name in ("systemctl", "loginctl"):
+        (bin_dir / name).write_text("#!/usr/bin/env bash\nexit 0\n")
+    for name in ("podman", "systemctl", "loginctl"):
+        (bin_dir / name).chmod(0o755)
+
+    home = tmp_path / "home"
+    home.mkdir()
+    env = dict(os.environ)
+    env.update(
+        HOME=str(home),
+        PATH=f"{bin_dir}:{env['PATH']}",
+        XDG_RUNTIME_DIR=str(tmp_path / "run"),
+    )
+    result = subprocess.run(
+        ["bash", str(REPO_ROOT / "deploy" / "setup.sh"), "inst", "8099"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    units = home / ".config/systemd/user"
+    service = (units / "mtgc-backup-check-inst.service").read_text()
+    timer = (units / "mtgc-backup-check-inst.timer").read_text()
+    alert = (units / "mtgc-alert-inst@.service").read_text()
+
+    # No placeholder survives into an installed unit — an unrendered {{REPO_DIR}}
+    # is a unit that fails only when the timer first fires, weeks later.
+    for unit in (service, timer, alert):
+        assert "{{" not in unit
+
+    assert f"{REPO_ROOT}/deploy/backup-check.sh inst" in service
+    assert "OnFailure=mtgc-alert-inst@%n.service" in service
+    assert "WantedBy=timers.target" in timer
+    assert f"{REPO_ROOT}/deploy/alert.sh" in alert


### PR DESCRIPTION
## Summary
- Adds `deploy/backup-check.sh`: verifies the nightly `mtgc-prod-data` S3 backup is actually FRESH (not just that the cron ran) — lists the instance's S3 prefix read-only, fails on list error, zero objects, newest object older than `MTGC_BACKUP_MAX_AGE_HOURS` (default 30h), newest under `MTGC_BACKUP_MIN_BYTES` (default 1 MiB), or a >`MTGC_BACKUP_MAX_SHRINK_PCT` (default 10%) size drop vs. the previous object. Mirrors pokedumpster's `backup-check.sh` "liveness is NOT freshness" lesson, adapted from Litestream-snapshot-listing to plain S3 object listing (deckdumpster's backup is a nightly `aws s3 sync` of tarballs, not continuous replication).
- Adds `deploy/alert.sh`: Pushover push, net new for this repo (mirrors pokedumpster's).
- Adds `deploy/mtgc-backup-check.{service,timer}` (6-hourly) and `deploy/mtgc-alert@.service`, rendered per-instance via `setup.sh`'s existing `{{INSTANCE}}` install loop so a test instance can never repoint prod alerting.
- Adds `tests/test_backup_check.py` (20 tests, PATH-shimmed aws/curl).
- `setup.sh`/`teardown.sh` updated to install/remove the new units.

## Verification (against the REAL gantt-mtgc-backup bucket, read-only — nothing written)
- GREEN: newest object `mtgc-prod/daily/mtgc-prod-20260812-030001.tar.gz`, age 1h, 3067 MiB (previous 3035 MiB). Monitor pinged.
- RED (stale): pointed at `mtgc-prod/weekly/`, newest object 2425h old → exit 1, `/fail` ping + Pushover both observed arriving.
- RED (empty prefix): exit 1, "contains NO objects".
- RED (bad AWS profile): exit 1, profile-not-found surfaced.
- RED (nonexistent bucket): exit 1, `NoSuchBucket` surfaced.
- RED (no bucket configured): exit 1 — explicitly not a silent skip.
- Read-only sufficiency confirmed: ran green using an assume-role session scoped to `s3:ListBucket` only; the same session gets 403 on `HeadObject`, so it cannot read a backup's bytes, only list them. No mutating call attempted against the real bucket at any point.

## Found while verifying (filed separately, not fixed by this PR)
`gantt-mtgc-backup` has no object for 2026-08-08 or 2026-08-11 — two real nightly backups silently never reached S3 in the last week. This checker would have caught both. Tracked as de-r0v, needs Ryan's attention (root cause is prod-side, out of scope here).

## Non-goals / guardrails honored
- `backup.sh` and the backup schedule are untouched.
- No restore drill performed.
- Nothing on `systemd-mtgc-prod`, the `mtgc-prod-data` volume, or a prod checkout was touched — all verification above was read-only S3 listing against the real bucket, independent of the running prod service.
- **Not armed on prod.** This PR only adds the tooling; enabling the timer on the real prod instance is Ryan's call.

🤖 Generated with Gas Town (dementus/mayor)