### PR TITLE
feat(growth): materialize collection_value_history for O(days) unfiltered growth chart (de-tz9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,9 @@ collection_views (id PK)         — saved filters + column layout for the colle
 - `mtgjson_uuid_map`, `mtgjson_printings`, `mtgjson_booster_sheets`, `mtgjson_booster_configs`, `tcgplayer_groups` — MTGJSON / TCGPlayer reference data.
 - `edhrec_recommendations` — populated by the `mtgc-edhrec` timer.
 - `prices`, `price_fetch_log` — append-only price time series and ingest log.
+- `collection_value_history`, `collection_value_history_meta`, `collection_rev` — the
+  materialized growth series, what it was built from, and the trigger-maintained stamp
+  that says when the collection last changed. See "Growth chart" under Key patterns.
 
 Schema version is `SCHEMA_VERSION` in `db/schema.py` — read the constant, never a
 number written down elsewhere. Auto-migrations live in the same file, and
@@ -151,6 +154,27 @@ Default DB location: `~/.mtgc/collection.sqlite` (override: `--db` or `MTGC_DB`)
 All filtering is one Scryfall-style query bar (`?q=...`). Standard Scryfall keywords (`c`, `id`, `t`, `o`, `m`, `mv`, `pow`, `tou`, `loy`, `r`, `s`, `cn`, `a`, `ft`, `kw`, `f`, `year`, `layout`, `produces`, `is:`, `has:`) plus collection-only extensions (`status:`, `added:`, `price:`, `deck:`, `binder:`, `order:`, `direction:`, `is:unassigned` / `is:decked` / `is:bindered` / `is:wanted` / `is:unowned`). Default when no `status:` is present: `status:owned OR status:ordered`. `is:unowned` flips the query to a LEFT JOIN against `printings` so unowned cards appear (lets users add a card from the modal). Operators `:`, `=`, `!=`, `>`, `>=`, `<`, `<=` are accepted on numeric/date keywords; the autocomplete suggests both keywords and per-keyword values, with corpus-driven suggestions (artist names, set codes, year/month buckets present in the user's collection) served by `/api/search-suggest`. `added:` resolves dates in the browser's local timezone (the page sends `Intl.DateTimeFormat().resolvedOptions().timeZone` on every `/api/collection` request).
 
 Search compiler lives in `mtg_collector/search/`: `grammar.py` (tokeniser), `transformer.py` (parser → AST), `compiler.py` (AST → SQL), `keywords.py` (canonical name registry), `dates.py` (timezone-aware date parsing).
+
+### Growth chart
+`/api/collection/growth` has two routes to the same numbers, and `mtg_collector/db/growth.py`
+holds both. A **query** is aggregated day by day inside SQLite from `collection` + `prices`;
+its cost is dominated by reading every price row every held card has ever had, which grows
+with the day axis. The **unfiltered** series is instead read out of `collection_value_history`
+— O(days), measured 15.4 s → 0.5 ms on a 5.1 M-price-row / 15 k-card / 365-day rig, output
+bit-identical.
+
+The materialized table serves the unfiltered case *only*: a filter changes which collection
+rows are summed, and there is no materializing one table per filter. That is an explicit
+branch on "was a query supplied?", not a fast path with a fallback — a filtered request
+never consults the table and so never has a miss to recover from. **Do not add a rule that
+tries to serve some filters from it.**
+
+Staleness is decided against three recorded facts, never a heuristic: `collection_rev`
+(bumped by triggers on `collection`, and only for `printing_id` / `finish` / `acquired_at` /
+`status` — a binder move or an edited note is not in the series), the last `price_fetch_log`
+id, and the last day stored. `mtg data fetch-prices` rebuilds after each import; the endpoint
+rebuilds on the request that first finds the table stale, because otherwise one added card
+would leave the chart on the slow route until the next 06:00 timer run.
 
 ### Card data access policy
 All runtime lookups MUST use the local database. Never Scryfall API. See `architecture/CARD_DATA_ACCESS.md`. The Scryfall API is only used by `mtg setup` / `mtg cache all` to populate the DB.

--- a/mtg_collector/cli/crack_pack_server.py
+++ b/mtg_collector/cli/crack_pack_server.py
@@ -2752,205 +2752,27 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         else:
             self._send_json({"available": False, "last_modified": None})
 
-    # Aggregates the whole growth series inside SQLite so only one row per day
-    # crosses the driver boundary (previously ~1.1M price rows did).
-    #
-    # Shape, in stages (each a TEMP table so it is computed exactly once):
-    #   pop_t     - the filtered population, one row per collection entry.
-    #   keys_t    - distinct (set_code, collector_number, price_type); rowid = kid.
-    #   carry_t   - per (key, source), the single most recent price strictly
-    #               before the window. See "Windowing" below.
-    #   grp_iv_t  - per key, the cumulative quantity held and the day range that
-    #               quantity is valid for (SUM/LEAD windows over acquisition days).
-    #   price_iv_t- per (key, source), each price and the day range it is the
-    #               most recent observation for. LEAD(observed_at) over the price
-    #               series IS the forward-fill, expressed declaratively.
-    #   seg_t     - grp_iv_t x price_iv_t intersected on key and overlapping day
-    #               range: "this many copies at this price for these days".
-    # The final statement turns segments into a per-day difference array and
-    # running-sums it over the day spine, which is O(segments) rather than
-    # O(groups x days).
-    #
-    # Windowing (`?range=` days, 0 = full history)
-    # -------------------------------------------
-    # Day 0 is the window start, not the first acquisition. The series is
-    # cumulative, so the window cannot simply drop everything before it — the
-    # carried-in position has to be reconstructed at day 0:
-    #
-    #   quantity - acquisition day offsets are clamped to >= 0, so every
-    #              pre-window acquisition collapses onto day 0 and the existing
-    #              GROUP BY sums them into the day-0 opening quantity.
-    #   price    - the price in effect at the window start is usually OLDER than
-    #              the window, so `observed_at >= start` alone would zero out
-    #              those cards until their next observation. carry_t adds back
-    #              exactly one row per (key, source): the latest price strictly
-    #              before the window, given sentinel day -1 so it sorts ahead of
-    #              every in-window row and then clamps to day 0. Its real date is
-    #              irrelevant once clamped, which is why only `price` is fetched.
-    #
-    # carry_t is a seek (ORDER BY observed_at DESC LIMIT 1 on the unique index),
-    # so it costs O(keys) regardless of how deep the price history goes; a
-    # GROUP BY ... MAX(observed_at) formulation would instead scan every
-    # pre-window row and reintroduce the O(history) cost this change removes.
-    #
-    # Days are integer offsets from the window start, not date strings:
-    # the window sort is the dominant cost and sorting one INTEGER beats sorting
-    # five TEXT columns by a wide margin. Dates are rebuilt for the 163-ish
-    # output rows only.
-    #
-    # Money is summed as INTEGER cents. Every `prices.price` is exactly two
-    # decimal places, so `ROUND(qty * price * 100)` is exact and the running sum
-    # carries no float drift across ~1M deltas.
-
-    _GROWTH_POP_SQL = """
-        CREATE TEMP TABLE pop_t AS
-        SELECT p.set_code AS set_code,
-               p.collector_number AS cn,
-               CASE WHEN c.finish IN ('foil', 'etched') THEN 'foil' ELSE 'normal' END AS price_type,
-               substr(c.acquired_at, 1, 10) AS acq_date
-        FROM collection c
-        JOIN printings p ON c.printing_id = p.printing_id
-        JOIN cards card ON p.oracle_id = card.oracle_id
-        JOIN sets s ON p.set_code = s.set_code
-        LEFT JOIN orders o ON c.order_id = o.id
-        LEFT JOIN deck_cards dc ON dc.collection_id = c.id
-        LEFT JOIN decks d ON dc.deck_id = d.id
-        LEFT JOIN binders b ON c.binder_id = b.id
-        {extra_joins_sql}
-        WHERE ({where_sql}) AND c.acquired_at IS NOT NULL
-        GROUP BY c.id
-    """
-
-    _GROWTH_GRP_SQL = """
-        CREATE TEMP TABLE grp_iv_t AS
-        WITH grp AS (
-            SELECT k.rowid AS kid,
-                   MAX(MIN(CAST(julianday(pop_t.acq_date) - julianday(?) AS INTEGER), ?), 0) AS day,
-                   COUNT(*) AS qty
-            FROM pop_t
-            JOIN keys_t k ON k.set_code = pop_t.set_code
-                         AND k.cn = pop_t.cn
-                         AND k.price_type = pop_t.price_type
-            GROUP BY kid, day
-        )
-        SELECT kid,
-               day AS from_d,
-               LEAD(day) OVER w AS to_d,
-               qty,
-               SUM(qty) OVER w AS cum
-        FROM grp
-        WINDOW w AS (PARTITION BY kid ORDER BY day)
-    """
-
-    # `source` is folded to an integer bit (1 = tcgplayer, 0 = cardkingdom) so the
-    # window partition is a single INTEGER expression.
-
-    # The carried-in price: per (key, source) the latest observation strictly
-    # before the window start. One index seek per row of `keys_t` x 2 sources --
-    # the correlated ORDER BY ... DESC LIMIT 1 lets SQLite land on the end of the
-    # range and step back once, so this does not scan pre-window history.
-    _GROWTH_CARRY_SQL = """
-        CREATE TEMP TABLE carry_t AS
-        SELECT kid, src, price FROM (
-            SELECT k.rowid AS kid,
-                   s.src AS src,
-                   (SELECT pr.price
-                      FROM prices pr
-                     WHERE pr.set_code = k.set_code
-                       AND pr.collector_number = k.cn
-                       AND pr.source = s.nm
-                       AND pr.price_type = k.price_type
-                       AND pr.observed_at < ?
-                     ORDER BY pr.observed_at DESC
-                     LIMIT 1) AS price
-            FROM keys_t k
-            CROSS JOIN (SELECT 'tcgplayer' AS nm, 1 AS src
-                        UNION ALL SELECT 'cardkingdom', 0) s
-        )
-        WHERE price IS NOT NULL
-    """
-
-    # LEAD orders on the raw (possibly -1) day so the carried-in row is
-    # unambiguously first; only the emitted `from_d` is clamped into the window.
-    # A carried-in row followed by an observation on day 0 yields the empty
-    # interval [0, 0), whose +cents/-cents deltas cancel.
-    _GROWTH_PRICE_SQL = """
-        CREATE TEMP TABLE price_iv_t AS
-        SELECT kid, src, MAX(from_d, 0) AS from_d,
-               LEAD(from_d) OVER (PARTITION BY kid * 2 + src ORDER BY from_d) AS to_d,
-               price
-        FROM (
-            SELECT k.rowid AS kid,
-                   (pr.source = 'tcgplayer') AS src,
-                   CAST(julianday(pr.observed_at) - julianday(?) AS INTEGER) AS from_d,
-                   pr.price AS price
-            FROM keys_t k
-            JOIN prices pr ON pr.set_code = k.set_code
-                          AND pr.collector_number = k.cn
-                          AND pr.price_type = k.price_type
-            WHERE pr.source IN ('tcgplayer', 'cardkingdom')
-              AND pr.observed_at >= ?
-            UNION ALL
-            SELECT kid, src, -1 AS from_d, price FROM carry_t
-        )
-    """
-
-    _GROWTH_SEG_SQL = """
-        CREATE TEMP TABLE seg_t AS
-        SELECT pv.src AS src,
-               MAX(gi.from_d, pv.from_d) AS s,
-               CASE WHEN gi.to_d IS NULL THEN pv.to_d
-                    WHEN pv.to_d IS NULL THEN gi.to_d
-                    ELSE MIN(gi.to_d, pv.to_d) END AS e,
-               CAST(ROUND(gi.cum * pv.price * 100) AS INTEGER) AS cents
-        FROM price_iv_t pv
-        JOIN grp_iv_t gi ON gi.kid = pv.kid
-                        AND (gi.to_d IS NULL OR pv.from_d < gi.to_d)
-                        AND (pv.to_d IS NULL OR gi.from_d < pv.to_d)
-    """
-
-    _GROWTH_SERIES_SQL = """
-        WITH RECURSIVE days(dn) AS (
-            SELECT 0 UNION ALL SELECT dn + 1 FROM days WHERE dn < ?
-        ),
-        delta AS (
-            SELECT s AS dn, src, cents FROM seg_t
-            UNION ALL
-            SELECT e AS dn, src, -cents FROM seg_t WHERE e IS NOT NULL
-        ),
-        dd AS (
-            SELECT dn,
-                   SUM(CASE WHEN src = 1 THEN cents ELSE 0 END) AS dt,
-                   SUM(CASE WHEN src = 0 THEN cents ELSE 0 END) AS dc
-            FROM delta GROUP BY dn
-        ),
-        cnt AS (
-            SELECT from_d AS dn, SUM(qty) AS q FROM grp_iv_t GROUP BY from_d
-        )
-        SELECT date(?, '+' || dy.dn || ' day') AS d,
-               SUM(COALESCE(cnt.q, 0)) OVER (ORDER BY dy.dn) AS n,
-               SUM(COALESCE(dd.dt, 0)) OVER (ORDER BY dy.dn) AS tcg_cents,
-               SUM(COALESCE(dd.dc, 0)) OVER (ORDER BY dy.dn) AS ck_cents
-        FROM days dy
-        LEFT JOIN dd ON dd.dn = dy.dn
-        LEFT JOIN cnt ON cnt.dn = dy.dn
-        ORDER BY dy.dn
-    """
-
     def _api_collection_growth(self, params: dict):
         """Return daily (count, tcg_value, ck_value) series for the filtered collection.
 
-        Mirrors the search-filter parsing in `/api/collection`, then aggregates
-        each day of the requested window inside SQLite:
-          - cards acquired by that date (count)
-          - historical price on that date for each held card (value)
+        Mirrors the search-filter parsing in `/api/collection`. A query is
+        aggregated day by day inside SQLite; the *unfiltered* series is instead
+        read out of the materialized `collection_value_history` table, which is
+        O(days) rather than O(price rows the collection has ever had).
+
+        The two are separate branches on "was a query supplied?", not a fast path
+        that falls back — there is one table and a filter would need a different
+        one, so a filtered request never consults it and never has a miss to
+        recover from. The unfiltered branch rebuilds the table when it is stale
+        and then reads it, so the answer always comes from freshly-valid data.
 
         `?range=` is the window length in days (0 / absent = full history). The
         window is the last `range` days ending today; it is clamped to the first
         acquisition, so asking for more days than the collection has is the same
         as asking for everything. The series is cumulative and every point is
         absolute, so a windowed response is bit-identical to the corresponding
-        slice of the full-history response.
+        slice of the full-history response — which is also what lets the stored
+        full history serve a windowed request by slicing.
 
         Prices forward-fill: the most recent known price <= D is used, including
         observations from before the window. Cards with no price on/before D
@@ -2961,11 +2783,12 @@ class CrackPackHandler(BaseHTTPRequestHandler):
         `earliest` is the first acquisition in the whole filtered collection,
         independent of the window, so the UI can size its range pills.
         """
-        import datetime as _dt
-
+        from mtg_collector.db import growth
         from mtg_collector.search import SearchError, compile_query, parse_query
 
-        q = params.get("q", [""])[0]
+        # Stripped, so a query bar holding nothing but spaces is the unfiltered
+        # case it renders as rather than a filter that happens to match all.
+        q = params.get("q", [""])[0].strip()
         tz = params.get("tz", [""])[0] or None
         range_days = int(params.get("range", ["0"])[0] or 0)
 
@@ -2982,22 +2805,18 @@ class CrackPackHandler(BaseHTTPRequestHandler):
                 self._send_json({"error": str(e), "position": e.position}, 400)
                 return
 
-        empty = {
-            "dates": [], "counts": [], "tcg_values": [], "ck_values": [], "earliest": None,
-        }
-
         # is:unowned makes no sense for a growth chart — ignore.
         if compiled and compiled.include_unowned:
-            self._send_json(empty)
+            self._send_json(dict(growth.EMPTY_SERIES))
             return
 
         # Match /api/collection's status default
         has_status = compiled and compiled.has_status_filter
         if not has_status:
             if where_sql == "1=1":
-                where_sql = "c.status IN ('owned', 'ordered')"
+                where_sql = growth.UNFILTERED_WHERE
             else:
-                where_sql = f"c.status IN ('owned', 'ordered') AND ({where_sql})"
+                where_sql = f"{growth.UNFILTERED_WHERE} AND ({where_sql})"
 
         # Conditional joins (mirrors /api/collection's default template — the
         # collection-anchored one, since growth is always about owned rows).
@@ -3015,59 +2834,22 @@ class CrackPackHandler(BaseHTTPRequestHandler):
 
         conn = self._get_conn()
         try:
-            conn.execute(
-                self._GROWTH_POP_SQL.format(
-                    extra_joins_sql=extra_joins_sql, where_sql=where_sql
-                ),
-                sql_params,
-            )
-
-            # Date axis: window start -> today (UTC). `acquired_at` is ISO 8601
-            # UTC, so the first 10 chars are a UTC date.
-            today = _dt.datetime.now(_dt.timezone.utc).date().isoformat()
-            earliest, end_d = conn.execute(
-                "SELECT MIN(acq_date),"
-                " CASE WHEN MIN(acq_date) > ? THEN MIN(acq_date) ELSE ? END"
-                " FROM pop_t",
-                (today, today),
-            ).fetchone()
-            if earliest is None:
-                self._send_json(empty)
-                return
-
-            # The window is the last `range_days` days ending at end_d, clamped
-            # to the first acquisition — a range wider than the collection's own
-            # span degrades to full history rather than padding empty days.
-            start_d = earliest
-            if range_days > 0:
-                win_start = (
-                    _dt.date.fromisoformat(end_d) - _dt.timedelta(days=range_days)
-                ).isoformat()
-                if win_start > start_d:
-                    start_d = win_start
-            end_dn = (
-                _dt.date.fromisoformat(end_d) - _dt.date.fromisoformat(start_d)
-            ).days
-
-            conn.execute(
-                "CREATE TEMP TABLE keys_t AS"
-                " SELECT DISTINCT set_code, cn, price_type FROM pop_t"
-            )
-            conn.execute(self._GROWTH_CARRY_SQL, (start_d,))
-            conn.execute(self._GROWTH_GRP_SQL, (start_d, end_dn))
-            conn.execute(self._GROWTH_PRICE_SQL, (start_d, start_d))
-            conn.execute(self._GROWTH_SEG_SQL)
-            rows = conn.execute(self._GROWTH_SERIES_SQL, (end_dn, start_d)).fetchall()
+            if q:
+                result = growth.compute_series(
+                    conn,
+                    where_sql=where_sql,
+                    params=sql_params,
+                    extra_joins_sql=extra_joins_sql,
+                    range_days=range_days,
+                )
+            else:
+                if not growth.history_is_current(conn):
+                    growth.rebuild_history(conn)
+                result = growth.read_history(conn, range_days)
         finally:
             conn.close()
 
-        self._send_json({
-            "dates": [r["d"] for r in rows],
-            "counts": [r["n"] for r in rows],
-            "tcg_values": [r["tcg_cents"] / 100.0 for r in rows],
-            "ck_values": [r["ck_cents"] / 100.0 for r in rows],
-            "earliest": earliest,
-        })
+        self._send_json(result)
 
     def _api_price_history(self, set_code: str, collector_number: str):
         """Return full price time series for a card."""

--- a/mtg_collector/cli/data_cmd.py
+++ b/mtg_collector/cli/data_cmd.py
@@ -627,12 +627,28 @@ def _fetch_prices(force: bool = False):
     print(f"Done! AllPricesToday.json ({size_mb:.0f} MB) saved to: {dest}")
 
     # Auto-import into SQLite
+    from mtg_collector.db.connection import get_db_path
+    db_path = get_db_path()
     try:
-        from mtg_collector.db.connection import get_db_path
-        db_path = get_db_path()
         import_prices(db_path)
     except Exception as e:
         print(f"Warning: auto-import failed: {e}", file=sys.stderr)
+
+    # Rebuild the materialized growth series. The import above is exactly what
+    # makes it stale — new observations change what the collection was worth on
+    # the days already plotted — and this is a scheduled job, so it is the right
+    # place to pay for a full-history aggregation instead of leaving it to the
+    # first person to open the chart. Goes through get_connection() rather than
+    # import_prices' connection: prices are written to the shared reference DB,
+    # which has no `collection` to aggregate.
+    from mtg_collector.db.connection import get_connection
+    from mtg_collector.db.growth import rebuild_history
+    from mtg_collector.db.schema import init_db
+
+    conn = get_connection(db_path)
+    init_db(conn)
+    days = rebuild_history(conn)
+    print(f"  Collection value history: {days} day(s) materialized")
 
 
 def _ensure_uuid_map(conn: sqlite3.Connection):

--- a/mtg_collector/db/growth.py
+++ b/mtg_collector/db/growth.py
@@ -1,0 +1,460 @@
+"""Daily (count, tcg_value, ck_value) series for the collection.
+
+Two routes to the same numbers:
+
+  * ``compute_series()`` aggregates the series inside SQLite from ``collection``
+    and ``prices``.  It honours an arbitrary search filter, and its cost is
+    dominated by reading every price row every held card ever had — which grows
+    with the day axis, not with the number of points plotted.
+  * ``read_history()`` reads the materialized ``collection_value_history``
+    table, which is O(days).
+
+The materialized table exists for the **unfiltered** series only.  A filter
+changes which collection rows are summed, and there is no way to materialize one
+table per possible filter, so a filtered request must go the computed route.
+Nothing about that is a fallback: `_api_collection_growth` branches on whether a
+query was supplied, and the two branches are separate code paths, not one path
+retrying the other.
+
+``rebuild_history()`` is the bridge: it runs the computed route unfiltered over
+full history and stores the result.  Two callers, for the two ways the stored
+series goes out of date:
+
+  * the price fetch (`mtg data fetch-prices`, i.e. the ``mtgc-prices`` timer) —
+    new observations change what the series is worth on the days it covers, and
+    the day axis has advanced;
+  * the endpoint itself, on the request that first finds the table stale —
+    otherwise a single card added to the collection would leave the chart on the
+    slow route until the next 06:00 timer run, which for this app is most of the
+    time.
+
+Staleness is decided by ``history_is_current()`` against three recorded facts,
+never by a heuristic: the collection revision (see ``collection_rev``), the id of
+the last price import, and the last day the stored series covers.
+"""
+
+import datetime as _dt
+import sqlite3
+
+#: The population the materialized table describes, and the default the endpoint
+#: applies when the query carries no `status:` of its own.  One definition: a
+#: materialized series that summed a different set of rows than the computed one
+#: would be wrong in a way no test of either alone could see.
+UNFILTERED_WHERE = "c.status IN ('owned', 'ordered')"
+
+#: Staging tables compute_series() builds.  Dropped before and after each run:
+#: the endpoint gets a fresh connection per request, but the price timer reuses
+#: the process-wide cached connection, where a leftover would collide.
+_TEMP_TABLES = ("pop_t", "keys_t", "carry_t", "grp_iv_t", "price_iv_t", "seg_t")
+
+# Aggregates the whole growth series inside SQLite so only one row per day
+# crosses the driver boundary (previously ~1.1M price rows did).
+#
+# Shape, in stages (each a TEMP table so it is computed exactly once):
+#   pop_t     - the filtered population, one row per collection entry.
+#   keys_t    - distinct (set_code, collector_number, price_type); rowid = kid.
+#   carry_t   - per (key, source), the single most recent price strictly
+#               before the window. See "Windowing" below.
+#   grp_iv_t  - per key, the cumulative quantity held and the day range that
+#               quantity is valid for (SUM/LEAD windows over acquisition days).
+#   price_iv_t- per (key, source), each price and the day range it is the
+#               most recent observation for. LEAD(observed_at) over the price
+#               series IS the forward-fill, expressed declaratively.
+#   seg_t     - grp_iv_t x price_iv_t intersected on key and overlapping day
+#               range: "this many copies at this price for these days".
+# The final statement turns segments into a per-day difference array and
+# running-sums it over the day spine, which is O(segments) rather than
+# O(groups x days).
+#
+# Windowing (`?range=` days, 0 = full history)
+# -------------------------------------------
+# Day 0 is the window start, not the first acquisition. The series is
+# cumulative, so the window cannot simply drop everything before it — the
+# carried-in position has to be reconstructed at day 0:
+#
+#   quantity - acquisition day offsets are clamped to >= 0, so every
+#              pre-window acquisition collapses onto day 0 and the existing
+#              GROUP BY sums them into the day-0 opening quantity.
+#   price    - the price in effect at the window start is usually OLDER than
+#              the window, so `observed_at >= start` alone would zero out
+#              those cards until their next observation. carry_t adds back
+#              exactly one row per (key, source): the latest price strictly
+#              before the window, given sentinel day -1 so it sorts ahead of
+#              every in-window row and then clamps to day 0. Its real date is
+#              irrelevant once clamped, which is why only `price` is fetched.
+#
+# carry_t is a seek (ORDER BY observed_at DESC LIMIT 1 on the unique index),
+# so it costs O(keys) regardless of how deep the price history goes; a
+# GROUP BY ... MAX(observed_at) formulation would instead scan every
+# pre-window row and reintroduce the O(history) cost this change removes.
+#
+# Days are integer offsets from the window start, not date strings:
+# the window sort is the dominant cost and sorting one INTEGER beats sorting
+# five TEXT columns by a wide margin. Dates are rebuilt for the 163-ish
+# output rows only.
+#
+# Money is summed as INTEGER cents. Every `prices.price` is exactly two
+# decimal places, so `ROUND(qty * price * 100)` is exact and the running sum
+# carries no float drift across ~1M deltas.  The materialized table stores the
+# same cents for the same reason.
+
+_POP_SQL = """
+    CREATE TEMP TABLE pop_t AS
+    SELECT p.set_code AS set_code,
+           p.collector_number AS cn,
+           CASE WHEN c.finish IN ('foil', 'etched') THEN 'foil' ELSE 'normal' END AS price_type,
+           substr(c.acquired_at, 1, 10) AS acq_date
+    FROM collection c
+    JOIN printings p ON c.printing_id = p.printing_id
+    JOIN cards card ON p.oracle_id = card.oracle_id
+    JOIN sets s ON p.set_code = s.set_code
+    LEFT JOIN orders o ON c.order_id = o.id
+    LEFT JOIN deck_cards dc ON dc.collection_id = c.id
+    LEFT JOIN decks d ON dc.deck_id = d.id
+    LEFT JOIN binders b ON c.binder_id = b.id
+    {extra_joins_sql}
+    WHERE ({where_sql}) AND c.acquired_at IS NOT NULL
+    GROUP BY c.id
+"""
+
+_GRP_SQL = """
+    CREATE TEMP TABLE grp_iv_t AS
+    WITH grp AS (
+        SELECT k.rowid AS kid,
+               MAX(MIN(CAST(julianday(pop_t.acq_date) - julianday(?) AS INTEGER), ?), 0) AS day,
+               COUNT(*) AS qty
+        FROM pop_t
+        JOIN keys_t k ON k.set_code = pop_t.set_code
+                     AND k.cn = pop_t.cn
+                     AND k.price_type = pop_t.price_type
+        GROUP BY kid, day
+    )
+    SELECT kid,
+           day AS from_d,
+           LEAD(day) OVER w AS to_d,
+           qty,
+           SUM(qty) OVER w AS cum
+    FROM grp
+    WINDOW w AS (PARTITION BY kid ORDER BY day)
+"""
+
+# `source` is folded to an integer bit (1 = tcgplayer, 0 = cardkingdom) so the
+# window partition is a single INTEGER expression.
+
+# The carried-in price: per (key, source) the latest observation strictly
+# before the window start. One index seek per row of `keys_t` x 2 sources --
+# the correlated ORDER BY ... DESC LIMIT 1 lets SQLite land on the end of the
+# range and step back once, so this does not scan pre-window history.
+_CARRY_SQL = """
+    CREATE TEMP TABLE carry_t AS
+    SELECT kid, src, price FROM (
+        SELECT k.rowid AS kid,
+               s.src AS src,
+               (SELECT pr.price
+                  FROM prices pr
+                 WHERE pr.set_code = k.set_code
+                   AND pr.collector_number = k.cn
+                   AND pr.source = s.nm
+                   AND pr.price_type = k.price_type
+                   AND pr.observed_at < ?
+                 ORDER BY pr.observed_at DESC
+                 LIMIT 1) AS price
+        FROM keys_t k
+        CROSS JOIN (SELECT 'tcgplayer' AS nm, 1 AS src
+                    UNION ALL SELECT 'cardkingdom', 0) s
+    )
+    WHERE price IS NOT NULL
+"""
+
+# LEAD orders on the raw (possibly -1) day so the carried-in row is
+# unambiguously first; only the emitted `from_d` is clamped into the window.
+# A carried-in row followed by an observation on day 0 yields the empty
+# interval [0, 0), whose +cents/-cents deltas cancel.
+_PRICE_SQL = """
+    CREATE TEMP TABLE price_iv_t AS
+    SELECT kid, src, MAX(from_d, 0) AS from_d,
+           LEAD(from_d) OVER (PARTITION BY kid * 2 + src ORDER BY from_d) AS to_d,
+           price
+    FROM (
+        SELECT k.rowid AS kid,
+               (pr.source = 'tcgplayer') AS src,
+               CAST(julianday(pr.observed_at) - julianday(?) AS INTEGER) AS from_d,
+               pr.price AS price
+        FROM keys_t k
+        JOIN prices pr ON pr.set_code = k.set_code
+                      AND pr.collector_number = k.cn
+                      AND pr.price_type = k.price_type
+        WHERE pr.source IN ('tcgplayer', 'cardkingdom')
+          AND pr.observed_at >= ?
+        UNION ALL
+        SELECT kid, src, -1 AS from_d, price FROM carry_t
+    )
+"""
+
+_SEG_SQL = """
+    CREATE TEMP TABLE seg_t AS
+    SELECT pv.src AS src,
+           MAX(gi.from_d, pv.from_d) AS s,
+           CASE WHEN gi.to_d IS NULL THEN pv.to_d
+                WHEN pv.to_d IS NULL THEN gi.to_d
+                ELSE MIN(gi.to_d, pv.to_d) END AS e,
+           CAST(ROUND(gi.cum * pv.price * 100) AS INTEGER) AS cents
+    FROM price_iv_t pv
+    JOIN grp_iv_t gi ON gi.kid = pv.kid
+                    AND (gi.to_d IS NULL OR pv.from_d < gi.to_d)
+                    AND (pv.to_d IS NULL OR gi.from_d < pv.to_d)
+"""
+
+_SERIES_SQL = """
+    WITH RECURSIVE days(dn) AS (
+        SELECT 0 UNION ALL SELECT dn + 1 FROM days WHERE dn < ?
+    ),
+    delta AS (
+        SELECT s AS dn, src, cents FROM seg_t
+        UNION ALL
+        SELECT e AS dn, src, -cents FROM seg_t WHERE e IS NOT NULL
+    ),
+    dd AS (
+        SELECT dn,
+               SUM(CASE WHEN src = 1 THEN cents ELSE 0 END) AS dt,
+               SUM(CASE WHEN src = 0 THEN cents ELSE 0 END) AS dc
+        FROM delta GROUP BY dn
+    ),
+    cnt AS (
+        SELECT from_d AS dn, SUM(qty) AS q FROM grp_iv_t GROUP BY from_d
+    )
+    SELECT date(?, '+' || dy.dn || ' day') AS d,
+           SUM(COALESCE(cnt.q, 0)) OVER (ORDER BY dy.dn) AS n,
+           SUM(COALESCE(dd.dt, 0)) OVER (ORDER BY dy.dn) AS tcg_cents,
+           SUM(COALESCE(dd.dc, 0)) OVER (ORDER BY dy.dn) AS ck_cents
+    FROM days dy
+    LEFT JOIN dd ON dd.dn = dy.dn
+    LEFT JOIN cnt ON cnt.dn = dy.dn
+    ORDER BY dy.dn
+"""
+
+#: The response every route returns for a collection with nothing in it.
+EMPTY_SERIES = {
+    "dates": [], "counts": [], "tcg_values": [], "ck_values": [], "earliest": None,
+}
+
+
+def _today() -> str:
+    """Today, UTC.  `acquired_at` is ISO 8601 UTC, so its first 10 chars are a
+    UTC date and the day axis has to be built in the same zone."""
+    return _dt.datetime.now(_dt.timezone.utc).date().isoformat()
+
+
+def end_date(earliest: str) -> str:
+    """The last day of the series: today, or the first acquisition if that is
+    still in the future."""
+    return max(_today(), earliest)
+
+
+def window_start(earliest: str, end_d: str, range_days: int) -> str:
+    """First day of a `range_days`-long window ending at `end_d`.
+
+    Clamped to `earliest`, so asking for more days than the collection has is
+    the same as asking for everything rather than padding empty days.
+    """
+    if range_days <= 0:
+        return earliest
+    win_start = (
+        _dt.date.fromisoformat(end_d) - _dt.timedelta(days=range_days)
+    ).isoformat()
+    return max(win_start, earliest)
+
+
+def _drop_temp_tables(conn: sqlite3.Connection):
+    for name in _TEMP_TABLES:
+        conn.execute(f"DROP TABLE IF EXISTS temp.{name}")
+
+
+def series_rows(
+    conn: sqlite3.Connection,
+    *,
+    where_sql: str,
+    params: list,
+    extra_joins_sql: str = "",
+    range_days: int = 0,
+) -> tuple[str | None, list[tuple]]:
+    """Compute the series in SQLite.
+
+    Returns ``(earliest, rows)`` where each row is
+    ``(date, cumulative_count, tcg_cents, ck_cents)`` and `earliest` is the first
+    acquisition in the whole filtered collection, independent of the window, so
+    the UI can size its range pills.  ``(None, [])`` when nothing matches.
+
+    Prices forward-fill: the most recent known price <= D is used, including
+    observations from before the window.  Cards with no price on/before D
+    contribute 0 to value but still count.
+    """
+    _drop_temp_tables(conn)
+    try:
+        conn.execute(
+            _POP_SQL.format(extra_joins_sql=extra_joins_sql, where_sql=where_sql),
+            params,
+        )
+
+        today = _today()
+        earliest, end_d = conn.execute(
+            "SELECT MIN(acq_date),"
+            " CASE WHEN MIN(acq_date) > ? THEN MIN(acq_date) ELSE ? END"
+            " FROM pop_t",
+            (today, today),
+        ).fetchone()
+        if earliest is None:
+            return None, []
+
+        start_d = window_start(earliest, end_d, range_days)
+        end_dn = (
+            _dt.date.fromisoformat(end_d) - _dt.date.fromisoformat(start_d)
+        ).days
+
+        conn.execute(
+            "CREATE TEMP TABLE keys_t AS"
+            " SELECT DISTINCT set_code, cn, price_type FROM pop_t"
+        )
+        conn.execute(_CARRY_SQL, (start_d,))
+        conn.execute(_GRP_SQL, (start_d, end_dn))
+        conn.execute(_PRICE_SQL, (start_d, start_d))
+        conn.execute(_SEG_SQL)
+        rows = conn.execute(_SERIES_SQL, (end_dn, start_d)).fetchall()
+    finally:
+        _drop_temp_tables(conn)
+
+    return earliest, [
+        (r["d"], r["n"], r["tcg_cents"], r["ck_cents"]) for r in rows
+    ]
+
+
+def payload(earliest: str | None, rows: list[tuple]) -> dict:
+    """Turn ``(earliest, rows)`` into the endpoint's response body."""
+    if earliest is None:
+        return dict(EMPTY_SERIES)
+    return {
+        "dates": [r[0] for r in rows],
+        "counts": [r[1] for r in rows],
+        "tcg_values": [r[2] / 100.0 for r in rows],
+        "ck_values": [r[3] / 100.0 for r in rows],
+        "earliest": earliest,
+    }
+
+
+def compute_series(conn: sqlite3.Connection, **kwargs) -> dict:
+    """The computed route: aggregate the series from `collection` + `prices`."""
+    return payload(*series_rows(conn, **kwargs))
+
+
+# ── The materialized unfiltered series ──
+
+
+def collection_rev(conn: sqlite3.Connection) -> int:
+    """The collection's current revision stamp.
+
+    Maintained by triggers on `collection` (see the DDL in schema.py), because
+    the stored series has no other way to learn that a card was added, sold,
+    refinished or re-attributed to a different printing.
+    """
+    row = conn.execute("SELECT rev FROM collection_rev WHERE id = 1").fetchone()
+    if row is None:
+        raise RuntimeError(
+            "collection_rev holds no row, so the growth cache cannot tell "
+            "whether the collection changed. Run 'mtg db init --force'."
+        )
+    return row[0]
+
+
+def price_log_id(conn: sqlite3.Connection) -> int:
+    """The id of the last price import.
+
+    Prices live in the shared reference DB and are appended wholesale by
+    `import_prices`, which logs exactly one row per run — so this moves if and
+    only if the price series the stored history was built from has grown.
+    """
+    return conn.execute(
+        "SELECT COALESCE(MAX(id), 0) FROM price_fetch_log"
+    ).fetchone()[0]
+
+
+def history_is_current(conn: sqlite3.Connection) -> bool:
+    """Whether `collection_value_history` still describes the live data.
+
+    False when it has never been built, when the collection or the prices moved
+    under it, or when the day axis has advanced past the last stored day.
+    """
+    meta = conn.execute(
+        "SELECT collection_rev, price_log_id, earliest, through_d"
+        " FROM collection_value_history_meta WHERE id = 1"
+    ).fetchone()
+    if meta is None:
+        return False
+    if meta["collection_rev"] != collection_rev(conn):
+        return False
+    if meta["price_log_id"] != price_log_id(conn):
+        return False
+    if meta["earliest"] is None:
+        # An empty collection has no day axis, so no amount of elapsed time
+        # makes "empty" the wrong answer — only a collection change can.
+        return True
+    return meta["through_d"] == end_date(meta["earliest"])
+
+
+def rebuild_history(conn: sqlite3.Connection) -> int:
+    """Recompute and store the unfiltered full-history series.
+
+    Returns the number of days stored.  Stamps the collection revision and price
+    import the build saw, which is what `history_is_current()` later checks.
+
+    The stamps are read *before* the series so a collection edit that lands
+    mid-build is recorded as not-yet-included and invalidates on the next read,
+    rather than being stamped as included and silently missing.
+    """
+    from mtg_collector.utils import now_iso
+
+    rev = collection_rev(conn)
+    log_id = price_log_id(conn)
+
+    earliest, rows = series_rows(conn, where_sql=UNFILTERED_WHERE, params=[])
+    through_d = end_date(earliest) if earliest is not None else None
+
+    conn.execute("DELETE FROM collection_value_history")
+    conn.executemany(
+        "INSERT INTO collection_value_history (d, n, tcg_cents, ck_cents)"
+        " VALUES (?, ?, ?, ?)",
+        rows,
+    )
+    conn.execute("DELETE FROM collection_value_history_meta")
+    conn.execute(
+        "INSERT INTO collection_value_history_meta"
+        " (id, built_at, collection_rev, price_log_id, earliest, through_d)"
+        " VALUES (1, ?, ?, ?, ?, ?)",
+        (now_iso(), rev, log_id, earliest, through_d),
+    )
+    conn.commit()
+    return len(rows)
+
+
+def read_history(conn: sqlite3.Connection, range_days: int = 0) -> dict:
+    """Serve the unfiltered series from the materialized table — O(days).
+
+    Only valid when `history_is_current()`; the caller rebuilds first otherwise.
+    A window is a slice: every point is absolute and the series is cumulative, so
+    a windowed response is bit-identical to the tail of the full one.
+    """
+    meta = conn.execute(
+        "SELECT earliest, through_d FROM collection_value_history_meta WHERE id = 1"
+    ).fetchone()
+    if meta["earliest"] is None:
+        return dict(EMPTY_SERIES)
+
+    start_d = window_start(meta["earliest"], meta["through_d"], range_days)
+    rows = conn.execute(
+        "SELECT d, n, tcg_cents, ck_cents FROM collection_value_history"
+        " WHERE d >= ? ORDER BY d",
+        (start_d,),
+    ).fetchall()
+    return payload(
+        meta["earliest"],
+        [(r["d"], r["n"], r["tcg_cents"], r["ck_cents"]) for r in rows],
+    )

--- a/mtg_collector/db/schema.py
+++ b/mtg_collector/db/schema.py
@@ -3,7 +3,7 @@
 import re
 import sqlite3
 
-SCHEMA_VERSION = 46
+SCHEMA_VERSION = 47
 
 
 class SchemaIntegrityError(Exception):
@@ -641,9 +641,74 @@ LEFT JOIN binders b ON c.binder_id = b.id
 LEFT JOIN batches bat ON c.batch_id = bat.id;
 """
 
+# The growth cache, kept as its own constant because _migrate_v46_to_v47 applies
+# the identical text.  The triggers below are load-bearing for correctness — a
+# copy that drifted from this one would leave an upgraded database serving a
+# stored series that never notices the collection changing.
+GROWTH_CACHE_SQL = """
+-- Materialized daily series for the UNFILTERED collection: one row per day,
+-- cumulative, absolute.  Built by mtg_collector/db/growth.py, which is also
+-- where the reason it can only serve the unfiltered case is written down.
+-- Money is INTEGER cents, exactly as the computed route sums it.
+CREATE TABLE IF NOT EXISTS collection_value_history (
+    d TEXT PRIMARY KEY,            -- YYYY-MM-DD (UTC)
+    n INTEGER NOT NULL,            -- cards held on that day
+    tcg_cents INTEGER NOT NULL,
+    ck_cents INTEGER NOT NULL
+);
 
+-- What the table above was built from.  Every column is a staleness test:
+-- read them back and the answer "is this still true?" is a fact, not a guess.
+CREATE TABLE IF NOT EXISTS collection_value_history_meta (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    built_at TEXT NOT NULL,
+    collection_rev INTEGER NOT NULL,
+    price_log_id INTEGER NOT NULL,
+    earliest TEXT,                 -- NULL when the collection was empty
+    through_d TEXT                 -- last day stored; NULL alongside earliest
+);
+
+-- Revision stamp for `collection`, bumped by the triggers below and read by
+-- nothing but the growth cache.  A materialized series cannot notice that a
+-- card was added, sold, refinished or re-attributed to another printing, so
+-- the table says when it changed.  The UPDATE trigger names only the columns
+-- the series is computed from: a binder move or an edited note leaves the
+-- numbers alone and must not throw the cache away.  It fires on any statement
+-- that assigns one of those columns, changed value or not — invalidating one
+-- time too many costs a rebuild, invalidating one time too few serves a lie.
+CREATE TABLE IF NOT EXISTS collection_rev (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    rev INTEGER NOT NULL
+);
+INSERT OR IGNORE INTO collection_rev (id, rev) VALUES (1, 0);
+
+CREATE TRIGGER IF NOT EXISTS collection_rev_on_insert
+AFTER INSERT ON collection
+BEGIN
+    UPDATE collection_rev SET rev = rev + 1 WHERE id = 1;
+END;
+
+CREATE TRIGGER IF NOT EXISTS collection_rev_on_delete
+AFTER DELETE ON collection
+BEGIN
+    UPDATE collection_rev SET rev = rev + 1 WHERE id = 1;
+END;
+
+CREATE TRIGGER IF NOT EXISTS collection_rev_on_update
+AFTER UPDATE OF printing_id, finish, acquired_at, status ON collection
+BEGIN
+    UPDATE collection_rev SET rev = rev + 1 WHERE id = 1;
+END;
+"""
+
+SCHEMA_SQL = SCHEMA_SQL + GROWTH_CACHE_SQL
+
+
+# TRIGGER is in here with the rest: the growth cache's invalidation triggers are
+# the difference between a stale chart and a correct one, and a database missing
+# them looks perfectly healthy until it quietly serves last week's numbers.
 _CREATE_RE = re.compile(
-    r"CREATE\s+(?:VIRTUAL\s+)?(?:TABLE|VIEW|INDEX)\s+"
+    r"CREATE\s+(?:VIRTUAL\s+)?(?:TABLE|VIEW|INDEX|TRIGGER)\s+"
     r"(?:IF\s+NOT\s+EXISTS\s+)?\[?([A-Za-z_][A-Za-z0-9_]*)\]?",
     re.IGNORECASE,
 )
@@ -890,6 +955,8 @@ def init_db(conn: sqlite3.Connection, force: bool = False) -> bool:
             _migrate_v44_to_v45(conn)
         if current < 46:
             _migrate_v45_to_v46(conn)
+        if current < 47:
+            _migrate_v46_to_v47(conn)
 
     # Record schema version
     conn.execute(
@@ -2889,6 +2956,19 @@ def _migrate_v45_to_v46(conn: sqlite3.Connection):
     )
 
 
+def _migrate_v46_to_v47(conn: sqlite3.Connection):
+    """Add the materialized growth series and the trigger that invalidates it.
+
+    Creates the tables empty and the revision stamp at 0.  Nothing backfills the
+    series here: `collection_value_history_meta` is left with no row, which
+    growth.history_is_current() reads as "never built", so the first unfiltered
+    chart request builds it — the same path that rebuilds it after any later
+    collection edit.  Doing it at migration time would put a full-history
+    aggregation in front of every `mtg` command on the upgrade run.
+    """
+    conn.executescript(GROWTH_CACHE_SQL)
+
+
 def rebuild_card_names(conn):
     """Resync printings.card_name from cards.name.
 
@@ -2969,6 +3049,9 @@ def drop_all_tables(conn: sqlite3.Connection):
         DROP TABLE IF EXISTS batches;
         DROP TABLE IF EXISTS ingest_cache;
         DROP TABLE IF EXISTS collection_views;
+        DROP TABLE IF EXISTS collection_value_history;
+        DROP TABLE IF EXISTS collection_value_history_meta;
+        DROP TABLE IF EXISTS collection_rev;
         DROP TABLE IF EXISTS collection;
         DROP TABLE IF EXISTS decks;
         DROP TABLE IF EXISTS deck_states;

--- a/tests/test_collection_growth.py
+++ b/tests/test_collection_growth.py
@@ -1,0 +1,418 @@
+"""
+The growth chart's two routes to the same numbers (de-tz9).
+
+`/api/collection/growth` reads the unfiltered series out of the materialized
+`collection_value_history` table and computes everything else from `collection`
++ `prices`.  Two routes to one answer is a licence to disagree, so these tests
+are mostly about the ways the stored one could be wrong:
+
+  * it must equal the computed one, point for point, before anything moves;
+  * it must stop being used the moment the collection or the prices move under
+    it — the failure mode of a cache is not slowness, it is a confident wrong
+    number;
+  * a filtered request must never touch it, because it describes a population
+    the filter has already excluded rows from.
+
+To run: uv run pytest tests/test_collection_growth.py -v
+"""
+
+import datetime as dt
+import os
+import sqlite3
+import tempfile
+
+import pytest
+
+from mtg_collector.db import growth
+from mtg_collector.db.schema import init_db, refresh_latest_prices
+
+
+def _day(offset: int) -> str:
+    """A UTC date `offset` days from today, as the collection stores dates."""
+    return (dt.datetime.now(dt.timezone.utc).date() + dt.timedelta(days=offset)).isoformat()
+
+
+def _stamp(offset: int) -> str:
+    return f"{_day(offset)}T12:00:00.000Z"
+
+
+def _add_card(conn, n, name, set_code="tst"):
+    conn.execute(
+        "INSERT INTO cards (oracle_id, name, mana_cost, type_line, colors, color_identity) "
+        "VALUES (?, ?, '{R}', 'Creature — Goblin', '[\"R\"]', '[\"R\"]')",
+        (f"oracle-{n}", name),
+    )
+    conn.execute(
+        "INSERT INTO printings (printing_id, oracle_id, set_code, collector_number, rarity, finishes) "
+        "VALUES (?, ?, ?, ?, 'R', '[\"nonfoil\", \"foil\"]')",
+        (f"print-{n}", f"oracle-{n}", set_code, str(n)),
+    )
+
+
+def _own(conn, n, acquired_offset, copies=1, finish="nonfoil", status="owned"):
+    for _ in range(copies):
+        conn.execute(
+            "INSERT INTO collection (printing_id, finish, acquired_at, source, status) "
+            "VALUES (?, ?, ?, 'manual', ?)",
+            (f"print-{n}", finish, _stamp(acquired_offset), status),
+        )
+
+
+def _price(conn, n, offset, tcg=None, ck=None, price_type="normal", set_code="tst"):
+    for source, value in (("tcgplayer", tcg), ("cardkingdom", ck)):
+        if value is None:
+            continue
+        conn.execute(
+            "INSERT INTO prices (set_code, collector_number, source, price_type, price, observed_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (set_code, str(n), source, price_type, value, _day(offset)),
+        )
+
+
+def _log_price_fetch(conn):
+    """Record a price import the way `import_prices` does."""
+    conn.execute(
+        "INSERT INTO price_fetch_log (fetched_at, source_file, dates_imported,"
+        " uuid_total, uuid_mapped, uuid_unmapped, rows_inserted)"
+        " VALUES (?, 'test', '[]', 0, 0, 0, 0)",
+        (_stamp(0),),
+    )
+
+
+# Three cards, acquired on different days, priced on different days, so the
+# series has to move for more than one reason:
+#
+#   card  copies  acquired   tcg on -10 / -4      ck on -10 / -4
+#   1     2       -10 days   1.00      3.00       0.50      0.50
+#   2     1        -4 days   —        10.00       —         2.00
+#   3     1        -4 days   (never priced: counts, contributes nothing)
+@pytest.fixture
+def db_path():
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        path = f.name
+
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    conn.execute("INSERT INTO sets (set_code, set_name) VALUES ('tst', 'Test Set')")
+
+    _add_card(conn, 1, "Alpha")
+    _own(conn, 1, -10, copies=2)
+    _price(conn, 1, -10, tcg=1.00, ck=0.50)
+    _price(conn, 1, -4, tcg=3.00, ck=0.50)
+
+    _add_card(conn, 2, "Bravo")
+    _own(conn, 2, -4)
+    _price(conn, 2, -4, tcg=10.00, ck=2.00)
+
+    _add_card(conn, 3, "Charlie")
+    _own(conn, 3, -4)
+
+    _log_price_fetch(conn)
+    refresh_latest_prices(conn)
+    conn.commit()
+    conn.close()
+    yield path
+    os.unlink(path)
+
+
+@pytest.fixture
+def conn(db_path):
+    c = sqlite3.connect(db_path)
+    c.row_factory = sqlite3.Row
+    yield c
+    c.close()
+
+
+def _growth(db_path, **params):
+    """Call /api/collection/growth and return the response body."""
+    from mtg_collector.cli.crack_pack_server import CrackPackHandler
+
+    handler = object.__new__(CrackPackHandler)
+    handler.db_path = db_path
+    handler.generator = object()  # truthy, never called by this path
+    responses = []
+    handler._send_json = lambda obj, status=200: responses.append((status, obj))
+    handler._api_collection_growth({k: [str(v)] for k, v in params.items()})
+    status, body = responses[-1]
+    assert status == 200, body
+    return body
+
+
+def _computed(conn, **kwargs):
+    kwargs.setdefault("where_sql", growth.UNFILTERED_WHERE)
+    kwargs.setdefault("params", [])
+    return growth.compute_series(conn, **kwargs)
+
+
+class TestTheTwoRoutesAgree:
+    """The materialized series is the computed one, or it is a bug."""
+
+    def test_unfiltered_matches_the_computed_series(self, db_path, conn):
+        assert _growth(db_path) == _computed(conn)
+
+    def test_the_numbers_are_the_ones_arithmetic_gives(self, db_path):
+        """Pinned by hand, so an error shared by both routes still fails.
+
+        Two Alphas at 1.00 from day -10, joined on day -4 by a second Alpha
+        price, a Bravo and an unpriced Charlie.
+        """
+        body = _growth(db_path)
+        by_day = dict(zip(body["dates"], body["counts"]))
+        assert by_day[_day(-10)] == 2
+        assert by_day[_day(-5)] == 2
+        assert by_day[_day(-4)] == 4
+        assert by_day[_day(0)] == 4
+
+        tcg = dict(zip(body["dates"], body["tcg_values"]))
+        assert tcg[_day(-10)] == 2.00   # 2 x 1.00
+        assert tcg[_day(-5)] == 2.00    # forward-filled
+        assert tcg[_day(-4)] == 16.00   # 2 x 3.00 + 10.00 + unpriced Charlie
+        assert tcg[_day(0)] == 16.00
+
+        ck = dict(zip(body["dates"], body["ck_values"]))
+        assert ck[_day(-10)] == 1.00
+        assert ck[_day(-4)] == 3.00
+
+        assert body["earliest"] == _day(-10)
+
+    @pytest.mark.parametrize("range_days", [1, 3, 7, 30, 3650])
+    def test_a_window_is_a_slice_of_the_full_series(self, db_path, range_days):
+        """The stored table holds full history and serves windows by slicing;
+        that is only sound because every point is absolute."""
+        full = _growth(db_path)
+        windowed = _growth(db_path, range=range_days)
+        n = len(windowed["dates"])
+        assert n > 0
+        for key in ("dates", "counts", "tcg_values", "ck_values"):
+            assert windowed[key] == full[key][-n:], key
+        assert windowed["earliest"] == full["earliest"]
+
+    def test_windows_agree_with_the_computed_route(self, db_path, conn):
+        assert _growth(db_path, range=5) == _computed(conn, range_days=5)
+
+
+class TestStaleness:
+    """What must invalidate the stored series, and what must not."""
+
+    def test_a_new_card_is_visible_immediately(self, db_path, conn):
+        """The failure this guards: a card added after the last rebuild is
+        simply absent from the chart until the next 06:00 price fetch."""
+        before = _growth(db_path)  # materializes
+        conn.execute("INSERT INTO sets (set_code, set_name) VALUES ('two', 'Other')")
+        _add_card(conn, 9, "Delta", set_code="two")
+        _own(conn, 9, -6, copies=3)
+        conn.commit()
+
+        after = _growth(db_path)
+        assert after != before
+        assert after == _computed(conn)
+        assert after["counts"][-1] == before["counts"][-1] + 3
+
+    def test_a_backdated_card_rewrites_history(self, db_path, conn):
+        """A card acquired before the series starts moves `earliest` and every
+        point after it — the stored table cannot be patched, only rebuilt."""
+        before = _growth(db_path)
+        conn.execute("INSERT INTO sets (set_code, set_name) VALUES ('two', 'Other')")
+        _add_card(conn, 9, "Delta", set_code="two")
+        _own(conn, 9, -40)
+        conn.commit()
+
+        after = _growth(db_path)
+        assert after["earliest"] == _day(-40)
+        assert before["earliest"] == _day(-10)
+        assert after == _computed(conn)
+
+    def test_selling_a_card_leaves_the_series(self, db_path, conn):
+        before = _growth(db_path)
+        conn.execute("UPDATE collection SET status = 'sold' WHERE printing_id = 'print-2'")
+        conn.commit()
+
+        after = _growth(db_path)
+        assert after["counts"][-1] == before["counts"][-1] - 1
+        assert after == _computed(conn)
+
+    def test_refinishing_a_card_reprices_it(self, db_path, conn):
+        """finish decides which price series a card is valued from, so it
+        changes the answer without changing the count."""
+        _price(conn, 1, -4, tcg=99.00, price_type="foil")
+        conn.commit()
+        before = _growth(db_path)
+
+        conn.execute("UPDATE collection SET finish = 'foil' WHERE printing_id = 'print-1'")
+        conn.commit()
+
+        after = _growth(db_path)
+        assert after["counts"] == before["counts"]
+        assert after["tcg_values"][-1] != before["tcg_values"][-1]
+        assert after == _computed(conn)
+
+    def test_new_prices_are_visible_immediately(self, db_path, conn):
+        """A price import is the other thing that moves the series, and it
+        moves days already stored, not just today's."""
+        before = _growth(db_path)
+        _price(conn, 2, -2, tcg=50.00)
+        _log_price_fetch(conn)
+        conn.commit()
+
+        after = _growth(db_path)
+        assert after["tcg_values"][-1] == before["tcg_values"][-1] + 40.00
+        assert after == _computed(conn)
+
+    def test_an_unrelated_edit_keeps_the_stored_series(self, db_path, conn):
+        """Notes and binder assignments are not in the series, so editing one
+        must not throw away a perfectly good build."""
+        _growth(db_path)
+        built_at = conn.execute(
+            "SELECT built_at FROM collection_value_history_meta"
+        ).fetchone()[0]
+
+        conn.execute("UPDATE collection SET notes = 'foo' WHERE id = 1")
+        conn.commit()
+        assert growth.history_is_current(conn)
+
+        _growth(db_path)
+        assert conn.execute(
+            "SELECT built_at FROM collection_value_history_meta"
+        ).fetchone()[0] == built_at
+
+    def test_a_valid_build_is_reused(self, db_path, conn):
+        """The point of the exercise: the second request does not rebuild."""
+        _growth(db_path)
+        assert growth.history_is_current(conn)
+
+        conn.execute("UPDATE collection_value_history SET n = -1")
+        conn.commit()
+        # Read straight out of the table, sabotage included — proof the second
+        # request never recomputed.
+        assert set(_growth(db_path)["counts"]) == {-1}
+
+
+class TestTriggers:
+    """The revision stamp the staleness check rests on."""
+
+    def test_insert_update_and_delete_all_bump_the_stamp(self, conn):
+        seen = [growth.collection_rev(conn)]
+        _own(conn, 1, -1)
+        seen.append(growth.collection_rev(conn))
+        conn.execute("UPDATE collection SET status = 'sold' WHERE id = 1")
+        seen.append(growth.collection_rev(conn))
+        conn.execute("DELETE FROM collection WHERE id = 1")
+        seen.append(growth.collection_rev(conn))
+        assert seen == sorted(set(seen)), seen
+
+    def test_columns_outside_the_series_do_not_bump_it(self, conn):
+        before = growth.collection_rev(conn)
+        conn.execute("UPDATE collection SET notes = 'x', condition = 'Damaged'")
+        conn.execute("UPDATE collection SET binder_id = NULL")
+        assert growth.collection_rev(conn) == before
+
+    def test_a_missing_stamp_is_an_error_not_a_shrug(self, conn):
+        """Serving the chart off a stamp that cannot move is exactly the silent
+        wrong answer this whole mechanism exists to prevent."""
+        conn.execute("DELETE FROM collection_rev")
+        with pytest.raises(RuntimeError, match="mtg db init --force"):
+            growth.collection_rev(conn)
+
+
+class TestFilteredRequestsGoTheOtherWay:
+    """A filter selects a different population; the stored table is not it."""
+
+    def test_a_filter_narrows_the_series(self, db_path, conn):
+        body = _growth(db_path, q="Alpha")
+        assert body["counts"][-1] == 2
+        assert body["tcg_values"][-1] == 6.00
+        assert body["earliest"] == _day(-10)
+
+    def test_a_filter_does_not_read_the_stored_table(self, db_path, conn):
+        """Sabotage the table, then filter: a filtered answer that changed
+        would mean the fast path leaked into a query it cannot serve."""
+        _growth(db_path)
+        conn.execute("UPDATE collection_value_history SET n = -1, tcg_cents = -1")
+        conn.commit()
+
+        body = _growth(db_path, q="Alpha")
+        assert body["counts"][-1] == 2
+        assert body["tcg_values"][-1] == 6.00
+
+    def test_a_filter_does_not_write_the_stored_table(self, db_path, conn):
+        """...and it does not overwrite the unfiltered build with its own,
+        narrower numbers."""
+        unfiltered = _growth(db_path)
+        _growth(db_path, q="Alpha")
+        assert _growth(db_path) == unfiltered
+
+    def test_a_status_filter_still_computes(self, db_path, conn):
+        conn.execute("UPDATE collection SET status = 'sold' WHERE printing_id = 'print-2'")
+        conn.commit()
+        body = _growth(db_path, q="status:sold")
+        assert body["counts"][-1] == 1
+
+    def test_blank_query_is_the_unfiltered_case(self, db_path):
+        """A query bar holding whitespace is what an empty one posts."""
+        assert _growth(db_path, q="   ") == _growth(db_path)
+
+    def test_is_unowned_is_empty(self, db_path):
+        assert _growth(db_path, q="is:unowned") == growth.EMPTY_SERIES
+
+
+class TestEmptyCollection:
+    def test_empty_collection_returns_the_empty_series(self, db_path, conn):
+        conn.execute("DELETE FROM collection")
+        conn.commit()
+        assert _growth(db_path) == growth.EMPTY_SERIES
+
+    def test_an_empty_build_does_not_age_out(self, db_path, conn):
+        """There is no day axis to fall behind, so only a collection change can
+        make "nothing" the wrong answer."""
+        conn.execute("DELETE FROM collection")
+        conn.commit()
+        _growth(db_path)
+        assert growth.history_is_current(conn)
+
+    def test_the_first_card_after_an_empty_build_shows_up(self, db_path, conn):
+        conn.execute("DELETE FROM collection")
+        conn.commit()
+        assert _growth(db_path) == growth.EMPTY_SERIES
+
+        _own(conn, 1, -3, copies=2)
+        conn.commit()
+        body = _growth(db_path)
+        assert body["earliest"] == _day(-3)
+        assert body["counts"][-1] == 2
+
+
+class TestRebuildHistory:
+    """What the price timer calls."""
+
+    def test_rebuild_stores_every_day_and_validates(self, db_path, conn):
+        days = growth.rebuild_history(conn)
+        assert days == len(_computed(conn)["dates"])
+        assert conn.execute(
+            "SELECT COUNT(*) FROM collection_value_history"
+        ).fetchone()[0] == days
+        assert growth.history_is_current(conn)
+
+    def test_a_warmed_table_is_what_the_request_serves(self, db_path, conn):
+        """The timer's job: the first chart of the day costs a table read."""
+        growth.rebuild_history(conn)
+        conn.execute("UPDATE collection_value_history SET n = -1")
+        conn.commit()
+        assert set(_growth(db_path)["counts"]) == {-1}
+
+    def test_rebuild_is_idempotent(self, db_path, conn):
+        growth.rebuild_history(conn)
+        first = _growth(db_path)
+        growth.rebuild_history(conn)
+        assert _growth(db_path) == first
+
+    def test_rebuild_leaves_no_staging_tables_behind(self, conn):
+        """The timer reuses one process-wide connection, so a leftover TEMP
+        table would collide on the next run rather than being dropped with the
+        request's connection."""
+        growth.rebuild_history(conn)
+        growth.rebuild_history(conn)
+        names = {
+            r[0] for r in conn.execute("SELECT name FROM temp.sqlite_master")
+        }
+        assert names & {"pop_t", "keys_t", "seg_t"} == set()


### PR DESCRIPTION
## Summary
- Materializes `collection_value_history` (+ meta table, trigger-maintained `collection_rev`) from the existing `mtgc-prices` timer so the unfiltered `/api/collection/growth` case is an O(days) table read instead of a full aggregation.
- Filtered growth requests are unaffected — they still fall through to the existing computed path (`db/growth.py: compute_series`); the branch is explicit on "no filter present", not a fallback.
- Schema v46 -> v47.

## Test plan
Recorded in bead de-tz9 (independently re-verified by two polecats, capable then rictus):
- [x] Unit suite: 1845 passed, 195 skipped
- [x] Integration: 118 passed, 6 skipped
- [x] Full UI suite: 235 passed, 0 failed (`--instance rictus`)
- [x] ruff clean
- [x] Migration verified v44->v47 and v46->v47, `mt db verify` clean (87 objects)
- [x] Computed vs. stored routes verified object-identical across multiple synthetic rigs and against a live container end-to-end (staleness triggers on insert/status-edit, not on unrelated column edits)
- [x] Refinery pass: unit suite + ruff re-run clean against current main tip (3183be2), rebase was a no-op (branch already based on current main)

🤖 Generated with refinery merge automation